### PR TITLE
Use utf16 for most windows paths

### DIFF
--- a/source/qcommon/files.c
+++ b/source/qcommon/files.c
@@ -384,7 +384,7 @@ static bool FS_SearchDirectoryForFile( searchpath_t *search, const char *filenam
 
 	Q_snprintfz( tempname, sizeof( tempname ), "%s/%s", search->path, filename );
 
-	f = fopen( tempname, "rb" );
+	f = Sys_FS_fopen( tempname, "rb" );
 	if( f )
 	{
 		fclose( f );
@@ -935,7 +935,7 @@ static int FS_FileExists( const char *filename, bool base, bool inVFS )
 	{
 		assert( tempname[0] != '\0' );
 		if( tempname[0] != '\0' ) {
-			return FS_FileLength( fopen( tempname, "rb" ), true );
+			return FS_FileLength( Sys_FS_fopen( tempname, "rb" ), true );
 		}
 	}
 
@@ -952,7 +952,7 @@ static int FS_AbsoluteFileExists( const char *filename )
 	if( !COM_ValidateFilename( filename ) )
 		return -1;
 
-	f = fopen( filename, "rb" );
+	f = Sys_FS_fopen( filename, "rb" );
 	if( !f )
 		return -1;
 
@@ -1028,7 +1028,7 @@ int FS_FOpenAbsoluteFile( const char *filename, int *filenum, int mode )
 	if( gz ) {
 		gzf = qgzopen( filename, modestr );
 	} else {
-		f = fopen( filename, modestr );
+		f = Sys_FS_fopen( filename, modestr );
 	}
 	if( !f && !gzf )
 	{
@@ -1093,7 +1093,7 @@ static int _FS_FOpenPakFile( packfile_t *pakFile, int *filenum )
 
 	*filenum = FS_OpenFileHandle();
 	file = &fs_filehandles[*filenum - 1];
-	file->fstream = fopen( pakFile->vfsHandle ? Sys_VFS_VFSName( pakFile->vfsHandle ) : pakFile->pakname, "rb" );
+	file->fstream = Sys_FS_fopen( pakFile->vfsHandle ? Sys_VFS_VFSName( pakFile->vfsHandle ) : pakFile->pakname, "rb" );
 	if( !file->fstream )
 		Com_Error( ERR_FATAL, "Error opening pak file: %s", pakFile->pakname );
 	file->uncompressedSize = pakFile->uncompressedSize;
@@ -1259,7 +1259,7 @@ static int _FS_FOpenFile( const char *filename, int *filenum, int mode, bool bas
 		if( gz ) {
 			gzf = qgzopen( tempname, modestr );
 		} else {
-			f = fopen( tempname, modestr );
+			f = Sys_FS_fopen( tempname, modestr );
 		}
 		if( !f && !gzf )
 			return -1;
@@ -1316,7 +1316,7 @@ static int _FS_FOpenFile( const char *filename, int *filenum, int mode, bool bas
 		unsigned int vfsOffset;
 
 		vfsName = Sys_VFS_VFSName( vfsHandle );
-		f = fopen( vfsName, "rb" );
+		f = Sys_FS_fopen( vfsName, "rb" );
 		if( !f ) {
 			Com_Error( ERR_FATAL, "Error opening VFS file: %s", vfsName );
 			goto error;
@@ -1349,7 +1349,7 @@ static int _FS_FOpenFile( const char *filename, int *filenum, int mode, bool bas
 			goto error;
 		}
 
-		f = fopen( tempname, "rb" );
+		f = Sys_FS_fopen( tempname, "rb" );
 		end = FS_FileLength( f, gz );
 
 		if( gz ) {
@@ -2605,7 +2605,7 @@ static pack_t *FS_LoadPK3File( const char *packfilename, bool silent )
 		}
 	}
 
-	fin = fopen( vfsHandle ? Sys_VFS_VFSName( vfsHandle ) : packfilename, "rb" );
+	fin = Sys_FS_fopen( vfsHandle ? Sys_VFS_VFSName( vfsHandle ) : packfilename, "rb" );
 	if( fin == NULL )
 	{
 		if( !silent ) Com_Printf( "Error opening PK3 file: %s\n", packfilename );

--- a/source/qcommon/sys_fs.h
+++ b/source/qcommon/sys_fs.h
@@ -39,6 +39,7 @@ void	    Sys_FS_UnlockFile( void *handle );
 
 time_t		Sys_FS_FileMTime( const char *filename );
 
+FILE* Sys_FS_fopen(const char* path, const char* mode);
 int			Sys_FS_FileNo( FILE *fp );
 
 void		*Sys_FS_MMapFile( int fileno, size_t size, size_t offset, void **mapping, size_t *mapping_offset );

--- a/source/qcommon/sys_vfs_zip.c
+++ b/source/qcommon/sys_vfs_zip.c
@@ -190,7 +190,7 @@ static void Sys_VFS_Zip_LoadVFS( int idx, const char *filename )
 		goto end;
 	}
 
-	fin = fopen( filename, "rb" );
+	fin = Sys_FS_fopen( filename, "rb" );
 	if( !fin )
 	{
 		Com_Printf( "Error opening VFS zip file: %s\n", filename );

--- a/source/unix/unix_fs.c
+++ b/source/unix/unix_fs.c
@@ -471,6 +471,14 @@ time_t Sys_FS_FileMTime( const char *filename )
 }
 
 /*
+* Sys_FS_fopen
+*/
+FILE* Sys_FS_fopen(const char* path, const char* mode)
+{
+	return fopen(path, mode);
+}
+
+/*
 * Sys_FS_FileNo
 */
 int	Sys_FS_FileNo( FILE *fp )


### PR DESCRIPTION
What needs to be fixed after this:
* ftlib uses fopen (`FT_Stream_Open`), check if this should be fixed?
* curllib uses fopen, check if this should be fixed
* snd_openal and snd_qf import fopen, due to libvorbis using fopen, check if this should be fixed?
* ref_gl uses fopen (stbiw__fopen), check if this should be fixed, possibly define `STBI_WINDOWS_UTF8` before including stb
* ui uses fopen (`Rocket::Core::FileInterfaceDefault::Open`), check if this should be fixed?