### PR TITLE
Basic Steamworks integration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,12 +4,14 @@ image: Visual Studio 2017
 configuration: Release
 environment:
   matrix:
-  - BUILD_PLATFORM: x86
+  - BUILD_STEAMLIB: 1
+    BUILD_PLATFORM: x86
     VS_GENERATOR: Visual Studio 15 2017
   - USE_SDL2: 1
     BUILD_PLATFORM: x86
     VS_GENERATOR: Visual Studio 15 2017
-  - BUILD_PLATFORM: x64
+  - BUILD_STEAMLIB: 1
+    BUILD_PLATFORM: x64
     VS_GENERATOR: Visual Studio 15 2017 Win64
   - USE_SDL2: 1
     BUILD_PLATFORM: x64
@@ -21,7 +23,7 @@ install:
 
     cd "build_%BUILD_PLATFORM%"
 
-    cmake -G "%VS_GENERATOR%" -T "%VS_TOOLSET%" ..\source\ -DUSE_SDL2=%USE_SDL2%
+    cmake -G "%VS_GENERATOR%" -T "%VS_TOOLSET%" ..\source\ -DUSE_SDL2=%USE_SDL2% -DBUILD_STEAMLIB=%BUILD_STEAMLIB%
 
     cd ..
 build_script:

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ libsrcs/SDL2/VisualC/SDL/Win32
 libsrcs/SDL2/VisualC/SDLmain/Win32
 libsrcs/SDL2/VisualC/SDLtest/Win32
 libsrcs/SDL2/VisualC/tests/*/Win32
+third-party/steamworks/sdk

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -29,6 +29,7 @@ endif()
 
 option(USE_SDL2 "Build using SDL2" OFF)
 option(GAME_MODULES_ONLY "Only build game modules" OFF)
+option(BUILD_STEAMLIB "Include the steamlib module (requires Steamworks SDK)" OFF)
 
 # We build angelscript and libRocket from source
 
@@ -254,7 +255,9 @@ if (NOT GAME_MODULES_ONLY)
     add_subdirectory(snd_openal)
     add_subdirectory(snd_qf)
     add_subdirectory(ui)
-    add_subdirectory(steamlib)
+    if (BUILD_STEAMLIB)
+        add_subdirectory(steamlib)
+    endif()
     add_subdirectory(server)
     add_subdirectory(tv_server)
     add_subdirectory(client)

--- a/source/client/cl_main.c
+++ b/source/client/cl_main.c
@@ -3087,8 +3087,6 @@ void CL_Init( void )
 	// init localization subsystem
 	L10n_Init();
 
-	Steam_Init();
-
 	VID_Init();
 
 	CL_ClearState();

--- a/source/qcommon/common.c
+++ b/source/qcommon/common.c
@@ -990,10 +990,6 @@ void Qcommon_Init( int argc, char **argv )
 
 	CM_Init();
 
-#if APP_STEAMID
-	Steam_LoadLibrary();
-#endif
-
 	Com_ScriptModule_Init();
 
 	MM_Init();

--- a/source/qcommon/files.c
+++ b/source/qcommon/files.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "sys_fs.h"
 #include "sys_threads.h"
+#include "steam.h"
 
 #include "compression.h"
 #include "wswcurl.h"
@@ -155,6 +156,7 @@ typedef struct searchpath_s
 	pack_t *pack;
 	struct searchpath_s *base;		// parent basepath
 	struct searchpath_s *next;
+	bool append_basegame;
 } searchpath_t;
 
 typedef struct
@@ -3596,7 +3598,10 @@ static char **FS_GamePathPaks( searchpath_t *basepath, const char *gamedir, int 
 		int numvfsfiles = 0, numfiles = 0;
 		char **vfsfilenames = NULL, **filenames;
 
-		Q_snprintfz( pattern, sizeof( pattern ), "%s/*.%s", gamedir, pak_extensions[e] );
+		if( basepath->append_basegame )
+			Q_snprintfz( pattern, sizeof( pattern ), "%s/*.%s", gamedir, pak_extensions[e] );
+		else
+			Q_snprintfz( pattern, sizeof( pattern ), "*.%s", pak_extensions[e] );
 		Q_snprintfz( basePattern, sizeof( basePattern ), "%s/%s", basepath->path, pattern );
 
 		if( basepath == fs_root_searchpath ) // only add VFS once per game, treat it like the installation directory
@@ -3690,7 +3695,11 @@ static int FS_TouchGamePath( searchpath_t *basepath, const char *gamedir, bool i
 		path_size = sizeof( char ) * ( strlen( basepath->path ) + 1 + strlen( gamedir ) + 1 );
 		search->path = ( char* )FS_Malloc( path_size );
 		search->base = basepath;
-		Q_snprintfz( search->path, path_size, "%s/%s", basepath->path, gamedir );
+		search->append_basegame = basepath->append_basegame;
+		if( search->append_basegame )
+			Q_snprintfz( search->path, path_size, "%s/%s", basepath->path, gamedir );
+		else
+			Q_snprintfz( search->path, path_size, "%s", basepath->path );
 
 		search->next = fs_searchpaths;
 		fs_searchpaths = search;
@@ -4090,16 +4099,23 @@ bool FS_SetGameDirectory( const char *dir, bool force )
 /*
 * FS_AddBasePath
 */
-static void FS_AddBasePath( const char *path )
+static void FS_AddBasePath( const char *path, bool append_basegame )
 {
 	searchpath_t *newpath;
 
 	newpath = ( searchpath_t* )FS_Malloc( sizeof( searchpath_t ) );
 	newpath->path = FS_CopyString( path );
 	newpath->next = fs_basepaths;
+	newpath->append_basegame = append_basegame;
 	fs_basepaths = newpath;
 	COM_SanitizeFilePath( newpath->path );
 }
+
+void FS_AddExtraPK3Directory( const char *path )
+{
+	FS_AddBasePath( path, false );
+}
+
 
 /*
 * FS_FreeSearchFiles
@@ -4351,27 +4367,33 @@ void FS_Init( void )
 			Q_snprintfz( downloadsdir, sizeof( downloadsdir ), "%s", "downloads" );
 		}
 
-		FS_AddBasePath( downloadsdir );
+		FS_AddBasePath( downloadsdir, true );
 		fs_downloads_searchpath = fs_basepaths;
 	}
 
 	if( fs_cdpath->string[0] )
-		FS_AddBasePath( fs_cdpath->string );
+		FS_AddBasePath( fs_cdpath->string, true );
 
-	FS_AddBasePath( fs_basepath->string );
+	FS_AddBasePath( fs_basepath->string, true );
 	fs_root_searchpath = fs_basepaths;
 	fs_write_searchpath = fs_basepaths;
 
 	if( homedir != NULL && fs_usehomedir->integer ) {
-		FS_AddBasePath( homedir );
+		FS_AddBasePath( homedir, true );
 		fs_write_searchpath = fs_basepaths;
 	}
 
 	cachedir = Sys_FS_GetCacheDirectory();
 	if( cachedir )
-		FS_AddBasePath( cachedir );
+		FS_AddBasePath( cachedir, true );
 
 	Sys_VFS_Init();
+
+	// Need to initialize before FS is done, but after the basic search path is constructed.
+#if APP_STEAMID
+	Steam_LoadLibrary();
+	Steam_Init();
+#endif
 
 	//
 	// set game directories

--- a/source/qcommon/files.c
+++ b/source/qcommon/files.c
@@ -4392,7 +4392,11 @@ void FS_Init( void )
 	// Need to initialize before FS is done, but after the basic search path is constructed.
 #if APP_STEAMID
 	Steam_LoadLibrary();
+#if !defined(DEDICATED_ONLY)
 	Steam_Init();
+#else
+	// FIXME: Steam server init here!
+#endif
 #endif
 
 	//

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -745,6 +745,7 @@ const char *FS_RuntimeDirectory( void );
 void	    FS_CreateAbsolutePath( const char *path );
 const char *FS_AbsoluteNameForFile( const char *filename );
 const char *FS_AbsoluteNameForBaseFile( const char *filename );
+void	    FS_AddExtraPK3Directory( const char *path );
 
 // // game and base files
 // file streaming

--- a/source/qcommon/steam.c
+++ b/source/qcommon/steam.c
@@ -44,6 +44,7 @@ void Steam_LoadLibrary( void )
 	import.Com_Printf = Com_Printf;
 	import.Com_DPrintf = Com_DPrintf;
 	import.Cbuf_ExecuteText = Cbuf_ExecuteText;
+	import.FS_AddExtraPK3Directory = FS_AddExtraPK3Directory;
 
 	// load dynamic library
 	Com_Printf( "Loading Steam module... " );

--- a/source/steamlib/CMakeLists.txt
+++ b/source/steamlib/CMakeLists.txt
@@ -7,7 +7,48 @@ file(GLOB STEAMLIB_HEADERS
 
 file(GLOB STEAMLIB_SOURCES
     "*.cpp"
+    "../gameshared/q_shared.c"
 )
 
+set(STEAMWORKS_SDK_DIR ${CMAKE_HOME_DIRECTORY}/../third-party/steamworks/sdk)
+include_directories("${STEAMWORKS_SDK_DIR}/public")
+
+set(STEAMWORKS_LIBRARY steam_api)
+# Please note, this is not in the 'libs' directory!
+set(STEAMWORKS_OUTPUT_PATH ${CMAKE_HOME_DIRECTORY}/build)
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(STEAMWORKS_LIBRARY_DIR ${STEAMWORKS_SDK_DIR}/redistributable_bin/win64)
+        set(STEAMWORKS_LIBRARY steam_api64)
+    else()
+        set(STEAMWORKS_LIBRARY_DIR ${STEAMWORKS_SDK_DIR}/redistributable_bin)
+    endif()
+    set(STEAMWORKS_LIBRARY_EXTENSION .dll)
+    # This is not a typo, but using Visual Studio's 'Configuration' property!
+    set(STEAMWORKS_OUTPUT_PATH "${CMAKE_HOME_DIRECTORY}/build/$(Configuration)")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(STEAMWORKS_LIBRARY_DIR ${STEAMWORKS_SDK_DIR}/redistributable_bin/osx)
+    set(STEAMWORKS_LIBRARY_EXTENSION .dylib)
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(STEAMWORKS_LIBRARY_DIR ${STEAMWORKS_SDK_DIR}/redistributable_bin/linux64)
+    else()
+        set(STEAMWORKS_LIBRARY_DIR ${STEAMWORKS_SDK_DIR}/redistributable_bin/linux32)
+    endif()
+    set(STEAMWORKS_LIBRARY_EXTENSION .so)
+endif()
+
+link_directories(${STEAMWORKS_LIBRARY_DIR})
+
 add_library(steamlib SHARED ${STEAMLIB_SOURCES} ${STEAMLIB_HEADERS})
+target_link_libraries(steamlib ${STEAMWORKS_LIBRARY})
 qf_set_output_dir(steamlib libs)
+
+add_custom_command(TARGET steamlib
+    POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+        "${STEAMWORKS_LIBRARY_DIR}/${STEAMWORKS_LIBRARY}${STEAMWORKS_LIBRARY_EXTENSION}"
+        "${STEAMWORKS_OUTPUT_PATH}"
+        
+)

--- a/source/steamlib/steamlib_main.cpp
+++ b/source/steamlib/steamlib_main.cpp
@@ -16,71 +16,186 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library.
 */
 
+#include "../gameshared/q_shared.h"
+#include "../qcommon/qcommon.h"
 #include "steamlib_local.h"
+#include <steam/steam_api.h>
 
-namespace WSWSTEAM {
+namespace WSWSTEAM
+{
+typedef void ( *auth_callback_t )( void *, size_t );
+
+struct CSteamCallbacks {
+	auth_callback_t m_callback;
+	uint8 m_AuthTicket[1024];
+	uint32 m_AuthTicketLength;
+	HAuthTicket m_AuthTicketResult;
+
+	CSteamCallbacks() : m_callback( NULL ), m_AuthTicketLength( 0 ), m_AuthTicketResult( k_HAuthTicketInvalid ) {}
+
+	int GetAuthSessionTicket( void ( *callback )( void *, size_t ) )
+	{
+		m_callback = callback;
+		m_AuthTicketResult = SteamUser()->GetAuthSessionTicket( m_AuthTicket, sizeof( m_AuthTicket ), &m_AuthTicketLength );
+		return m_AuthTicketResult != k_HAuthTicketInvalid ? 1 : 0;
+	}
+
+	STEAM_CALLBACK( CSteamCallbacks, OnGetAuthSessionTicketResponse, GetAuthSessionTicketResponse_t );
+	STEAM_CALLBACK( CSteamCallbacks, OnWorkshopItemInstalled, ItemInstalled_t );
+};
+static CSteamCallbacks *g_pCallbacks = nullptr;
+
+void CSteamCallbacks::OnGetAuthSessionTicketResponse( GetAuthSessionTicketResponse_t *pParam )
+{
+	if( pParam->m_eResult != k_EResultOK )
+		m_AuthTicketLength = 0;
+
+	m_callback( m_AuthTicket, m_AuthTicketLength );
+}
+
+void AddUGCItem(PublishedFileId_t workshopItemID);
+
+void CSteamCallbacks::OnWorkshopItemInstalled( ItemInstalled_t *pParam )
+{
+	if( pParam->m_unAppID == SteamUtils()->GetAppID() ) {
+		//AddUGCItem(pParam->m_nPublishedFileId);
+		Com_Printf( "New workshop item installed, please restart!\n" );
+	}
+}
+
+void AddUGCItem( PublishedFileId_t workshopItemID )
+{
+	uint32 unItemState = SteamUGC()->GetItemState( workshopItemID );
+	if( !( unItemState & k_EItemStateInstalled ) )
+		return;
+
+	uint32 unTimeStamp = 0;
+	uint64 unSizeOnDisk = 0;
+	char szItemFolder[1024] = { 0 };
+
+	if( !SteamUGC()->GetItemInstallInfo( workshopItemID, &unSizeOnDisk, szItemFolder, sizeof( szItemFolder ), &unTimeStamp ) ) {
+		Com_Printf( S_COLOR_RED "Unable to retrieve info for %uLL\n", workshopItemID );
+		return;
+	}
+
+	if( unItemState & k_EItemStateLegacyItem ) {
+		// szItemFolder just points directly to the item for legacy items that were published with the RemoteStorage API.
+		// figure out how to handle this later!
+		Com_Printf( S_COLOR_RED "Skipping legacy item '%s'\n", szItemFolder );
+		return;
+	}
+
+	Com_Printf( "Found workshop folder '%s'\n", szItemFolder );
+	WSWSTEAM::GetSteamImport()->FS_AddExtraPK3Directory( szItemFolder );
+}
+
+static void AddWorkshopDirectories(void)
+{
+	// Enumerate installed UGC (User Generated Content)
+	uint32 count = SteamUGC()->GetNumSubscribedItems();
+	if (count > 0) {
+		PublishedFileId_t* vecSubscribedItems = new PublishedFileId_t[count];
+
+		uint32 num = SteamUGC()->GetSubscribedItems(vecSubscribedItems, count);
+		if (num > count)
+			num = count;
+
+		for (uint32 iSubscribedItem = 0; iSubscribedItem < count; iSubscribedItem++) {
+			AddUGCItem(vecSubscribedItems[iSubscribedItem]);
+		}
+
+		delete[] vecSubscribedItems;
+	}
+}
 
 /*
-* SteamLib_API
-*/
+ * SteamLib_API
+ */
 int SteamLib_API( void )
 {
 	return STEAMLIB_API_VERSION;
 }
 
 /*
-* SteamLib_SteamLib_InitAPI
-*/
+ * SteamLib_SteamLib_InitAPI
+ */
 int SteamLib_Init( void )
 {
+	if( SteamAPI_Init() ) {
+
+		// Register our steam callbacks
+		g_pCallbacks = new CSteamCallbacks();
+
+		// Register workshop items
+		AddWorkshopDirectories();
+
+		return 1;
+	}
+
 	return 0;
 }
 
 /*
-* SteamLib_RunFrame
-*/
+ * SteamLib_RunFrame
+ */
 void SteamLib_RunFrame( void )
 {
+	SteamAPI_RunCallbacks();
 }
 
 /*
-* SteamLib_Shutdown
-*/
+ * SteamLib_Shutdown
+ */
 void SteamLib_Shutdown( void )
 {
+	delete g_pCallbacks;
+	g_pCallbacks = nullptr;
+	SteamAPI_Shutdown();
 }
 
 /*
-* SteamLib_GetSteamID
-*/
+ * SteamLib_GetSteamID
+ */
 uint64_t SteamLib_GetSteamID( void )
 {
-	return 0;
+	return SteamUser()->GetSteamID().ConvertToUint64();
 }
 
 /*
-* SteamLib_GetAuthSessionTicket
-*/
-int SteamLib_GetAuthSessionTicket( void (*callback)( void *, size_t ) )
+ * SteamLib_GetAuthSessionTicket
+ */
+int SteamLib_GetAuthSessionTicket( void ( *callback )( void *, size_t ) )
 {
-	return 0;
+	return g_pCallbacks->GetAuthSessionTicket( callback );
 }
 
 /*
-* SteamLib_AdvertiseGame
-*/
+ * SteamLib_AdvertiseGame
+ */
 void SteamLib_AdvertiseGame( const uint8_t *ip, unsigned short port )
 {
+	uint32 unIPServer = 0;
+	CSteamID steamIDGameServer;
+	if( ip ) {
+		unIPServer = ( uint32( ip[0] ) << 24 ) | ( uint32( ip[1] ) << 16 ) | ( uint32( ip[2] ) << 8 ) | ( uint32( ip[3] ) << 0 );
+		steamIDGameServer = k_steamIDNonSteamGS;
+	} else {
+		port = 0;
+		steamIDGameServer = k_steamIDNil;
+	}
+
+	SteamUser()->AdvertiseGame( steamIDGameServer, unIPServer, port );
 }
 
 /*
-* SteamLib_GetPersonaName
-*/
+ * SteamLib_GetPersonaName
+ */
 void SteamLib_GetPersonaName( char *name, size_t namesize )
 {
 	if( namesize ) {
 		name[0] = '\0';
+		Q_strncpyz( name, SteamFriends()->GetPersonaName(), namesize );
 	}
 }
 
-}
+} // namespace WSWSTEAM

--- a/source/steamlib/steamlib_public.h
+++ b/source/steamlib/steamlib_public.h
@@ -24,7 +24,7 @@ License along with this library.
 
 // steamlib_public.h - steam integration subsystem
 
-#define	STEAMLIB_API_VERSION 3
+#define	STEAMLIB_API_VERSION 4
 
 //===============================================================
 
@@ -42,6 +42,10 @@ typedef struct
 
 	// console commands
 	void ( *Cbuf_ExecuteText )( int exec_when, const char *text );
+
+	// Allow steam to add a directory containing PK3 files
+	void ( *FS_AddExtraPK3Directory )( const char *path );
+
 } steamlib_import_t;
 
 //

--- a/source/steamlib/steamlib_syscalls.cpp
+++ b/source/steamlib/steamlib_syscalls.cpp
@@ -17,6 +17,7 @@ License along with this library.
 */
 
 #include "steamlib_local.h"
+#include "../gameshared/q_shared.h"
 
 namespace WSWSTEAM {
 
@@ -57,6 +58,30 @@ extern "C" STEAMDLL_EXPORT steamlib_export_t *GetSteamLibAPI( steamlib_import_t 
 	globals.GetPersonaName = &WSWSTEAM::SteamLib_GetPersonaName;
 
 	return &globals;
+}
+
+void Sys_Error(const char* format, ...)
+{
+	va_list	argptr;
+	char msg[3072];
+
+	va_start(argptr, format);
+	Q_vsnprintfz(msg, sizeof(msg), format, argptr);
+	va_end(argptr);
+
+	WSWSTEAM::GetSteamImport()->Com_Error(ERR_FATAL, S_COLOR_RED "STEAM" S_COLOR_WHITE ": %s", msg);
+}
+
+void Com_Printf(const char* format, ...)
+{
+	va_list	argptr;
+	char msg[3072];
+
+	va_start(argptr, format);
+	Q_vsnprintfz(msg, sizeof(msg), format, argptr);
+	va_end(argptr);
+
+	WSWSTEAM::GetSteamImport()->Com_Printf(S_COLOR_YELLOW "STEAM" S_COLOR_WHITE ": %s", msg);
 }
 
 #if defined ( HAVE_DLLMAIN ) && !defined ( STEAMLIB_HARD_LINKED )

--- a/third-party/steamworks/README.md
+++ b/third-party/steamworks/README.md
@@ -1,0 +1,6 @@
+
+# Building with the Steamworks SDK:
+
+- Extract the contents of the steamworks SDK to this folder (the folder 'sdk' shouldbe in the same directory as this README)
+- Enable the option 'BUILD_STEAMLIB' in CMake
+- Reconfigure


### PR DESCRIPTION
Steamworks is now initialized inside the FS initialization code,
because it needs a (semi) functional search path.

Implemented:

- [x] Add UGC (User Generated Content) from steam to the game's search path
- [x] Authenticate to steam when requested (MM backend)
- [x] Advertise the game as 'in progress'
- [x] Figure out how the join an advertised game

To do:
- [ ] Test on Linux, (Mac?), and any Windows versions supported that are not Win10 x64.
- [ ] Update travis (and other) builds to build with steamworks