### PR TITLE
Target MacOS 10.11

### DIFF
--- a/libsrcs/lib/mac/Frameworks/soft_oal.framework/Versions/C/Resources/Info.plist
+++ b/libsrcs/lib/mac/Frameworks/soft_oal.framework/Versions/C/Resources/Info.plist
@@ -23,7 +23,7 @@
 		<string>MacOSX</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>4252</string>
+	<string>4270</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>DTCompiler</key>
@@ -43,6 +43,6 @@
 	<key>DTXcodeBuild</key>
 	<string>13F100</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.9</string>
+	<string>10.11</string>
 </dict>
 </plist>

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -98,7 +98,7 @@ endif()
 # OS X specific settings
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(ARCHS_STANDARD_32_64_BIT "x86_64")                         # Compile only 64-bit version
-    set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "11.3")     # Use 11.3 as deployment target
+    set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "10.11")     # Use 10.11 as deployment target
     set(CMAKE_XCODE_ATTRIBUTE_GCC_C_LANGUAGE_STANDARD "gnu99")     # Use GNU99 standart for compiling C files
     set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11") # Use C++11 standart for compiling C++ files
     set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")          # Use modern libc++ instead of libstdc++


### PR DESCRIPTION
We used to target 10.8 and bumped up to 11.3 in testing (c546745d01b4d42a5f6d2b5f1ce326dc1c78d5a3). For our CI we use Xcode 13.4.1, which can go back to 10.9. Recent SDL2 versions target 10.11, so we should match that. This adds support for building with Xcode 14.3.

Additionally, the OpenAL-Soft framework we use previously targeted 10.9. This new framework targets 10.11 to match the deployment target for Warfork and SDL2