### PR TITLE
Remove Warshell for headhunt matches

### DIFF
--- a/assets/data0_21pure/progs/gametypes/headhunt.as
+++ b/assets/data0_21pure/progs/gametypes/headhunt.as
@@ -729,6 +729,17 @@ void GT_Shutdown()
 // playing, but nothing has yet started.
 void GT_SpawnGametype()
 {
+    // Prevent Warshell from spawning since we use the effect to identify the tagged player
+    for ( int i = 0; i < numEntities; i++ )
+    {
+        Entity@ ent = @G_GetEntity( i );
+
+        if ( @ent.item != null && ent.item.tag == POWERUP_SHELL )
+        {
+            ent.freeEntity();
+        }
+    }
+
     // Initialize minimap. Player location is automatically
     // updated at tagged_player_minimap_think
     Entity @minimap = @G_SpawnEntity( "tagged_player_minimap" );


### PR DESCRIPTION
Resolves #75

We use the Warshell effect (`EF_SHELL`) on the tagged player in headhunt, so this will reduce confusion. Also, the scoreboard detects who's carrying Warshell by the effect, so this also ensures that the scoreboard will always only show the tagged player with the Warshell icon during headhunt, rather than possibly showing two players with the icon.

Note, this does not remove the drop code related to Warshell, just in case Warshell is added back: https://github.com/TeamForbiddenLLC/warfork-qfusion/blob/a4382a109539571f1a286c839bd0dbdaef8d0fb9/assets/data0_21pure/progs/gametypes/headhunt.as#L223-L227