### PR TITLE
feat: improvments  to mem.c

### DIFF
--- a/source/qcommon/mem.c
+++ b/source/qcommon/mem.c
@@ -521,7 +521,7 @@ void *__q_realloc( void *ptr, size_t size, const char *sourceFilename, const cha
 		_Mem_Error( "Mem_Free: Request to deallocate RAM that was naver allocated (alloc at %s:%i)", mem->sourceFilename, mem->sourceline );
 	}
 
-	const ptrdiff_t oldPtrDiff = ( mem->reportedAddress - mem->baseAddress ) - CANARY_SIZE;
+	const ptrdiff_t oldPtrDiff = ( (uint8_t*)mem->reportedAddress - (uint8_t*)mem->baseAddress ) - CANARY_SIZE;
 	const size_t realsize = size + ( CANARY_SIZE * 2 ) + mem->alignment;
 	const size_t oldReportedSize = mem->size;
 	void *baseAddress = realloc( mem->baseAddress, realsize );
@@ -530,7 +530,7 @@ void *__q_realloc( void *ptr, size_t size, const char *sourceFilename, const cha
 	if( offset ) {
 		reportedAddress = (uint8_t *)reportedAddress + ( mem->alignment - offset );
 	}
-	const ptrdiff_t newPtrDiff = ( reportedAddress - baseAddress ) - CANARY_SIZE;
+	const ptrdiff_t newPtrDiff = ( (uint8_t*)reportedAddress - (uint8_t*)baseAddress ) - CANARY_SIZE;
 
 	mem->realsize = realsize;
 	mem->reportedAddress = reportedAddress;

--- a/source/qcommon/mem.c
+++ b/source/qcommon/mem.c
@@ -529,6 +529,12 @@ void *__q_realloc( void *ptr, size_t size, const char *sourceFilename, const cha
 		reportedAddress = (uint8_t *)reportedAddress + ( mem->alignment - offset );
 	}
 	const ptrdiff_t newPtrDiff = ( (uint8_t*)reportedAddress - (uint8_t*)baseAddress ) - CANARY_SIZE;
+	if(mem->pool) {
+		mem->pool->realsize -= mem->realsize;
+		mem->pool->totalsize -= mem->size;
+		mem->pool->realsize += realsize;
+		mem->pool->totalsize += size;
+	}
 
 	mem->realsize = realsize;
 	mem->reportedAddress = reportedAddress;

--- a/source/qcommon/mem.c
+++ b/source/qcommon/mem.c
@@ -536,15 +536,16 @@ void *__q_realloc( void *ptr, size_t size, const char *sourceFilename, const cha
 	mem->sourceline = sourceLine;
 	mem->sourceFilename = sourceFilename;
 	mem->functionName = functionName;
+	__validateHeader( mem );
+
 	QMutex_Unlock( memMutex );
 
-	// the offset from the base address is different so we need to adjust the memory to be re-aligned
+	// the offset from the base address is different so we need to adjust the memory to be re-aligned when the memory was allocated
 	if( newPtrDiff != oldPtrDiff ) {
 		memmove( (uint8_t*)reportedAddress - CANARY_SIZE, (uint8_t*)reportedAddress - CANARY_SIZE + ( newPtrDiff - oldPtrDiff ), mem->size + ( CANARY_SIZE * 2 ) );
 	}
 
 	// validate the reported address
-	__validateHeader( reportedAddress );
 	__wipeWithPattern( reportedAddress, size, oldReportedSize, unusedPattern );
 
 	return mem->reportedAddress;

--- a/source/qcommon/mem.c
+++ b/source/qcommon/mem.c
@@ -16,12 +16,43 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
+// ---------------------------------------------------------------------------------------------------------------------------------
+//                                     _
+//                                    | |
+//  _ __ ___  _ __ ___   __ _ _ __    | |___
+// | '_ ` _ \| '_ ` _ \ / _` | '__|   | '_  |
+// | | | | | | | | | | | (_| | |    _ | | | |
+// |_| |_| |_|_| |_| |_|\__, |_|   (_)|_| |_|
+//                       __/ |
+//                      |___/
+//
+// Memory manager & tracking software
+//
+// Best viewed with 8-character tabs and (at least) 132 columns
+//
+// ---------------------------------------------------------------------------------------------------------------------------------
+//
+// Restrictions & freedoms pertaining to usage and redistribution of this software:
+//
+//  * This software is 100% free
+//  * If you use this software (in part or in whole) you must credit the author.
+//  * This software may not be re-distributed (in part or in whole) in a modified
+//    form without clear documentation on how to obtain a copy of the original work.
+//  * You may not use this software to directly or indirectly cause harm to others.
+//  * This software is provided as-is and without warrantee. Use at your own risk.
+//
+// For more information, visit HTTP://www.FluidStudios.com
+//
+// ---------------------------------------------------------------------------------------------------------------------------------
+// Originally created on 12/22/2000 by Paul Nettle
+//
+// Copyright 2000, Fluid Studios, Inc., all rights reserved.
+// ---------------------------------------------------------------------------------------------------------------------------------
+
 */
 // Z_zone.c
 
 #include "qcommon.h"
-
-//#define MEMTRASH
 
 #define POOLNAMESIZE 128
 
@@ -30,10 +61,37 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define MEMALIGNMENT_DEFAULT		16
 
+#define AllocHashSize ( 1u << 12u )
+
+static const unsigned int prefixPattern = 0xbaadf00d;      // Fill pattern for bytes preceeding allocated blocks
+static const unsigned int postfixPattern = 0xdeadc0de;     // Fill pattern for bytes following allocated blocks
+static const unsigned int unusedPattern = 0xfeedface;      // Fill pattern for freshly allocated blocks
+static const unsigned int releasedPattern = 0xdeadbeef;    // Fill pattern for deallocated blocks
+
+
+static bool memory_initialized = false;
+static bool commands_initialized = false;
+
+#if defined( _DEBUG )
+static const bool alwaysWipeAll = true; 
+static const size_t paddingSize = 4;
+#else
+static const size_t paddingSize = 1;
+static const bool alwaysWipeAll = false; 
+#endif
+
+static const size_t canarySize = paddingSize * sizeof(uint32_t);
+
+static const bool randomWipe = false; 
 typedef struct memheader_s
 {
-	// address returned by malloc (may be significantly before this header to satisify alignment)
-	void *baseaddress;
+	// address returned by malloc (may be significantly before this header to satisfy alignment)
+
+	void *baseAddress;
+	void *reportedAddress;
+	
+	struct memheader_s *hnext;
+	struct memheader_s *hprev;
 
 	// next and previous memheaders in chain belonging to pool
 	struct memheader_s *next;
@@ -42,19 +100,14 @@ typedef struct memheader_s
 	// pool this memheader belongs to
 	struct mempool_s *pool;
 
-	// size of the memory after the header (excluding header and sentinel2)
-	size_t size;
-
-	// size of the memory including the header, alignment and sentinel2
-	size_t realsize;
+	size_t size; // size of the memory 
+	size_t offset;
+	size_t alignment;
+	size_t realsize; // size of the memory alignment and sentinel2
 
 	// file name and line where Mem_Alloc was called
 	const char *filename;
 	int fileline;
-
-	// should always be MEMHEADER_SENTINEL1
-	unsigned int sentinel1;
-	// immediately followed by data, which is followed by a MEMHEADER_SENTINEL2 byte
 } memheader_t;
 
 struct mempool_s
@@ -95,10 +148,6 @@ struct mempool_s
 	unsigned int sentinel2;
 };
 
-// ============================================================================
-
-//#define SHOW_NONFREED
-
 cvar_t *developerMemory;
 
 static mempool_t *poolChain = NULL;
@@ -107,14 +156,201 @@ static mempool_t *poolChain = NULL;
 // storage, if anything in this pool stays allocated during gameplay, it is
 // considered a leak
 mempool_t *tempMemPool;
-
 // only for zone
 mempool_t *zoneMemPool;
 
 static qmutex_t *memMutex;
 
-static bool memory_initialized = false;
-static bool commands_initialized = false;
+static struct memheader_s *hashTable[AllocHashSize];
+static struct memheader_s *reservoirHeaders;
+static struct memheader_s **reservoirAllocHeaderBuffer;
+static size_t reservoirIndex = 0;
+
+static struct memheader_s *__GetHeadFromReserved()
+{
+	if(reservoirHeaders == NULL) {
+		reservoirHeaders = malloc( 256 * sizeof( struct memheader_s ) );
+		memset( reservoirHeaders, 0, sizeof( struct memheader_s ) * 256 );
+		for( unsigned int i = 0; i < 256 - 1; i++ ) {
+			reservoirHeaders[i].next = &reservoirHeaders[i + 1];
+		}
+
+		reservoirAllocHeaderBuffer = realloc( reservoirAllocHeaderBuffer, ( reservoirIndex + 1 ) * sizeof( struct memheader_s * ) );
+		reservoirAllocHeaderBuffer[reservoirIndex++] = reservoirHeaders;
+	}
+	struct memheader_s *unit = reservoirHeaders;
+	reservoirHeaders = unit->next;
+	memset( unit, 0, sizeof( struct memheader_s ) );
+
+	return unit;
+}
+
+static void __wipeWithPattern( void *reportedAddress, size_t reportedSize, size_t originalReportedSize, uint32_t pattern )
+{
+	// For a serious test run, we use wipes of random a random value. However, if this causes a crash, we don't want it to
+	// crash in a differnt place each time, so we specifically DO NOT call srand. If, by chance your program calls srand(),
+	// you may wish to disable that when running with a random wipe test. This will make any crashes more consistent so they
+	// can be tracked down easier.
+
+	if( randomWipe ) {
+		pattern = ( ( rand() & 0xff ) << 24 ) | ( ( rand() & 0xff ) << 16 ) | ( ( rand() & 0xff ) << 8 ) | ( rand() & 0xff );
+	}
+
+	// -DOC- We should wipe with 0's if we're not in debug mode, so we can help hide bugs if possible when we release the
+	// product. So uncomment the following line for releases.
+	//
+	// Note that the "alwaysWipeAll" should be turned on for this to have effect, otherwise it won't do much good. But we'll
+	// leave it this way (as an option) because this does slow things down.
+	//	pattern = 0;
+
+	// This part of the operation is optional
+	if( alwaysWipeAll && reportedSize > originalReportedSize ) {
+		// Fill the bulk
+
+		uint32_t *lptr = (uint32_t *)( ( (char *)reportedAddress ) + originalReportedSize );
+		size_t length = reportedSize - originalReportedSize;
+		for( size_t i = 0; i < ( length >> 2 ); i++, lptr++ ) {
+			*lptr = pattern;
+		}
+
+		// Fill the remainder
+
+		unsigned int shiftCount = 0;
+		char *cptr = (char *)( lptr );
+		for( size_t i = 0; i < ( length & 0x3 ); i++, cptr++, shiftCount += 8 ) {
+			*cptr = (char)( ( pattern & ( 0xff << shiftCount ) ) >> shiftCount );
+		}
+	}
+
+	// Write in the prefix/postfix bytes
+
+	// Calculate the correct start addresses for pre and post patterns relative to
+	// allocUnit->reportedAddress, since it may have been offset due to alignment requirements
+	uint8_t *pre = (uint8_t *)reportedAddress - paddingSize * sizeof( uint32_t );
+	uint8_t* post = (uint8_t*)reportedAddress + reportedSize;
+
+	const size_t paddingBytes = paddingSize * sizeof(uint32_t);
+	for (size_t i = 0; i < paddingBytes; i++, pre++, post++)
+	{
+		*pre = (prefixPattern >> ((i % sizeof(uint32_t)) * 8)) & 0xFF;
+		*post = (postfixPattern >> ((i % sizeof(uint32_t)) * 8)) & 0xFF;
+	}
+}
+
+static const char* insertCommas(unsigned int value)
+{
+	static char str[30];
+	memset(str, 0, sizeof(str));
+
+	sprintf(str, "%u", value);
+	if (strlen(str) > 3)
+	{
+		memmove(&str[strlen(str) - 3], &str[strlen(str) - 4], 4);
+		str[strlen(str) - 4] = ',';
+	}
+	if (strlen(str) > 7)
+	{
+		memmove(&str[strlen(str) - 7], &str[strlen(str) - 8], 8);
+		str[strlen(str) - 8] = ',';
+	}
+	if (strlen(str) > 11)
+	{
+		memmove(&str[strlen(str) - 11], &str[strlen(str) - 12], 12);
+		str[strlen(str) - 12] = ',';
+	}
+
+	return str;
+}
+
+
+static const char* __memorySizeString(uint32_t size)
+{
+	static char str[90];
+	if (size > (1024 * 1024))
+		printf(str, "%10s (%7.2fM)", insertCommas(size), ((float)size) / (1024.0f * 1024.0f));
+	else if (size > 1024)
+		sprintf(str, "%10s (%7.2fK)", insertCommas(size), ((float)size) / 1024.0f);
+	else
+		sprintf(str, "%10s bytes     ", insertCommas(size));
+	return str;
+}
+
+static inline size_t resolveUnitHashIndex(const void *reportedAddress ) {
+	return ( ( (size_t)reportedAddress ) >> 4 ) & ( AllocHashSize - 1 );
+}
+
+
+static struct memheader_s *__findMemAllocUnit( const void *reportedAddress )
+{
+	// Just in case...
+	assert( reportedAddress != NULL );
+
+	// Use the address to locate the hash index. Note that we shift off the lower four bits. This is because most allocated
+	// addresses will be on four-, eight- or even sixteen-byte boundaries. If we didn't do this, the hash index would not have
+	// very good coverage.
+
+	const size_t hashIndex = resolveUnitHashIndex(reportedAddress);
+	struct memheader_s *ptr = hashTable[hashIndex];
+	while( ptr ) {
+		if( ptr->reportedAddress == reportedAddress )
+			return ptr;
+		ptr = ptr->hnext;
+	}
+	return NULL;
+}
+
+static void __dumpAllocUnit(const struct memheader_s* allocUnit)
+{
+	Com_Printf("[I] Address (reported): %010p", allocUnit->reportedAddress);
+	Com_Printf("[I] Address (actual)  : %010p", allocUnit->baseAddress);
+	Com_Printf("[I] Size (reported)   : 0x%08X (%s)", (unsigned int)(allocUnit->size),
+		__memorySizeString((unsigned int)(allocUnit->size)));
+	Com_Printf("[I] Size (actual)     : 0x%08X (%s)", (unsigned int)(allocUnit->realsize),
+		__memorySizeString((unsigned int)(allocUnit->size)));
+	Com_Printf("[I] Owner             : %s(%d)", allocUnit->filename, allocUnit->fileline);
+}
+
+bool __validateHeader(const struct memheader_s* header)
+{
+	// Make sure the padding is untouched
+
+	uint8_t* pre = ((uint8_t*)header->reportedAddress - paddingSize * sizeof(uint32_t));
+	uint8_t* post = ((uint8_t*)header->reportedAddress + header->size);
+	bool      errorFlag = false;
+	const size_t paddingBytes = paddingSize * sizeof(uint32_t);
+	for (size_t i = 0; i < paddingBytes; i++, pre++, post++)
+	{
+		const uint8_t expectedPrefixByte = (prefixPattern >> ((i % sizeof(uint32_t)) * 8)) & 0xFF;
+		if (*pre != expectedPrefixByte)
+		{
+			Com_Printf("[!] A memory allocation unit was corrupt because of an underrun:");
+			__dumpAllocUnit(header);
+			errorFlag = true;
+		}
+
+		// If you hit this assert, then you should know that this allocation unit has been damaged. Something (possibly the
+		// owner?) has underrun the allocation unit (modified a few bytes prior to the start). You can interrogate the
+		// variable 'allocUnit' to see statistics and information about this damaged allocation unit.
+		assert(*pre == expectedPrefixByte);
+
+		const uint8_t expectedPostfixByte = (postfixPattern >> ((i % sizeof(uint32_t)) * 8)) & 0xFF;
+		if (*post != expectedPostfixByte)
+		{
+			Com_Printf("[!] A memory allocation unit was corrupt because of an overrun:");
+			__dumpAllocUnit(header);
+			errorFlag = true;
+		}
+
+		// If you hit this assert, then you should know that this allocation unit has been damaged. Something (possibly the
+		// owner?) has overrun the allocation unit (modified a few bytes after the end). You can interrogate the variable
+		// 'allocUnit' to see statistics and information about this damaged allocation unit.
+		assert(*post == expectedPostfixByte);
+	}
+
+	// Return the error status (we invert it, because a return of 'false' means error)
+
+	return !errorFlag;
+}
 
 static void _Mem_Error( const char *format, ... )
 {
@@ -130,16 +366,12 @@ static void _Mem_Error( const char *format, ... )
 
 void *_Mem_AllocExt( mempool_t *pool, size_t size, size_t alignment, int z, int musthave, int canthave, const char *filename, int fileline )
 {
-	void *base;
-	size_t realsize;
-	memheader_t *mem;
 
 	if( size <= 0 )
 		return NULL;
 
 	// default to 16-bytes alignment
-	if( !alignment )
-		alignment = MEMALIGNMENT_DEFAULT;
+	alignment = alignment < sizeof(void*) ? sizeof(void*) : alignment;
 
 	assert( pool != NULL );
 
@@ -156,26 +388,14 @@ void *_Mem_AllocExt( mempool_t *pool, size_t size, size_t alignment, int z, int 
 	QMutex_Lock( memMutex );
 
 	pool->totalsize += size;
-	realsize = sizeof( memheader_t ) + size + alignment + sizeof( int );
 
-	pool->realsize += realsize;
-
-	base = malloc( realsize );
-	if( base == NULL )
+	const size_t realsize = size + ( canarySize * 2 ) + alignment;
+	void *baseAddress = malloc( realsize );
+	void *reportedAddress = ( baseAddress + canarySize );
+	struct memheader_s *mem = __GetHeadFromReserved();
+	
+	if( baseAddress == NULL )
 		_Mem_Error( "Mem_Alloc: out of memory (alloc at %s:%i)", filename, fileline );
-
-	// calculate address that aligns the end of the memheader_t to the specified alignment
-	mem = ( memheader_t * )((((size_t)base + sizeof( memheader_t ) + (alignment-1)) & ~(alignment-1)) - sizeof( memheader_t ));
-	mem->baseaddress = base;
-	mem->filename = filename;
-	mem->fileline = fileline;
-	mem->size = size;
-	mem->realsize = realsize;
-	mem->pool = pool;
-	mem->sentinel1 = MEMHEADER_SENTINEL1;
-
-	// we have to use only a single byte for this sentinel, because it may not be aligned, and some platforms can't use unaligned accesses
-	*( (uint8_t *) mem + sizeof( memheader_t ) + mem->size ) = MEMHEADER_SENTINEL2;
 
 	// append to head of list
 	mem->next = pool->chain;
@@ -184,12 +404,38 @@ void *_Mem_AllocExt( mempool_t *pool, size_t size, size_t alignment, int z, int 
 	if( mem->next )
 		mem->next->prev = mem;
 
+	mem->offset = ( (size_t)reportedAddress ) % alignment;
+	mem->alignment = alignment;
+	if( mem->offset ) {
+		reportedAddress = (uint8_t*)reportedAddress + ( alignment - mem->offset );
+	}
+
+	const size_t hashIndex = resolveUnitHashIndex( reportedAddress );
+	if( hashTable[hashIndex] )
+		hashTable[hashIndex]->hprev = mem;
+	mem->hnext = hashTable[hashIndex];
+	mem->hprev = NULL;
+	hashTable[hashIndex] = mem;
+
+	pool->realsize += realsize;
+	// calculate address that aligns the end of the memheader_t to the specified alignment
+	mem->reportedAddress = reportedAddress; 
+	mem->baseAddress = baseAddress;
+	mem->filename = filename;
+	mem->fileline = fileline;
+	mem->size = size;
+	mem->realsize = realsize;
+	mem->pool = pool;
+
+
 	QMutex_Unlock( memMutex );
 
-	if( z )
-		memset( (void *)( (uint8_t *) mem + sizeof( memheader_t ) ), 0, mem->size );
+	__wipeWithPattern(reportedAddress, size, 0, unusedPattern);
 
-	return (void *)( (uint8_t *) mem + sizeof( memheader_t ) );
+	if( z )
+		memset(reportedAddress, 0, mem->size );
+
+	return reportedAddress; 
 }
 
 void *_Mem_Alloc( mempool_t *pool, size_t size, int musthave, int canthave, const char *filename, int fileline )
@@ -200,8 +446,6 @@ void *_Mem_Alloc( mempool_t *pool, size_t size, int musthave, int canthave, cons
 // FIXME: rewrite this?
 void *_Mem_Realloc( void *data, size_t size, const char *filename, int fileline )
 {
-	void *newdata;
-	memheader_t *mem;
 
 	if( data == NULL )
 		_Mem_Error( "Mem_Realloc: data == NULL (called at %s:%i)", filename, fileline );
@@ -210,14 +454,19 @@ void *_Mem_Realloc( void *data, size_t size, const char *filename, int fileline 
 		Mem_Free( data );
 		return NULL;
 	}
-
-	mem = ( memheader_t * )( (uint8_t *) data - sizeof( memheader_t ) );
+	QMutex_Lock( memMutex );
+	struct memheader_s *mem = __findMemAllocUnit( data );
+	if( mem == NULL ) {
+		assert( false);
+		_Mem_Error( "Mem_Free: Request to deallocate RAM that was naver allocated (alloc at %s:%i)", filename, fileline );
+	}
 	if( size <= mem->size )
 		return data;
 
-	newdata = Mem_AllocExt( mem->pool, size, 0 );
+	void *newdata = Mem_AllocExt( mem->pool, size, 0 );
 	memcpy( newdata, data, mem->size );
 	memset( (uint8_t *)newdata + mem->size, 0, size - mem->size );
+	QMutex_Unlock( memMutex );
 	Mem_Free( data );
 
 	return newdata;
@@ -237,38 +486,26 @@ char *_Mem_CopyString( mempool_t *pool, const char *in, const char *filename, in
 
 void _Mem_Free( void *data, int musthave, int canthave, const char *filename, int fileline )
 {
-	void *base;
-	memheader_t *mem;
-	mempool_t *pool;
-
 	if( data == NULL )
 		//_Mem_Error( "Mem_Free: data == NULL (called at %s:%i)", filename, fileline );
 		return;
 
-	mem = ( memheader_t * )( (uint8_t *) data - sizeof( memheader_t ) );
+	QMutex_Lock( memMutex );
 
-	assert( mem->sentinel1 == MEMHEADER_SENTINEL1 );
-	assert( *( (uint8_t *) mem + sizeof( memheader_t ) + mem->size ) == MEMHEADER_SENTINEL2 );
+	struct memheader_s* mem = __findMemAllocUnit(data);
+	if( mem == NULL ) {
+		assert( false);
+		_Mem_Error( "Mem_Free: Request to deallocate RAM that was never allocated (alloc at %s:%i)", filename, fileline );
+	}
+	__validateHeader(mem);
 
-	if( mem->sentinel1 != MEMHEADER_SENTINEL1 )
-		_Mem_Error( "Mem_Free: trashed header sentinel 1 (alloc at %s:%i, free at %s:%i)", mem->filename, mem->fileline, filename, fileline );
-	if( *( (uint8_t *)mem + sizeof( memheader_t ) + mem->size ) != MEMHEADER_SENTINEL2 )
-		_Mem_Error( "Mem_Free: trashed header sentinel 2 (alloc at %s:%i, free at %s:%i)", mem->filename, mem->fileline, filename, fileline );
-
-	pool = mem->pool;
+	mempool_t *pool = mem->pool;
 	if( musthave && ( ( pool->flags & musthave ) != musthave ) )
 		_Mem_Error( "Mem_Free: bad pool flags (musthave) (alloc at %s:%i)", filename, fileline );
 	if( canthave && ( pool->flags & canthave ) )
 		_Mem_Error( "Mem_Free: bad pool flags (canthave) (alloc at %s:%i)", filename, fileline );
-
 	if( developerMemory && developerMemory->integer )
 		Com_DPrintf( "Mem_Free: pool %s, alloc %s:%i, free %s:%i, size %i bytes\n", pool->name, mem->filename, mem->fileline, filename, fileline, mem->size );
-
-	QMutex_Lock( memMutex );
-
-	// unlink memheader from doubly linked list
-	if( ( mem->prev ? mem->prev->next != mem : pool->chain != mem ) || ( mem->next && mem->next->prev != mem ) )
-		_Mem_Error( "Mem_Free: not allocated or double freed (free at %s:%i)", filename, fileline );
 
 	if( mem->prev )
 		mem->prev->next = mem->next;
@@ -277,19 +514,31 @@ void _Mem_Free( void *data, int musthave, int canthave, const char *filename, in
 	if( mem->next )
 		mem->next->prev = mem->prev;
 
+	size_t hashIndex = resolveUnitHashIndex( data );
+	if( hashTable[hashIndex] == mem ) {
+		hashTable[hashIndex] = mem->hnext;
+	} else {
+		if( mem->hprev )
+			mem->hprev->hnext = mem->hnext;
+		if( mem->hnext )
+			mem->hnext->hprev = mem->hprev;
+	}
+
 	// memheader has been unlinked, do the actual free now
 	pool->totalsize -= mem->size;
-
-	base = mem->baseaddress;
 	pool->realsize -= mem->realsize;
 
+	// wipe with closing pattern
+	__wipeWithPattern(mem->reportedAddress, mem->size, 0, releasedPattern);
+	
+	free(mem->baseAddress);
+	
+	// return the header to the reservoir
+	memset( mem, 0, sizeof( struct memheader_s ) );
+	mem->next = reservoirHeaders;
+	reservoirHeaders = mem;
+
 	QMutex_Unlock( memMutex );
-
-#ifdef MEMTRASH
-	memset( mem, 0xBF, sizeof( memheader_t ) + mem->size + sizeof( int ) );
-#endif
-
-	free( base );
 }
 
 mempool_t *_Mem_AllocPool( mempool_t *parent, const char *name, int flags, const char *filename, int fileline )
@@ -390,15 +639,12 @@ void _Mem_FreePool( mempool_t **pool, int musthave, int canthave, const char *fi
 	if( *chainAddress != *pool )
 		_Mem_Error( "Mem_FreePool: pool already free (freepool at %s:%i)", filename, fileline );
 
-	while( ( *pool )->chain )  // free memory owned by the pool
-		Mem_Free( (void *)( (uint8_t *)( *pool )->chain + sizeof( memheader_t ) ) );
+	while( ( *pool )->chain ) // free memory owned by the pool
+		Mem_Free( ( *pool )->chain->reportedAddress );
 
 	*chainAddress = ( *pool )->next;
 
 	// free the pool itself
-#ifdef MEMTRASH
-	memset( *pool, 0xBF, sizeof( mempool_t ) );
-#endif
 	free( *pool );
 	*pool = NULL;
 }
@@ -456,20 +702,16 @@ size_t Mem_PoolTotalSize( mempool_t *pool )
 
 void _Mem_CheckSentinels( void *data, const char *filename, int fileline )
 {
-	memheader_t *mem;
 
 	if( data == NULL )
 		_Mem_Error( "Mem_CheckSentinels: data == NULL (sentinel check at %s:%i)", filename, fileline );
+	
+	QMutex_Lock( memMutex );
+	struct memheader_s* mem = __findMemAllocUnit(data);
+	
+	QMutex_Unlock( memMutex );
+	__validateHeader(mem);
 
-	mem = (memheader_t *)( (uint8_t *) data - sizeof( memheader_t ) );
-
-	assert( mem->sentinel1 == MEMHEADER_SENTINEL1 );
-	assert( *( (uint8_t *) mem + sizeof( memheader_t ) + mem->size ) == MEMHEADER_SENTINEL2 );
-
-	if( mem->sentinel1 != MEMHEADER_SENTINEL1 )
-		_Mem_Error( "Mem_CheckSentinels: trashed header sentinel 1 (block allocated at %s:%i, sentinel check at %s:%i)", mem->filename, mem->fileline, filename, fileline );
-	if( *( (uint8_t *) mem + sizeof( memheader_t ) + mem->size ) != MEMHEADER_SENTINEL2 )
-		_Mem_Error( "Mem_CheckSentinels: trashed header sentinel 2 (block allocated at %s:%i, sentinel check at %s:%i)", mem->filename, mem->fileline, filename, fileline );
 }
 
 static void _Mem_CheckSentinelsPool( mempool_t *pool, const char *filename, int fileline )
@@ -492,8 +734,9 @@ static void _Mem_CheckSentinelsPool( mempool_t *pool, const char *filename, int 
 	if( pool->sentinel2 != MEMHEADER_SENTINEL1 )
 		_Mem_Error( "_Mem_CheckSentinelsPool: trashed pool sentinel 2 (allocpool at %s:%i, sentinel check at %s:%i)", pool->filename, pool->fileline, filename, fileline );
 
-	for( mem = pool->chain; mem; mem = mem->next )
-		_Mem_CheckSentinels( (void *)( (uint8_t *) mem + sizeof( memheader_t ) ), filename, fileline );
+	for( mem = pool->chain; mem != NULL; mem = mem->next ) {
+		__validateHeader(mem);
+	}
 }
 
 void _Mem_CheckSentinelsGlobal( const char *filename, int fileline )

--- a/source/qcommon/mem.c
+++ b/source/qcommon/mem.c
@@ -99,7 +99,6 @@ typedef struct memheader_s
 
 	// pool this memheader belongs to
 	struct mempool_s *pool;
-	bool temporary;
 
 	size_t size; // size of the memory 
 	size_t alignment;
@@ -311,7 +310,6 @@ static inline void __unlinkPool(struct memheader_s* mem) {
 		mem->pool = NULL;
 		mem->prev = NULL;
 		mem->next = NULL;
-		mem->temporary = false;
 	}
 }
 /**
@@ -563,21 +561,6 @@ void q_link_to_pool(void* ptr, mempool_t* pool) {
 	}
 	__linkPool(mem, pool);
 	QMutex_Unlock( memMutex );
-}
-
-void q_link_to_pool_temporary(void* ptr, mempool_t* pool) {
-	assert(ptr);
-	assert(pool);
-	QMutex_Lock( memMutex );
-	struct memheader_s *mem = __findLinkMemory( ptr );
-	if( mem == NULL ) {
-		assert( false );
-		_Mem_Error( "Mem_Free: Request to deallocate RAM that was naver allocated (alloc at %s:%i)", mem->sourceFilename, mem->sourceline );
-	}
-	mem->temporary  = true;
-	__linkPool(mem, pool);
-	QMutex_Unlock( memMutex );
-
 }
 
 static inline void __poolRemoveChild( struct mempool_s *pool, struct mempool_s *child ) {

--- a/source/qcommon/mem.h
+++ b/source/qcommon/mem.h
@@ -2,6 +2,6 @@
 #define R_MEM_H
 
 void Mem_ValidationAllAllocations();
-
+void Mem_DumpMemoryReport();
 #endif
 

--- a/source/qcommon/mem.h
+++ b/source/qcommon/mem.h
@@ -1,0 +1,7 @@
+#ifndef R_MEM_H
+#define R_MEM_H
+
+void Mem_ValidationAllAllocations();
+
+#endif
+

--- a/source/qcommon/mod_mem.h
+++ b/source/qcommon/mod_mem.h
@@ -1,0 +1,52 @@
+#ifndef R_MEM_MODULE_H
+#define R_MEM_MODULE_H
+
+#include "../gameshared/q_arch.h"
+
+struct mempool_s;
+typedef struct mempool_s mempool_t;
+
+#define DECLARE_TYPEDEF_METHOD( ret, name, ... ) \
+	typedef ret ( *name##Fn )( __VA_ARGS__ );    \
+	ret name( __VA_ARGS__ );
+
+DECLARE_TYPEDEF_METHOD( void *, __Q_Malloc, size_t size, const char *sourceFilename, const char *functionName, int sourceLine );
+DECLARE_TYPEDEF_METHOD( void *, __Q_Realloc, void *ptr, size_t size, const char *sourceFilename, const char *functionName, int sourceLine );
+DECLARE_TYPEDEF_METHOD( void *, __Q_MallocAligned, size_t alignment, size_t size, const char *sourceFilename, const char *functionName, int sourceLine );
+DECLARE_TYPEDEF_METHOD( void, Q_Free, void *ptr );
+
+#define Q_Malloc( size ) __Q_Malloc( size, __FILE__, __FUNCTION__, __LINE__ )
+#define Q_Realloc( ptr, size ) __Q_Realloc( ptr, size, __FILE__, __FUNCTION__, __LINE__ )
+#define Q_MallocAligned( alignment, size ) __Q_MallocAligned( alignment, size, __FILE__, __FUNCTION__, __LINE__ )
+
+DECLARE_TYPEDEF_METHOD( mempool_t *, Q_CreatePool, mempool_t *parent, const char *name );
+DECLARE_TYPEDEF_METHOD( void, Q_LinkToPool, void *ptr, mempool_t *pool );
+DECLARE_TYPEDEF_METHOD( void, Q_FreePool, mempool_t *pool );
+DECLARE_TYPEDEF_METHOD( void, Q_EmptyPool, mempool_t *pool );
+#undef DECLARE_TYPEDEF_METHOD
+
+struct mem_import_s {
+  mempool_t* parent;
+	__Q_MallocFn __Q_Malloc;
+	__Q_ReallocFn __Q_Realloc;
+	__Q_MallocAlignedFn __Q_MallocAligned;
+	Q_FreeFn Q_Free;
+	Q_CreatePoolFn Q_CreatePool;
+	Q_LinkToPoolFn Q_LinkToPool;
+	Q_FreePoolFn Q_FreePool;
+	Q_EmptyPoolFn Q_EmptyPool;
+};
+
+#if MEM_DEFINE_INTERFACE_IMPL
+static struct mem_import_s mem_import;
+void *__Q_Malloc( size_t size, const char *sourceFilename, const char *functionName, int sourceLine ) { return mem_import.__Q_Malloc(size, sourceFilename, functionName, sourceLine); }
+void *__Q_Realloc( void *ptr, size_t size, const char *sourceFilename, const char *functionName, int sourceLine ) { return mem_import.__Q_Realloc(ptr, size, sourceFilename, functionName, sourceLine); }
+void *__Q_MallocAligned( size_t alignment, size_t size, const char *sourceFilename, const char *functionName, int sourceLine ) { return mem_import.__Q_MallocAligned(alignment, size, sourceFilename, functionName, sourceLine); }
+void Q_Free( void *ptr ) { return mem_import.Q_Free(ptr); }
+mempool_t *Q_CreatePool( mempool_t *parent, const char *name ) { return mem_import.Q_CreatePool(parent ? mem_import.parent : parent, name);}
+void Q_LinkToPool( void *ptr, mempool_t *pool ) {return mem_import.Q_LinkToPool(ptr, parent ? mem_import.parent : parent);}
+void Q_FreePool( mempool_t *pool ) {mem_import.Q_FreePool(pool);}
+void Q_EmptyPool( mempool_t *pool ) {mem_import.Q_EmptyPool(pool);}
+#endif
+
+#endif

--- a/source/qcommon/mod_mem.h
+++ b/source/qcommon/mod_mem.h
@@ -43,8 +43,8 @@ void *__Q_Malloc( size_t size, const char *sourceFilename, const char *functionN
 void *__Q_Realloc( void *ptr, size_t size, const char *sourceFilename, const char *functionName, int sourceLine ) { return mem_import.__Q_Realloc(ptr, size, sourceFilename, functionName, sourceLine); }
 void *__Q_MallocAligned( size_t alignment, size_t size, const char *sourceFilename, const char *functionName, int sourceLine ) { return mem_import.__Q_MallocAligned(alignment, size, sourceFilename, functionName, sourceLine); }
 void Q_Free( void *ptr ) { return mem_import.Q_Free(ptr); }
-mempool_t *Q_CreatePool( mempool_t *parent, const char *name ) { return mem_import.Q_CreatePool(parent ? mem_import.parent : parent, name);}
-void Q_LinkToPool( void *ptr, mempool_t *pool ) {return mem_import.Q_LinkToPool(ptr, parent ? mem_import.parent : parent);}
+mempool_t *Q_CreatePool( mempool_t *parent, const char *name ) { return mem_import.Q_CreatePool(parent ? parent : mem_import.parent , name);}
+void Q_LinkToPool( void *ptr, mempool_t *pool ) {return mem_import.Q_LinkToPool(ptr, parent ? parent : mem_import.parent);}
 void Q_FreePool( mempool_t *pool ) {mem_import.Q_FreePool(pool);}
 void Q_EmptyPool( mempool_t *pool ) {mem_import.Q_EmptyPool(pool);}
 #endif

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -790,9 +790,27 @@ void Memory_Shutdown( void );
 void Memory_ShutdownCommands( void );
 
 void *__q_malloc(size_t size, const char* sourceFilename, const char* functionName, int sourceLine);
-void *__q_realloc(void* ptr, size_t size);
-void *__q_all(void* ptr, size_t size);
-void __q_free(void* ptr);
+void *__q_realloc(void* ptr, size_t size, const char* sourceFilename, const char* functionName, int sourceLine);
+void *__q_malloc_aligned( size_t alignment, size_t size, const char* sourceFilename, const char* functionName, int sourceLine);
+void q_free(void* ptr);
+
+#define q_malloc( size ) __q_malloc(size, __FILE__, __FUNCTION__, __LINE__ )
+#define q_realloc( ptr, size) __q_realloc( ptr, size, __FILE__, __FUNCTION__, __LINE__ )
+#define q_malloc_aligned( alignment, size ) __q_malloc_aligned( alignment, size, __FILE__, __FUNCTION__, __LINE__ )
+
+/**
+ * memory can only be linked to one pool so linking an already linked allocation will unlink the memory from the last pool
+ **/
+mempool_t* q_create_pool(mempool_t* parent, const char* name);
+void q_link_to_pool(void* ptr, mempool_t* pool);
+void q_free_pool(mempool_t* pool);
+void q_empty_pool(mempool_t* pool);
+/**;
+ * unlink the memory from the pool
+ **/
+void q_unlink_from_pool(void* ptr);
+
+
 
 void *_Mem_AllocExt( mempool_t *pool, size_t size, size_t aligment, int z, int musthave, int canthave, const char *filename, int fileline );
 void *_Mem_Alloc( mempool_t *pool, size_t size, int musthave, int canthave, const char *filename, int fileline );

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -789,27 +789,6 @@ void Memory_InitCommands( void );
 void Memory_Shutdown( void );
 void Memory_ShutdownCommands( void );
 
-void *__q_malloc(size_t size, const char* sourceFilename, const char* functionName, int sourceLine);
-void *__q_realloc(void* ptr, size_t size, const char* sourceFilename, const char* functionName, int sourceLine);
-void *__q_malloc_aligned( size_t alignment, size_t size, const char* sourceFilename, const char* functionName, int sourceLine);
-void q_free(void* ptr);
-
-#define q_malloc( size ) __q_malloc(size, __FILE__, __FUNCTION__, __LINE__ )
-#define q_realloc( ptr, size) __q_realloc( ptr, size, __FILE__, __FUNCTION__, __LINE__ )
-#define q_malloc_aligned( alignment, size ) __q_malloc_aligned( alignment, size, __FILE__, __FUNCTION__, __LINE__ )
-
-/**
- * memory can only be linked to one pool so linking an already linked allocation will unlink the memory from the last pool
- **/
-mempool_t* q_create_pool(mempool_t* parent, const char* name);
-void q_link_to_pool(void* ptr, mempool_t* pool);
-void q_free_pool(mempool_t* pool);
-void q_empty_pool(mempool_t* pool);
-/**
- * unlink the memory from the pool
- **/
-void q_unlink_from_pool(void* ptr);
-
 void *_Mem_AllocExt( mempool_t *pool, size_t size, size_t aligment, int z, int musthave, int canthave, const char *filename, int fileline );
 void *_Mem_Alloc( mempool_t *pool, size_t size, int musthave, int canthave, const char *filename, int fileline );
 void *_Mem_Realloc( void *data, size_t size, const char *filename, int fileline );

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -804,7 +804,6 @@ void _Mem_FreePool( mempool_t **pool, int musthave, int canthave, const char *fi
 void _Mem_EmptyPool( mempool_t *pool, int musthave, int canthave, const char *filename, int fileline );
 char *_Mem_CopyString( mempool_t *pool, const char *in, const char *filename, int fileline );
 
-void _Mem_CheckSentinels( void *data, const char *filename, int fileline );
 void _Mem_CheckSentinelsGlobal( const char *filename, int fileline );
 
 size_t Mem_PoolTotalSize( mempool_t *pool );
@@ -819,7 +818,6 @@ size_t Mem_PoolTotalSize( mempool_t *pool );
 #define Mem_EmptyPool( pool ) _Mem_EmptyPool( pool, 0, 0, __FILE__, __LINE__ )
 #define Mem_CopyString( pool, str ) _Mem_CopyString( pool, str, __FILE__, __LINE__ )
 
-#define Mem_CheckSentinels( data ) _Mem_CheckSentinels( data, __FILE__, __LINE__ )
 #define Mem_CheckSentinelsGlobal() _Mem_CheckSentinelsGlobal( __FILE__, __LINE__ )
 #ifdef NDEBUG
 #define Mem_DebugCheckSentinelsGlobal()

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -789,6 +789,11 @@ void Memory_InitCommands( void );
 void Memory_Shutdown( void );
 void Memory_ShutdownCommands( void );
 
+void *__q_malloc(size_t size, const char* sourceFilename, const char* functionName, int sourceLine);
+void *__q_realloc(void* ptr, size_t size);
+void *__q_all(void* ptr, size_t size);
+void __q_free(void* ptr);
+
 void *_Mem_AllocExt( mempool_t *pool, size_t size, size_t aligment, int z, int musthave, int canthave, const char *filename, int fileline );
 void *_Mem_Alloc( mempool_t *pool, size_t size, int musthave, int canthave, const char *filename, int fileline );
 void *_Mem_Realloc( void *data, size_t size, const char *filename, int fileline );

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -803,7 +803,6 @@ void q_free(void* ptr);
  **/
 mempool_t* q_create_pool(mempool_t* parent, const char* name);
 void q_link_to_pool(void* ptr, mempool_t* pool);
-void q_link_to_pool_temporary(void* ptr, mempool_t* pool);
 void q_free_pool(mempool_t* pool);
 void q_empty_pool(mempool_t* pool);
 /**

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -803,14 +803,13 @@ void q_free(void* ptr);
  **/
 mempool_t* q_create_pool(mempool_t* parent, const char* name);
 void q_link_to_pool(void* ptr, mempool_t* pool);
+void q_link_to_pool_temporary(void* ptr, mempool_t* pool);
 void q_free_pool(mempool_t* pool);
 void q_empty_pool(mempool_t* pool);
-/**;
+/**
  * unlink the memory from the pool
  **/
 void q_unlink_from_pool(void* ptr);
-
-
 
 void *_Mem_AllocExt( mempool_t *pool, size_t size, size_t aligment, int z, int musthave, int canthave, const char *filename, int fileline );
 void *_Mem_Alloc( mempool_t *pool, size_t size, int musthave, int canthave, const char *filename, int fileline );


### PR DESCRIPTION
I wanted to play around with fluid studios memory manager. 

there are a couple benefits:
- the padding can be extended so it should avoid a case where a write skips 1 bytes over the canary. If the end of the address is written past the canary then it won't trigger the check the extra padding in debug can catch some of these problems.
- The header is separate from this address space so an underun shouldn't corrupt the header. 
the padding can be extended so if you over run the padding by more then a byte then the canary is not detectable. 

This is just enough to get this to work I want to drop the temporary flag from the pool and just have a general malloc/realloc that doesn't depend on a pool. 