### PR TITLE
Fix vsays using the wrong sounds when dead.

### DIFF
--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -372,6 +372,7 @@ typedef struct
 	int hand;
 	byte_vec4_t color;
 	struct shader_s *icon;
+	int modelindex;
 } cg_clientInfo_t;
 
 #define MAX_ANGLES_KICKS 3

--- a/source/cgame/cg_players.cpp
+++ b/source/cgame/cg_players.cpp
@@ -264,4 +264,7 @@ void CG_LoadClientInfo( cg_clientInfo_t *ci, const char *info, int client )
 		Vector4Set( ci->color, COLOR_R( rgbcolor ), COLOR_G( rgbcolor ), COLOR_B( rgbcolor ), 255 );
 	else
 		Vector4Set( ci->color, 255, 255, 255, 255 );
+
+	s = Info_ValueForKey( info, "model" );
+	ci->modelindex = s && s[0] ? atoi( s ) : -1;
 }

--- a/source/cgame/cg_pmodels.cpp
+++ b/source/cgame/cg_pmodels.cpp
@@ -1047,11 +1047,10 @@ void CG_UpdatePlayerModelEnt( centity_t *cent )
 	}
 
 	// fallback
-	if( !pmodel->pmodelinfo || !pmodel->skin )
-	{
+	if( !pmodel->pmodelinfo )
 		pmodel->pmodelinfo = cgs.basePModelInfo;
+	if( !pmodel->skin )
 		pmodel->skin = cgs.baseSkin;
-	}
 
 	// make sure al poses have their memory space
 	cent->skel = CG_SkeletonForModel( pmodel->pmodelinfo->model );

--- a/source/cgame/cg_teams.cpp
+++ b/source/cgame/cg_teams.cpp
@@ -143,6 +143,7 @@ bool CG_PModelForCentity( centity_t *cent, pmodelinfo_t **pmodelinfo, struct ski
 	int team;
 	centity_t *owner;
 	unsigned int ownerNum;
+	int fallbackModelIndex;
 
 	owner = cent;
 	if( cent->current.type == ET_CORPSE && cent->current.bodyOwner )  // it's a body
@@ -153,9 +154,19 @@ bool CG_PModelForCentity( centity_t *cent, pmodelinfo_t **pmodelinfo, struct ski
 
 	CG_CheckUpdateTeamModelRegistration( team ); // check for cvar changes
 
-	// use the player defined one if not forcing
-	if( pmodelinfo )
-		*pmodelinfo = cgs.pModelsIndex[cent->current.modelindex];
+	// use the player defined one if not forcings
+	if( pmodelinfo ) {
+		if( cent->current.modelindex )
+			*pmodelinfo = cgs.pModelsIndex[cent->current.modelindex];
+		else
+		{
+			fallbackModelIndex = cgs.clientInfo[ownerNum - 1].modelindex;
+			if( fallbackModelIndex >= 0 && fallbackModelIndex < MAX_MODELS )
+			{
+				*pmodelinfo = cgs.pModelsIndex[fallbackModelIndex];
+			}
+		}
+	}
 	if( skin )
 		*skin = cgs.skinPrecache[cent->current.skinnum];
 

--- a/source/game/p_client.cpp
+++ b/source/game/p_client.cpp
@@ -1031,7 +1031,8 @@ void think_MoveTypeSwitcher( edict_t *ent )
 */
 static void G_UpdatePlayerInfoString( int playerNum )
 {
-	char playerString[MAX_INFO_STRING];
+	char playerString[MAX_INFO_STRING], playerModel[MAX_INFO_VALUE];
+	char *modelInfo;
 	gclient_t *client;
 
 	assert( playerNum >= 0 && playerNum < gs.maxclients );
@@ -1044,6 +1045,18 @@ static void G_UpdatePlayerInfoString( int playerNum )
 	Info_SetValueForKey( playerString, "hand", va( "%i", client->hand ) );
 	Info_SetValueForKey( playerString, "color",
 		va( "%i %i %i", client->color[0], client->color[1], client->color[2] ) );
+
+	modelInfo = Info_ValueForKey( client->userinfo, "model" );
+	if( !modelInfo || !modelInfo[0] || !COM_ValidateRelativeFilename( modelInfo ) || strchr( modelInfo, '/' ) )
+		modelInfo = NULL;
+
+	if( modelInfo )
+		Q_snprintfz( playerModel, sizeof( playerModel ), "$models/players/%s", modelInfo );
+	else
+		Q_snprintfz( playerModel, sizeof( playerModel ), "$models/players/%s", DEFAULT_PLAYERMODEL );
+
+	// cgame used the model for vsays
+	Info_SetValueForKey( playerString, "model", va( "%i", trap_ModelIndex( playerModel ) ) );
 
 	playerString[MAX_CONFIGSTRING_CHARS-1] = 0;
 	trap_ConfigString( CS_PLAYERINFOS + playerNum, playerString );


### PR DESCRIPTION
This works around game setting ent->s.modelindex to 0 in various places. Game also
depends on modelindex == 0 for G_ISGHOSTING among others. Instead of changing all these
interactions, this workaround synchronizes the chosen playermodel for each player via configstrings
in addition to the modelindex. If the modelindex received from the server is not valid, cgame
first falls back to the model provided using configstrings and only if that is invalid as well
cgame uses DEFAULT_PLAYERMODEL.