### PR TITLE
Fixes screenshots + more types

### DIFF
--- a/source/cgame/cg_screen.cpp
+++ b/source/cgame/cg_screen.cpp
@@ -329,7 +329,6 @@ void CG_ScreenInit( void )
 	cg_showViewBlends =	trap_Cvar_Get( "cg_showViewBlends", "1", CVAR_ARCHIVE );
 	cg_showAwards =		trap_Cvar_Get( "cg_showAwards", "1", CVAR_ARCHIVE );
 	cg_showZoomEffect =	trap_Cvar_Get( "cg_showZoomEffect", "1", CVAR_ARCHIVE );
-	cg_showCaptureAreas = trap_Cvar_Get( "cg_showCaptureAreas", "1", CVAR_ARCHIVE );
 
 	cg_showPlayerNames =	    trap_Cvar_Get( "cg_showPlayerNames", "1", CVAR_ARCHIVE );
 	cg_showPlayerNames_alpha =  trap_Cvar_Get( "cg_showPlayerNames_alpha", "0.4", CVAR_ARCHIVE );

--- a/source/ref_gl/r_cmds.c
+++ b/source/ref_gl/r_cmds.c
@@ -42,17 +42,26 @@ static struct tm *R_Localtime( const time_t time, struct tm* _tm )
 */
 void R_TakeScreenShot( const char *path, const char *name, const char *fmtString, int x, int y, int w, int h, bool silent, bool media )
 {
-	const char *extension = ".png";
+	const char *extension;
 	size_t path_size = strlen( path ) + 1;
 	char *checkname = NULL;
 	size_t checkname_size = 0;
 
-	
 	if( !R_IsRenderingToScreen() )
 		return;
 	
-
-
+	switch(r_screenshot_format->integer) 
+	{
+		case 2:
+			extension = ".jpg";
+			break;
+		case 3:
+			extension = ".tga";
+			break;
+		default:
+			extension = ".png";
+			break;
+	}
 	
 	if( name && name[0] && Q_stricmp(name, "*") )
 	{

--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -2148,7 +2148,7 @@ void R_ScreenShot( const char *filename, int x, int y, int width, int height,
 					   flipx, flipy, flipdiagonal );
 	}
 
-	if( WritePNG( filename, &imginfo ) && !silent ) {
+	if( WriteScreenShot( filename, &imginfo, r_screenshot_format->integer ) && !silent ) {
 		Com_Printf( "Wrote %s\n", filename );
 	}
 }

--- a/source/ref_gl/r_imagelib.c
+++ b/source/ref_gl/r_imagelib.c
@@ -44,8 +44,23 @@ r_imginfo_t IMG_LoadImage( const char * filename, uint8_t * ( *allocbuf )( void 
     
 }
 
-bool WritePNG( const char * filename, r_imginfo_t * img ) {
-return stbi_write_png( filename, img->width, img->height, img->samples, img->pixels, 0 ) != 0;
+bool WriteScreenShot( const char *filename, r_imginfo_t *img, int type )
+{
+	int file;
+	if( ri.FS_FOpenAbsoluteFile( filename, &file, FS_WRITE ) == -1 ) {
+		Com_Printf( "WriteScreenShot: Couldn't create %s\n", filename );
+		return false;
+	}
+	ri.FS_FCloseFile( file );
+
+	switch( type ) {
+		case 2:
+			return stbi_write_jpg( filename, img->width, img->height, img->samples, img->pixels, 100 ) != 0;
+		case 3:
+			return stbi_write_tga( filename, img->width, img->height, img->samples, img->pixels ) != 0;
+		default:
+			return stbi_write_png( filename, img->width, img->height, img->samples, img->pixels, 0 ) != 0;
+	}
 }
 
 /*

--- a/source/ref_gl/r_imagelib.h
+++ b/source/ref_gl/r_imagelib.h
@@ -40,6 +40,6 @@ typedef struct
 
 r_imginfo_t IMG_LoadImage( const char * filename, uint8_t *( *allocbuf )( void *, size_t, const char *, int ), void *uptr );
 
-bool WritePNG( const char * filename, r_imginfo_t *info );
+bool WriteScreenShot( const char * filename, r_imginfo_t *info, int type );
 
 void DecompressETC1( const uint8_t *in, int width, int height, uint8_t *out, bool bgr );

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -419,6 +419,7 @@ extern cvar_t *r_skymip;
 extern cvar_t *r_polyblend;
 extern cvar_t *r_lockpvs;
 extern cvar_t *r_screenshot_fmtstr;
+extern cvar_t *r_screenshot_format;
 extern cvar_t *r_swapinterval;
 extern cvar_t *r_swapinterval_min;
 

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -105,6 +105,7 @@ cvar_t *r_nobind;
 cvar_t *r_polyblend;
 cvar_t *r_lockpvs;
 cvar_t *r_screenshot_fmtstr;
+cvar_t *r_screenshot_format;
 cvar_t *r_swapinterval;
 cvar_t *r_swapinterval_min;
 
@@ -1099,6 +1100,7 @@ static void R_Register( const char *screenshotsPrefix )
 	r_stencilbits = ri.Cvar_Get( "r_stencilbits", "0", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 
 	r_screenshot_fmtstr = ri.Cvar_Get( "r_screenshot_fmtstr", va_r( tmp, sizeof( tmp ), "%s%%y%%m%%d_%%H%%M%%S", screenshotsPrefix ), CVAR_ARCHIVE );
+	r_screenshot_format = ri.Cvar_Get( "r_screenshot_format", "1", CVAR_ARCHIVE );
 
 #if defined(GLX_VERSION) && !defined(USE_SDL2)
 	r_swapinterval = ri.Cvar_Get( "r_swapinterval", "0", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );


### PR DESCRIPTION
Fixes screenshots and adds the cvar "r_screenshot_format"
1 = png;
2 = jpg;
3 = tga;

I removed the unused cg_showCaptureAreas from cg_screen.cpp:332 too.