### PR TITLE
Gameplay tunings

### DIFF
--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -127,11 +127,11 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			false,							// smooth refire
 
 			//damages
-			35,								// damage
+			30,								// damage
 			1.0,							// selfdamage ratio
 			90,								// knockback
 			0,								// stun
-			70,								// splash radius
+			80,								// splash radius
 			8,								// splash minimum damage
 			10,                             // splash minimum knockback
 

--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -661,7 +661,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			//ammo
 			5,                              // weapon pickup amount
 			10,								// pickup amount
-			10,								// max amount
+			15,								// max amount
 			3								// low ammo threshold
 		},
 

--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -585,9 +585,9 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			0,                              // v_spread
 
 			//ammo
-			50,                             // weapon pickup amount
-			100,							// pickup amount
-			150,							// max amount
+			60,                             // weapon pickup amount
+			120,							// pickup amount
+			180,							// max amount
 			20								// low ammo threshold
 		},
 


### PR DESCRIPTION
1) GL:
- damage is decreased 30->35, it seems a bit too strong. It also decreases self damage on GL jumps.
- on other side it got bigger splash radius, which makes GL jumps easier. But still they have the same height.

**Next ammo changes are only for Duel/FFA/TDM/etc, Bomb/CA are not touched as they have their own definitions in GTs**

2) LG:
- 50->60 Weapon pickup ammo 
- 100->120 Box pickup ammo
- 150->180 Max ammo

3) EB, weapon pickup and box pickup amount of ammo are still the same:
- 10->15 Max ammo