### PR TITLE
Scan for content in Steam Workshop folders on Windows

### DIFF
--- a/source/qcommon/sys_fs.h
+++ b/source/qcommon/sys_fs.h
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 const char *Sys_FS_GetHomeDirectory( void );
 const char *Sys_FS_GetCacheDirectory( void );
+const char *Sys_FS_GetSteamWorkshopDirectory( void );
 const char *Sys_FS_GetSecureDirectory( void );
 const char *Sys_FS_GetMediaDirectory( fs_mediatype_t type );
 const char *Sys_FS_GetRuntimeDirectory( void );

--- a/source/unix/unix_fs.c
+++ b/source/unix/unix_fs.c
@@ -308,6 +308,14 @@ const char *Sys_FS_GetCacheDirectory( void )
 }
 
 /*
+* Sys_FS_GetSteamWorkshopDirectory
+*/
+const char *Sys_FS_GetSteamWorkshopDirectory( void )
+{
+	return NULL;
+}
+
+/*
 * Sys_FS_GetSecureDirectory
 */
 const char *Sys_FS_GetSecureDirectory( void )


### PR DESCRIPTION
This fixes the windows part of #45

The location to steam is resolved from the registry.
Currently this is only tested on my pc, where steam is installed in a non-default location.
steam_appid.pk3 is a private test-mod uploaded to steam
This was tested on Windows 10 21H1 (x64),
with steam installed in `F:\Steam`

![image](https://user-images.githubusercontent.com/610685/154146001-57699805-e48d-4894-87c9-1fb547218d75.png)

![image](https://user-images.githubusercontent.com/610685/154146040-8dcd6b29-e581-4895-a7fe-ca9e5b862213.png)

Todo:

- [ ] Verify that it works on Windows (10) x86
- [ ] Verify that it works on Windows 7 (if that's supported)
- [ ] Verify that it builds on whatever other targets are there (it's not expected to work there, it should still build)
- [ ] Maybe have a few people test that this works reliably

