### PR TITLE
feat: split logic for loading ktx

### DIFF
--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -1508,7 +1508,7 @@ static bool R_LoadKTX( int ctx, image_t *image, const char *pathname )
 
 			R_SetupTexParameters( image->flags, scaledWidth, scaledHeight, image->minmipsize );
 
-			for(size_t i = 0; i < mip; ++i )
+			for( i = 0; i < mip; ++i )
 			{
 				data += sizeof( int ) + numFaces * ( (
 					ALIGN( max( header.pixelWidth >> i, 1 ), 4 ) *

--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -1521,7 +1521,7 @@ static bool R_LoadKTX( int ctx, image_t *image, const char *pathname )
 			{
 				faceSize = ( ( ALIGN( scaledWidth, 4 ) * ALIGN( scaledHeight, 4 ) ) >> 4 ) * 8;
 				data += sizeof( int );
-				for(size_t j = 0; j < numFaces; ++j )
+				for( j = 0; j < numFaces; ++j )
 				{
 					qglCompressedTexImage2DARB( target + j, i, compressedFormat,
 						scaledWidth, scaledHeight, 0, faceSize, data );


### PR DESCRIPTION
I think this is a logical way to split this code the validation logic is specific to r image and I don't want the loading logic to be bound directly to the ktx header. there is only one user so for the moment its fine to make this static and internal to this implementation of r_image. 