### PR TITLE
Fix qwertz layouts messing up the first char in the console.

### DIFF
--- a/source/client/keys.c
+++ b/source/client/keys.c
@@ -383,7 +383,7 @@ static void Key_Bindlist_f( void )
 * If nothing is bound to toggleconsole, we use default key for it
 * Also toggleconsole is specially handled, so it's never outputed to the console or so
 */
-static bool Key_IsToggleConsole( int key )
+bool Key_IsToggleConsole( int key )
 {
 	if( key == -1 )
 		return false;

--- a/source/client/keys.h
+++ b/source/client/keys.h
@@ -36,6 +36,7 @@ const char *Key_KeynumToString( int keynum );
 
 int Key_StringToKeynum( const char *str );
 bool Key_IsDown( int keynum );
+bool Key_IsToggleConsole( int key );
 
 // wsw : aiwa : delegate pattern to forward key strokes to arbitrary code
 // delegates can be stacked, the topmost delegate is sent the key

--- a/source/sdl/sdl_input.c
+++ b/source/sdl/sdl_input.c
@@ -257,6 +257,13 @@ static void key_event( const SDL_KeyboardEvent *event, const bool state )
 	if( charkey >= 0 && charkey <= 255 ) {
 		Key_Event( charkey, state, Sys_Milliseconds() );
 	}
+
+	if( Key_IsToggleConsole( charkey ) )
+	{
+		// clear the sdl input buffer. prevents accents etc from modifying the first character written.
+		SDL_StopTextInput();
+		SDL_StartTextInput();
+	}
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
On QWERTZ keyboards, the default console key is ^. This key opens the
console as expected, but is also recognized by SDL2 as an SDL_TEXTEDITING
event. Therefore it's stored and modifies the next SDL_TEXTINPUT emitted
by SDL. This fix restarts SDL text processing on entering the console,
clearing any modifiers SDL might carry over to console otherwise.