### PR TITLE
Reintroduces ServerCommand "cmd"

### DIFF
--- a/source/cgame/cg_cmds.cpp
+++ b/source/cgame/cg_cmds.cpp
@@ -880,6 +880,17 @@ static void CG_SC_AddAward( void )
 	CG_AddAward( trap_Cmd_Argv( 1 ) );
 }
 
+/*
+* CG_SC_ExecuteText
+*/
+static void CG_SC_ExecuteText( void )
+{
+    if( cgs.demoPlaying || cgs.tv )
+        return;
+
+    trap_Cmd_ExecuteText( EXEC_APPEND, trap_Cmd_Args() );
+}
+
 typedef struct
 {
 	const char *name;
@@ -909,6 +920,7 @@ static const svcmd_t cg_svcmds[] =
 	{ "motd", CG_SC_MOTD },
 	{ "aw", CG_SC_AddAward },
 	{ "qm", CG_SC_MenuQuick },
+	{ "cmd", CG_SC_ExecuteText },
 
 	{ NULL }
 };


### PR DESCRIPTION
This command was removed in commit c1fb9bcaf17b721badb38e410c8f3c4ac4e79527
while reworking the way 'Move to TV' works. That function was the only
one calling 'cmd' in the engine, so removing it seemed to be fine.
However GameCommands are exported to gametype AS via
Client::execGameCommand( String ), so removing the command broke
gametype scripts.