### PR TITLE
Send EV_DAMAGE to chasing spectators

### DIFF
--- a/source/cgame/cg_ents.cpp
+++ b/source/cgame/cg_ents.cpp
@@ -2157,6 +2157,14 @@ void CG_UpdateEntities( void )
 		cent->item = NULL;
 		cent->renderfx = 0;
 
+		if (cgs.demoPlaying)
+		{
+			if ((state->svflags & SVF_ONLYTEAM) && cg.predictedPlayerState.stats[STAT_TEAM] != state->team)
+				continue;
+			if (((state->svflags & SVF_ONLYOWNER) || (state->svflags & SVF_OWNERANDCHASERS)) && cg.predictedPlayerState.POVnum != state->ownerNum)
+				continue;
+		}
+
 		switch( cent->type )
 		{
 		case ET_GENERIC:

--- a/source/cgame/cg_events.cpp
+++ b/source/cgame/cg_events.cpp
@@ -1719,6 +1719,14 @@ static void CG_FireEntityEvents( bool early )
 	{
 		state = &cg.frame.parsedEntities[pnum&( MAX_PARSE_ENTITIES-1 )];
 
+		if (cgs.demoPlaying)
+		{
+			if ((state->svflags & SVF_ONLYTEAM) && cg.predictedPlayerState.stats[STAT_TEAM] != state->team)
+				continue;
+			if (((state->svflags & SVF_ONLYOWNER) || (state->svflags & SVF_OWNERANDCHASERS)) && cg.predictedPlayerState.POVnum != state->ownerNum)
+				continue;
+		}
+
 		if( state->type == ET_SOUNDEVENT )
 		{
 			if( early )

--- a/source/game/g_combat.cpp
+++ b/source/game/g_combat.cpp
@@ -461,7 +461,7 @@ void G_Damage( edict_t *targ, edict_t *inflictor, edict_t *attacker, const vec3_
 		// in G_Fire_SunflowerPattern and show one number there instead
 		if( !GS_Instagib() && mod != MOD_RIOTGUN_W && mod != MOD_RIOTGUN_S ) {
 			edict_t * damage = G_SpawnEvent( EV_DAMAGE, 0, targ->s.origin );
-			damage->r.svflags |= SVF_ONLYOWNER;
+			damage->r.svflags |= SVF_OWNERANDCHASERS;
 			damage->s.ownerNum = ENTNUM( attacker );
 			damage->s.damage = HEALTH_TO_INT( take + asave );
 		}

--- a/source/game/g_weapon.cpp
+++ b/source/game/g_weapon.cpp
@@ -571,7 +571,7 @@ static void G_Fire_SunflowerPattern( edict_t *self, vec3_t start, vec3_t dir, in
 			continue;
 		edict_t * target = &game.edicts[i];
 		edict_t * ev = G_SpawnEvent( EV_DAMAGE, 0, target->s.origin );
-		ev->r.svflags |= SVF_ONLYOWNER;
+		ev->r.svflags |= SVF_OWNERANDCHASERS;
 		ev->s.ownerNum = ENTNUM( self );
 		ev->s.damage = HEALTH_TO_INT( hits[i] * damage );
 	}

--- a/source/gameshared/q_comref.h
+++ b/source/gameshared/q_comref.h
@@ -257,6 +257,7 @@ typedef struct
 #define SVF_FORCEOWNER			0x00000400		// this entity forces the entity at s.ownerNum to be included in the snapshot
 #define SVF_ONLYOWNER			0x00000800		// this entity is only transmitted to its owner
 #define SVF_FORCETEAM			0x00001000		// this entity is always transmitted to clients with the same ent->s.team value
+#define SVF_OWNERANDCHASERS		0x00002000		// this entity is transmitted to it's owner and any chasers of the owner
 
 // edict->solid values
 typedef enum

--- a/source/qcommon/snap_write.c
+++ b/source/qcommon/snap_write.c
@@ -19,7 +19,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "qcommon.h"
-
+#include "../gameshared/gs_public.h"
 #include "snap_write.h"
 
 /*
@@ -917,6 +917,15 @@ static bool SNAP_SnapCullEntity( cmodel_state_t *cms, edict_t *ent, edict_t *cle
 	// send only to owner
 	if( ( ent->r.svflags & SVF_ONLYOWNER ) && ( clent && ent->s.ownerNum != clent->s.number ) )
 		return true;
+
+	// send only to owner and whoever is chasing this entity
+	// multi-pov demo's still receive it, so that is filtered in CG_UpdateEntities and CG_FireEntityEvents
+	if( ( ent->r.svflags & SVF_OWNERANDCHASERS ) && clent ) {
+		bool self = ent->s.ownerNum == clent->s.number;
+		bool pov = clent->s.team == TEAM_SPECTATOR && (int)clent->r.client->ps.POVnum == ent->s.ownerNum;
+		if (!self && !pov)
+			return true;
+	}
 
 	if( ent->r.svflags & SVF_BROADCAST )  // send to everyone
 		return false;

--- a/source/qcommon/version.warfork.h
+++ b/source/qcommon/version.warfork.h
@@ -45,15 +45,15 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 
 #ifdef PUBLIC_BUILD
-#define APP_PROTOCOL_VERSION			24
+#define APP_PROTOCOL_VERSION			25
 #else
 #define APP_PROTOCOL_VERSION			2400
 #endif
 
 #ifdef PUBLIC_BUILD
-#define APP_DEMO_PROTOCOL_VERSION		20
+#define APP_DEMO_PROTOCOL_VERSION		21
 #else
-#define APP_DEMO_PROTOCOL_VERSION		20
+#define APP_DEMO_PROTOCOL_VERSION		21
 #endif
 
 #ifndef APP_URL


### PR DESCRIPTION
EV_DAMAGE is now only sent to chasing spectators.
Due to the nature of server demo's, there is also some clientside filtering for when a demo is playing.

Because this touches flags in the protocol (and in the demo), I bumped both versions.

This is 90% the work of @mikejsavage, I simply ported it to WF