### PR TITLE
Implement some additional gametype functions

### DIFF
--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -3036,6 +3036,14 @@ static int asFunc_SoundIndex( asstring_t *str )
 	return asFunc_SoundIndexExt( str, false );
 }
 
+static void asFunc_PureFile( asstring_t *str )
+{
+    if( !str || !str->buffer )
+        return;
+
+    G_PureModel( str->buffer );
+}
+
 static void asFunc_RegisterCommand( asstring_t *str )
 {
 	if( !str || !str->buffer || !str->len )
@@ -3364,7 +3372,8 @@ static const asglobfuncs_t asGlobFuncs[] =
 	{ "int G_ModelIndex( const String &in )", asFUNCTION(asFunc_ModelIndex), NULL },
 	{ "int G_SoundIndex( const String &in )", asFUNCTION(asFunc_SoundIndex), NULL },
 	{ "int G_ModelIndex( const String &in, bool pure )", asFUNCTION(asFunc_ModelIndexExt), NULL },
-	{ "int G_SoundIndex( const String &in, bool pure )", asFUNCTION(asFunc_SoundIndexExt), NULL },
+    { "int G_SoundIndex( const String &in, bool pure )", asFUNCTION(asFunc_SoundIndexExt), NULL },
+    { "void G_PureFile( const String &in )", asFUNCTION(asFunc_PureFile), NULL },
 	{ "void G_RegisterCommand( const String &in )", asFUNCTION(asFunc_RegisterCommand), NULL },
 	{ "void G_RegisterCallvote( const String &in, const String &in, const String &in, const String &in )", asFUNCTION(asFunc_RegisterCallvote), NULL },
 	{ "void G_ConfigString( int index, const String &in )", asFUNCTION(asFunc_ConfigString), NULL },

--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -600,6 +600,19 @@ static const asEnumVal_t asMiscelaneaEnumVals[] =
 	ASLIB_ENUM_VAL_NULL
 };
 
+static const asEnumVal_t asButtonEnumVals[] =
+{
+    ASLIB_ENUM_VAL( BUTTON_ATTACK ),
+    ASLIB_ENUM_VAL( BUTTON_WALK ),
+    ASLIB_ENUM_VAL( BUTTON_SPECIAL ),
+    ASLIB_ENUM_VAL( BUTTON_USE ),
+    ASLIB_ENUM_VAL( BUTTON_ZOOM ),
+    ASLIB_ENUM_VAL( BUTTON_BUSYICON ),
+    ASLIB_ENUM_VAL( BUTTON_ANY ),
+
+    ASLIB_ENUM_VAL_NULL
+};
+
 //=======================================================================
 
 static const asEnum_t asEnums[] =
@@ -634,6 +647,7 @@ static const asEnum_t asEnums[] =
 	{ "takedamage_e", asDamageEnumVals },
 	{ "keyicon_e", asKeyiconEnumVals },
 	{ "miscelanea_e", asMiscelaneaEnumVals },
+    { "buttons_e", asButtonEnumVals },
 
 	ASLIB_ENUM_VAL_NULL
 };
@@ -2054,6 +2068,7 @@ static const asProperty_t gameclient_Properties[] =
 	{ ASLIB_PROPERTY_DECL(bool, takeStun), ASLIB_FOFFSET(gclient_t, resp.takeStun) },
 	{ ASLIB_PROPERTY_DECL(uint, lastActivity), ASLIB_FOFFSET(gclient_t, level.last_activity) },
 	{ ASLIB_PROPERTY_DECL(const uint, uCmdTimeStamp), ASLIB_FOFFSET(gclient_t, ucmd.serverTimeStamp) },
+    { ASLIB_PROPERTY_DECL(const uint8, buttons), ASLIB_FOFFSET(gclient_t, ucmd.buttons) },
 
 	ASLIB_PROPERTY_NULL
 };

--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -2431,6 +2431,26 @@ static void objectGameEntity_explosionEffect( int radius, edict_t *self )
 	G_SpawnEvent( eventType, eventRadius, center );
 }
 
+static bool objectGameEntity_GetAllowFunctionOverride( edict_t *self )
+{
+    return self->scriptSpawned;
+}
+
+static void objectGameEntity_SetAllowFunctionOverride( bool allow, edict_t *self )
+{
+    if( allow )
+    {
+        self->scriptSpawned = true;
+        self->asScriptModule = static_cast<void *>(GAME_AS_ENGINE()->GetModule(GAMETYPE_SCRIPTS_MODULE_NAME));
+    }
+    else
+    {
+        self->scriptSpawned = false;
+        self->asScriptModule = NULL;
+    }
+    G_asClearEntityBehaviors( self );
+}
+
 static const asFuncdef_t gedict_Funcdefs[] =
 {
 	{ ASLIB_FUNCTION_DECL(void, entThink, (Entity @ent)) },
@@ -2497,6 +2517,8 @@ static const asMethod_t gedict_Methods[] =
 	{ ASLIB_FUNCTION_DECL(void, sustainDamage, ( Entity @inflicter, Entity @attacker, const Vec3 &in dir, float damage, float knockback, float stun, int mod )), asFUNCTION(objectGameEntity_sustainDamage), asCALL_CDECL_OBJLAST },
 	{ ASLIB_FUNCTION_DECL(void, splashDamage, ( Entity @attacker, int radius, float damage, float knockback, float stun, int mod )), asFUNCTION(objectGameEntity_splashDamage), asCALL_CDECL_OBJLAST },
 	{ ASLIB_FUNCTION_DECL(void, explosionEffect, ( int radius )), asFUNCTION(objectGameEntity_explosionEffect), asCALL_CDECL_OBJLAST },
+    { ASLIB_FUNCTION_DECL(bool, get_allowFunctionOverride, () const), asFUNCTION(objectGameEntity_GetAllowFunctionOverride), asCALL_CDECL_OBJLAST },
+    { ASLIB_FUNCTION_DECL(void, set_allowFunctionOverride, (const bool &in)), asFUNCTION(objectGameEntity_SetAllowFunctionOverride), asCALL_CDECL_OBJLAST },
 
 	ASLIB_METHOD_NULL
 };

--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -1954,6 +1954,25 @@ static void objectGameClient_SetQuickMenuItems( asstring_t *str, gclient_t *self
 	trap_GameCmd( PLAYERENT( playerNum ), va( "qm %s", str->buffer ) );
 }
 
+static void objectGameClient_DropClient( asstring_t *str, gclient_t *self )
+{
+    int playerNum;
+
+    if( self->asFactored )
+        return;
+
+    if( !str || !str->buffer )
+        return;
+
+    playerNum = (int)( self - game.clients );
+    assert( playerNum >= 0 && playerNum < gs.maxclients );
+
+    if( playerNum < 0 || playerNum >= gs.maxclients )
+        return;
+
+    trap_DropClient( &game.edicts[playerNum + 1], DROP_TYPE_NORECONNECT, str->buffer );
+}
+
 static const asFuncdef_t gameclient_Funcdefs[] =
 {
 	ASLIB_FUNCDEF_NULL
@@ -2007,6 +2026,7 @@ static const asMethod_t gameclient_Methods[] =
 	{ ASLIB_FUNCTION_DECL(void, setRaceTime, ( int sector, uint time )), asFUNCTION(objectGameClient_SetRaceTime), asCALL_CDECL_OBJLAST },
 	{ ASLIB_FUNCTION_DECL(void, setHelpMessage, ( uint msg )), asFUNCTION(objectGameClient_SetHelpMessage), asCALL_CDECL_OBJLAST },
 	{ ASLIB_FUNCTION_DECL(void, setQuickMenuItems, ( const String &in )), asFUNCTION(objectGameClient_SetQuickMenuItems), asCALL_CDECL_OBJLAST },
+    { ASLIB_FUNCTION_DECL(void, dropClient, ( const String &in )), asFUNCTION(objectGameClient_DropClient), asCALL_CDECL_OBJLAST },
 
 	ASLIB_METHOD_NULL
 };
@@ -2019,9 +2039,9 @@ static const asProperty_t gameclient_Properties[] =
 	{ ASLIB_PROPERTY_DECL(const bool, tv), ASLIB_FOFFSET(gclient_t, isTV) },
 	{ ASLIB_PROPERTY_DECL(int, team), ASLIB_FOFFSET(gclient_t, team) },
 	{ ASLIB_PROPERTY_DECL(const int, hand), ASLIB_FOFFSET(gclient_t, hand) },
-	{ ASLIB_PROPERTY_DECL(const bool, isOperator), ASLIB_FOFFSET(gclient_t, isoperator) },
+	{ ASLIB_PROPERTY_DECL(bool, isOperator), ASLIB_FOFFSET(gclient_t, isoperator) },
 	{ ASLIB_PROPERTY_DECL(const uint, queueTimeStamp), ASLIB_FOFFSET(gclient_t, queueTimeStamp) },
-	{ ASLIB_PROPERTY_DECL(const int, muted), ASLIB_FOFFSET(gclient_t, muted) },
+	{ ASLIB_PROPERTY_DECL(int, muted), ASLIB_FOFFSET(gclient_t, muted) },
 	{ ASLIB_PROPERTY_DECL(float, armor), ASLIB_FOFFSET(gclient_t, resp.armor) },
 	{ ASLIB_PROPERTY_DECL(const bool, chaseActive), ASLIB_FOFFSET(gclient_t, resp.chase.active) },
 	{ ASLIB_PROPERTY_DECL(int, chaseTarget), ASLIB_FOFFSET(gclient_t, resp.chase.target) },

--- a/source/game/g_utils.cpp
+++ b/source/game/g_utils.cpp
@@ -1031,10 +1031,10 @@ void G_InitMover( edict_t *ent )
 */
 void G_CallThink( edict_t *ent )
 {
-	if( ent->think )
+    if( ent->scriptSpawned && ent->asThinkFunc )
+        G_asCallMapEntityThink( ent );
+	else if( ent->think )
 		ent->think( ent );
-	else if( ent->scriptSpawned && ent->asThinkFunc )
-		G_asCallMapEntityThink( ent );
 	else if( developer->integer )
 		G_Printf( "NULL ent->think in %s\n", ent->classname ? ent->classname : va( "'no classname. Entity type is %i", ent->s.type ) );
 }
@@ -1049,13 +1049,13 @@ void G_CallTouch( edict_t *self, edict_t *other, cplane_t *plane, int surfFlags 
 	if( self == other )
 		return;
 
-	if( self->touch ) {
+    if( self->scriptSpawned && self->asTouchFunc ) {
+        touched = true;
+        G_asCallMapEntityTouch( self, other, plane, surfFlags );
+    }
+    else if( self->touch ) {
 		touched = true;
 		self->touch( self, other, plane, surfFlags );
-	}
-	else if( self->scriptSpawned && self->asTouchFunc ) {
-		touched = true;
-		G_asCallMapEntityTouch( self, other, plane, surfFlags );
 	}
 
 	if( touched && other->ai )
@@ -1067,10 +1067,10 @@ void G_CallTouch( edict_t *self, edict_t *other, cplane_t *plane, int surfFlags 
 */
 void G_CallUse( edict_t *self, edict_t *other, edict_t *activator )
 {
-	if( self->use )
+    if( self->scriptSpawned && self->asUseFunc )
+        G_asCallMapEntityUse( self, other, activator );
+    else if( self->use )
 		self->use( self, other, activator );
-	else if( self->scriptSpawned && self->asUseFunc )
-		G_asCallMapEntityUse( self, other, activator );
 }
 
 /*
@@ -1078,10 +1078,10 @@ void G_CallUse( edict_t *self, edict_t *other, edict_t *activator )
 */
 void G_CallStop( edict_t *self )
 {
-	if( self->stop )
-		self->stop( self );
-	else if( self->scriptSpawned && self->asStopFunc )
+	if( self->scriptSpawned && self->asStopFunc )
 		G_asCallMapEntityStop( self );
+    else if( self->stop )
+        self->stop( self );
 }
 
 /*
@@ -1089,10 +1089,10 @@ void G_CallStop( edict_t *self )
 */
 void G_CallPain( edict_t *ent, edict_t *attacker, float kick, float damage )
 {
-	if( ent->pain )
+    if( ent->scriptSpawned && ent->asPainFunc )
+        G_asCallMapEntityPain( ent, attacker, kick, damage );
+	else if( ent->pain )
 		ent->pain( ent, attacker, kick, damage );
-	else if( ent->scriptSpawned && ent->asPainFunc )
-		G_asCallMapEntityPain( ent, attacker, kick, damage );
 }
 
 /*
@@ -1100,10 +1100,10 @@ void G_CallPain( edict_t *ent, edict_t *attacker, float kick, float damage )
 */
 void G_CallDie( edict_t *ent, edict_t *inflictor, edict_t *attacker, int damage, const vec3_t point )
 {
-	if( ent->die )
+    if( ent->scriptSpawned && ent->asDieFunc )
+        G_asCallMapEntityDie( ent, inflictor, attacker, damage, point );
+	else if( ent->die )
 		ent->die( ent, inflictor, attacker, damage, point );
-	else if( ent->scriptSpawned && ent->asDieFunc )
-		G_asCallMapEntityDie( ent, inflictor, attacker, damage, point );
 }
 
 


### PR DESCRIPTION
I developed quite a lot of gametypes for warsow back in 2009-2013. I've started to move them over to warfork. A few of those gametypes depend on additional AS functions that I provided using a modded game.so on the server side. With Warfork it seems to be more appropiate to pullrequest it into the game code itself.

Overall this PR aims to add the following functions to the AS gametype interface:
* G_PureFile( String )
* Entity::allowFunctionOverride property
* Client::buttons property
* advanced administration methods.

I've documented the details and reasons for every change into the commit messages. 


