### PR TITLE
Replace spaces in serverinfo when string is larger than 20 characters

### DIFF
--- a/source/ui/datasources/ui_serverbrowser_datasource.cpp
+++ b/source/ui/datasources/ui_serverbrowser_datasource.cpp
@@ -302,10 +302,12 @@ void ServerInfo::fixString( std::string &s )
 		s.erase( pos, 1 );
 		pos = s.find( '\n', pos );
 	}
-	pos = s.find( ' ' );
-	while( pos != std::string::npos ) {
-		s.replace( pos, 1, "&nbsp;" );
-		pos = s.find(' ' );
+	if ( s.length() > 20 ) {
+		pos = s.find( '   ' );
+		while( pos != std::string::npos ) {
+			s.replace( pos, 1, "&nbsp;" );
+			pos = s.find( '   ' );
+		}
 	}
 }
 


### PR DESCRIPTION
This also now only replaces blocks of 3 consecutive spaces