### PR TITLE
Add skimming

### DIFF
--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -49,6 +49,7 @@ int playerbox_gib_viewheight = 8;
 #define PM_AIRCONTROL_BOUNCE_DELAY 200
 #define PM_OVERBOUNCE		1.01f
 #define PM_FORWARD_ACCEL_TIMEDELAY 0 // delay before the forward acceleration kicks in
+#define PM_SKIM_TIME 250
 
 //===============================================================
 
@@ -1081,7 +1082,7 @@ static void PM_CheckJump( void )
 	}
 
 	// remove wj count
-	pm->playerState->pmove.pm_time = 250 >> 3; //skimming time
+	pm->playerState->pmove.pm_time = PM_SKIM_TIME >> 3; //skimming time adjusted for msec size
 	pm->playerState->pmove.pm_flags &= ~PMF_JUMPPAD_TIME;
 	PM_ClearDash();
 	PM_ClearWallJump();

--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -1081,6 +1081,7 @@ static void PM_CheckJump( void )
 	}
 
 	// remove wj count
+	pm->playerState->pmove.pm_time = 250 >> 3; //skimming time
 	pm->playerState->pmove.pm_flags &= ~PMF_JUMPPAD_TIME;
 	PM_ClearDash();
 	PM_ClearWallJump();


### PR DESCRIPTION
Adds 250ms timer to perform corner clipping / skimming. It forgives small mistakes for the players while they jump close to the corners, so they won't loose their speed. Also it makes double jumps easier. Doesn't work with dashes.