### PR TITLE
Fixed an oversight causing long playernames to overflow configstrings.

### DIFF
--- a/source/cgame/cg_players.cpp
+++ b/source/cgame/cg_players.cpp
@@ -265,6 +265,6 @@ void CG_LoadClientInfo( cg_clientInfo_t *ci, const char *info, int client )
 	else
 		Vector4Set( ci->color, 255, 255, 255, 255 );
 
-	s = Info_ValueForKey( info, "model" );
-	ci->modelindex = s && s[0] ? atoi( s ) : -1;
+	s = Info_ValueForKey( info, "m" );
+	ci->modelindex = s && s[0] ? atoi( s ) : 0;
 }

--- a/source/game/p_client.cpp
+++ b/source/game/p_client.cpp
@@ -1034,6 +1034,7 @@ static void G_UpdatePlayerInfoString( int playerNum )
 	char playerString[MAX_INFO_STRING], playerModel[MAX_INFO_VALUE];
 	char *modelInfo;
 	gclient_t *client;
+	size_t stringLength;
 
 	assert( playerNum >= 0 && playerNum < gs.maxclients );
 	client = &game.clients[playerNum];
@@ -1055,11 +1056,21 @@ static void G_UpdatePlayerInfoString( int playerNum )
 	else
 		Q_snprintfz( playerModel, sizeof( playerModel ), "$models/players/%s", DEFAULT_PLAYERMODEL );
 
-	// cgame used the model for vsays
-	Info_SetValueForKey( playerString, "model", va( "%i", trap_ModelIndex( playerModel ) ) );
+	stringLength = strlen( playerString );
 
-	playerString[MAX_CONFIGSTRING_CHARS-1] = 0;
-	trap_ConfigString( CS_PLAYERINFOS + playerNum, playerString );
+	// cgame used the model for vsays
+	Info_SetValueForKey( playerString, "m", va( "%i", trap_ModelIndex( playerModel ) ) );
+
+	if( strlen( playerString ) < MAX_CONFIGSTRING_CHARS )
+	{
+		trap_ConfigString( CS_PLAYERINFOS + playerNum, playerString );
+	}
+	else
+	{
+        playerString[stringLength] = 0;
+		trap_ConfigString( CS_PLAYERINFOS + playerNum, playerString );
+	}
+
 }
 
 /*


### PR DESCRIPTION
The addition of models into configstrings did not account for
MAX_CONFIGSTRING_CHARS. Therefore a long player name with a lot of
colors could cause the configstring to be an invalid InfoString. This
caused players to be kicked.

This quick and dirty fix works around this problem by only adding the model
to the playerinfo configstring if there's enough space available. If there's
no modelindex in the playerinfo, cgame falls back to DEFAULT_PLAYERMODEL.

This workaround should be replaced by a proper fix.