### PR TITLE
KTX NPOT fix

### DIFF
--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -491,9 +491,19 @@ static int R_ScaledImageSize( int width, int height, int *scaledWidth, int *scal
 		for( potWidth = 1; potWidth < width; potWidth <<= 1 );
 		for( potHeight = 1; potHeight < height; potHeight <<= 1 );
 
+        // Force a resample on Mac
+#ifdef __APPLE__
 		if( ( width != potWidth ) || ( height != potHeight ) )
+		{
 			mips = 1;
-
+			mip = -1;
+		}
+#else
+		if( ( width != potWidth ) || ( height != potHeight ) )
+		{
+			mips = 1;
+		}
+#endif
 		width = potWidth;
 		height = potHeight;
 	}


### PR DESCRIPTION
Credit to MSC

This fixes the Mac crashes (#169).

```
* thread #14, stop reason = EXC_BAD_ACCESS (code=1, address=0x150d34000)
  * frame #0: 0x00007ff817fd92a0 libsystem_platform.dylib`_platform_memmove$VARIANT$Haswell + 320
    frame #1: 0x00007ffa2bda20f2 AppleIntelHD5000GraphicsGLDriver`glrWriteTextureData + 5209
    frame #2: 0x00007ffa30ff1dce GLEngine`glTexImage2D_Exec + 1926
    frame #3: 0x00007ffa30fcf190 libGL.dylib`glTexImage2D + 55
    frame #4: 0x0000000106d49ba2 libref_gl_mac.dylib`R_UploadMipmapped(ctx=3, data=0x00007000019fb270, width=800, height=450, mipLevels=1, flags=5, minmipsize=1, upload_width=0x0000000106f60e4c, upload_height=0x0000000106f60e50, format=6408, type=5121) at r_image.c:1262:4
    frame #5: 0x0000000106d4919b libref_gl_mac.dylib`R_LoadKTX(ctx=3, image=0x0000000106f60e20, pathname="textures/billboard/bigbill5.ktx") at r_image.c:1596:3
    frame #6: 0x0000000106d4501a libref_gl_mac.dylib`R_LoadImageFromDisk(ctx=3, image=0x0000000106f60e20) at r_image.c:1632:6
    frame #7: 0x0000000106d4b1e1 libref_gl_mac.dylib`R_HandleLoadPicLoaderCmd(pcmd=0x000000010b2c48b0) at r_image.c:3060:11
    frame #8: 0x0000000100077324 Warfork`QBufPipe_ReadCmds + 404
    frame #9: 0x0000000106d4b29f libref_gl_mac.dylib`R_ImageLoaderCmdsWaiter(queue=0x000000010b2c4000, cmdHandlers=0x00007000019fbf80, timeout=true) at r_image.c:3096:9
    frame #10: 0x000000010007746c Warfork`QBufPipe_Wait + 172
    frame #11: 0x0000000106d4b092 libref_gl_mac.dylib`R_ImageLoaderThreadProc(param=0x000000010b2c4000) at r_image.c:3113:2
    frame #12: 0x00007ff817fc64e1 libsystem_pthread.dylib`_pthread_start + 125
    frame #13: 0x00007ff817fc1f6b libsystem_pthread.dylib`thread_start + 15
```

The crash always occurs on the billboard textures, which happen to be the only textures that were resized to new NPOT dimensions.

MSC wasn't sure whether or not this is a proper fix, but I've tested it and it does work. Some notes from MSC:

- In `R_Upload32` (which is used for non-KTX textures), we check if `scaledWidth` == `width` and `scaledHeight` == `height`. If not, the texture is resampled:
https://github.com/TeamForbiddenLLC/warfork-qfusion/blob/990ae6ae9f6aa7e1af433145e765da23ad3db340/source/ref_gl/r_image.c#L1019-L1090
- In `R_ScaledImageSize` (which is used for KTX textures), we do not resample in this case:
https://github.com/TeamForbiddenLLC/warfork-qfusion/blob/990ae6ae9f6aa7e1af433145e765da23ad3db340/source/ref_gl/r_image.c#L483-L499
- Note the check for `texture_non_power_of_two`
  - In some Mac OpenGL configurations, `texture_non_power_of_two` is disabled.
  - In some Mac OpenGL configurations, `texture_non_power_of_two` is reported as enabled and available, while not supporting NPOT mipmapping.
- In R_UploadMipmapped, resampling occurs when `mip` is less than 0 (so this fix is forcing resampling):
https://github.com/TeamForbiddenLLC/warfork-qfusion/blob/990ae6ae9f6aa7e1af433145e765da23ad3db340/source/ref_gl/r_image.c#L1206-L1245
 
Related reads:
- https://forums.insideqc.com/viewtopic.php?p=43992
- https://web.archive.org/web/20181028003452/http://www.idevgames.com/forums/printthread.php?tid=3814&page=2
- https://aras-p.info/blog/2012/10/17/non-power-of-two-textures/