### PR TITLE
Dynamically load proper libtheoradec if available

### DIFF
--- a/source/gameshared/q_arch.h
+++ b/source/gameshared/q_arch.h
@@ -213,7 +213,7 @@ typedef UINT_PTR socket_handle_t;
 #define LIBOGG_LIBNAME "libogg.so.0|libogg.so"
 #define LIBVORBIS_LIBNAME "libvorbis.so.0|libvorbis.so"
 #define LIBVORBISFILE_LIBNAME "libvorbisfile.so.3|libvorbisfile.so"
-#define LIBTHEORA_LIBNAME "libtheora.so.0|libtheora.so"
+#define LIBTHEORA_LIBNAME "libtheoradec.so.1|libtheoradec.so|libtheora.so.0|libtheora.so"
 #define LIBFREETYPE_LIBNAME "libfreetype.so.6|libfreetype.so"
 
 #if defined ( __FreeBSD__ )


### PR DESCRIPTION
This change tries to load libtheoradec (which is the newer 1.x version of theora) before attempting to load libtheora.so (which is the old 0.x version of theora). Loading the 0.x version of theora doesn't actually work since the export names have been changed from 0.x to 1.x in libtheora (the function name prefix changed from theora_ to th_).

When not being able to load libtheora there is a rare crash on startup on linux in warfork.