### PR TITLE
feat: remove Q_malloc, Q_realloc, Q_free

### DIFF
--- a/source/client/console.c
+++ b/source/client/console.c
@@ -190,7 +190,7 @@ void Con_Clear_f( void )
 
 	for( i = 0; i < CON_MAXLINES; i++ )
 	{
-		Q_free( con.text[i] );
+		free( con.text[i] );
 		con.text[i] = NULL;
 	}
 	con.numlines = 0;
@@ -476,7 +476,7 @@ static void Con_Linefeed( bool notify )
 {
 	// shift scrollback text up in the buffer to make room for a new line
 	if (con.numlines == con.totallines )
-		Q_free( con.text[con.numlines - 1] );
+		free( con.text[con.numlines - 1] );
 	memmove( con.text + 1, con.text, sizeof( con.text[0] ) * min( con.numlines, con.totallines - 1 ) );
 	con.text[0] = NULL;
 
@@ -514,7 +514,7 @@ static void addcharstostr( char **s, const char *c, size_t num ) {
 		num--;
 	}
 
-	newstr = Q_realloc( *s, len + addlen + 1 );
+	newstr = realloc( *s, len + addlen + 1 );
 	memcpy( newstr + len, c, addlen );
 	newstr[len + addlen] = '\0';
 	*s = newstr;

--- a/source/qcommon/common.c
+++ b/source/qcommon/common.c
@@ -635,6 +635,7 @@ void Com_FreePureList( purelist_t **purelist )
 	*purelist = NULL;
 }
 
+//============================================================================
 
 void Key_Init( void );
 void Key_Shutdown( void );
@@ -671,44 +672,6 @@ static void Com_Lag_f( void )
 	Com_Printf( "Lagged %i milliseconds\n", msecs );
 }
 #endif
-
-/*
-* Q_malloc
-* 
-* Just like malloc(), but die if allocation fails
-*/
-void *Q_malloc( size_t size )
-{
-	void *buf = malloc( size );
-
-	if( !buf )
-		Sys_Error( "Q_malloc: failed on allocation of %i bytes.\n", size );
-
-	return buf;
-}
-
-/*
-* Q_realloc
-* 
-* Just like realloc(), but die if reallocation fails
-*/
-void *Q_realloc( void *buf, size_t newsize )
-{
-	void *newbuf = realloc( buf, newsize );
-
-	if( !newbuf && newsize )
-		Sys_Error( "Q_realloc: failed on allocation of %i bytes.\n", newsize );
-
-	return newbuf;
-}
-
-/*
-* Q_free
-*/
-void Q_free( void *buf )
-{
-	free( buf );
-}
 
 /*
 * Qcommon_InitCommands

--- a/source/qcommon/library.c
+++ b/source/qcommon/library.c
@@ -87,13 +87,11 @@ void *Com_LoadLibraryExt( const char *name, dllfunc_t *funcs, bool sys )
 */
 void *Com_LoadSysLibrary( const char *name, dllfunc_t *funcs )
 {
-	char *names;
-	size_t names_size;
 	char *s, *saveptr;
 	void *lib = NULL;
 
-	names_size = strlen( name ) + 1;
-	names = Q_malloc( names_size );
+	const size_t names_size = strlen( name ) + 1;
+	char* const names = malloc( names_size );
 	memcpy( names, name, names_size );
 
 	s = strtok_r( names, "|", &saveptr );

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -898,9 +898,6 @@ extern mempool_t *zoneMemPool;
 #define Mem_TempMalloc( size ) Mem_Alloc( tempMemPool, size )
 #define Mem_TempFree( data ) Mem_Free( data )
 
-void *Q_malloc( size_t size );
-void *Q_realloc( void *buf, size_t newsize );
-void Q_free( void *buf );
 void Qcommon_InitCvarDescriptions( void );
 
 void Qcommon_Init( int argc, char **argv );

--- a/source/sdl/sdl_threads.c
+++ b/source/sdl/sdl_threads.c
@@ -39,10 +39,19 @@ struct qcondvar_s {
 */
 int Sys_Mutex_Create( qmutex_t **pmutex )
 {
-	qmutex_t *mutex;
+	if(!pmutex) 
+		return -1;
 
-	mutex = (qmutex_t *)Q_malloc(sizeof(*mutex));
+	qmutex_t *mutex = (qmutex_t *)malloc(sizeof(*mutex));
+	
+	if(!mutex) 
+		return -1;
+	
 	mutex->m = SDL_CreateMutex();
+	if(!mutex->m) {
+		free(mutex);
+		return -1;
+	}
 
 	*pmutex = mutex;
 	return 0;
@@ -58,7 +67,7 @@ void Sys_Mutex_Destroy( qmutex_t *mutex )
 	}
 
 	SDL_DestroyMutex(mutex->m);
-	Q_free(mutex);
+	free(mutex);
 }
 
 /*
@@ -82,10 +91,19 @@ void Sys_Mutex_Unlock( qmutex_t *mutex )
 */
 int Sys_Thread_Create( qthread_t **pthread, void *(*routine) (void*), void *param )
 {
-	qthread_t *thread;
+	if(!pthread) 
+		return -1;
+	
+	qthread_t *thread = (qthread_t *)malloc( sizeof( *thread ) );
+	if( !thread ) 
+		return -1;
+	
 
-	thread = (qthread_t *)Q_malloc(sizeof(*thread));
-	thread->t = SDL_CreateThread((SDL_ThreadFunction)routine, NULL, param);
+	thread->t = SDL_CreateThread( (SDL_ThreadFunction)routine, NULL, param );
+	if( !thread->t ) {
+		free(thread);
+		return -1;
+	}
 
 	*pthread = thread;
 	return 0;
@@ -133,16 +151,16 @@ bool Sys_Atomic_CAS( volatile int *value, int oldval, int newval, qmutex_t *mute
 */
 int Sys_CondVar_Create( qcondvar_t **pcond )
 {
-	qcondvar_t *cond;
-
-	if( !pcond ) {
+	if( !pcond )
 		return -1;
-	}
+	
 
-	cond = ( qcondvar_t * )Q_malloc( sizeof( *cond ) );
+	qcondvar_t *const cond = (qcondvar_t *)malloc( sizeof( *cond ) );
+	if(!cond)
+		return -1;
 	cond->c = SDL_CreateCond();
 	if( !cond->c ) {
-		Q_free( cond );
+		free( cond );
 		return -1;
 	}
 
@@ -160,7 +178,7 @@ void Sys_CondVar_Destroy( qcondvar_t *cond )
 	}
 
 	SDL_DestroyCond( cond->c );
-	Q_free( cond );
+	free( cond );
 }
 
 /*

--- a/source/unix/unix_clipboard.c
+++ b/source/unix/unix_clipboard.c
@@ -16,7 +16,7 @@ char *Sys_GetClipboardData( bool primary )
 	int format, ret;
 	unsigned long nitems, bytes_after, bytes_left;
 	unsigned char *data;
-	char *buffer;
+	char *buffer = NULL;
 	Atom atom;
 
 	if( !x11display.dpy )
@@ -49,12 +49,8 @@ char *Sys_GetClipboardData( bool primary )
 		&format, &nitems, &bytes_after, &data );
 	if( ret == Success )
 	{
-		buffer = Q_malloc( bytes_left + 1 );
+		buffer = malloc( bytes_left + 1 );
 		memcpy( buffer, data, bytes_left + 1 );
-	}
-	else
-	{
-		buffer = NULL;
 	}
 
 	XFree( data );
@@ -73,9 +69,10 @@ char *Sys_GetClipboardData( bool primary )
 bool Sys_SetClipboardData( const char *data )
 {
 	// Save the message
-	Q_free( clip_data );
-	clip_data = Q_malloc( strlen( data ) - 1 );
-	memcpy( clip_data, data, strlen( data ) - 1 );
+	const size_t clip_len = strlen(data);
+	clip_data = realloc(clip_data, clip_len + 1 );
+	memcpy( clip_data, data, strlen( data ) );
+	clip_data[clip_len] = '\0';
 	
 	// Requesting clipboard ownership
 	Atom XA_CLIPBOARD = XInternAtom( x11display.dpy, "CLIPBOARD", True );
@@ -96,5 +93,5 @@ bool Sys_SetClipboardData( const char *data )
 */
 void Sys_FreeClipboardData( char *data )
 {
-	Q_free( data );
+	free( data );
 }

--- a/source/win32/win_clipboard.c
+++ b/source/win32/win_clipboard.c
@@ -19,7 +19,7 @@ char *Sys_GetClipboardData( bool primary )
 			if( ( cliptext = GlobalLock( hClipboardData ) ) != 0 )
 			{
 				utf8size = WideCharToMultiByte( CP_UTF8, 0, cliptext, -1, NULL, 0, NULL, NULL );
-				utf8text = Q_malloc( utf8size );
+				utf8text = malloc( utf8size );
 				WideCharToMultiByte( CP_UTF8, 0, cliptext, -1, utf8text, utf8size, NULL, NULL );
 				GlobalUnlock( hClipboardData );
 			}
@@ -79,5 +79,5 @@ bool Sys_SetClipboardData( const char *data )
 */
 void Sys_FreeClipboardData( char *data )
 {
-	Q_free( data );
+	free( data );
 }

--- a/source/win32/win_input.c
+++ b/source/win32/win_input.c
@@ -1298,7 +1298,7 @@ void IN_WinIME_Shutdown( void )
 
 	if( in_winime_candList )
 	{
-		Q_free( in_winime_candList );
+		free( in_winime_candList );
 		in_winime_candList = NULL;
 		in_winime_candListSize = 0;
 	}
@@ -1443,7 +1443,7 @@ unsigned int IN_IME_GetCandidates( char * const *cands, size_t candSize, unsigne
 
 	if( candListSize > in_winime_candListSize )
 	{
-		candList = Q_realloc( candList, candListSize );
+		candList = realloc( candList, candListSize );
 		if( !candList )
 			return 0;
 		in_winime_candList = candList;

--- a/source/win32/win_sys.c
+++ b/source/win32/win_sys.c
@@ -256,9 +256,7 @@ const char *Sys_GetPreferredLanguage( void )
 	}
 
 	if( hr ) {
-		WCHAR *pwszLanguagesBuffer;
-		
-		pwszLanguagesBuffer = Q_malloc( sizeof( WCHAR ) * cchLanguagesBuffer );
+		WCHAR *pwszLanguagesBuffer = malloc( sizeof( WCHAR ) * cchLanguagesBuffer );
 		hr = GetUserPreferredUILanguages_f( MUI_LANGUAGE_NAME, &numLanguages, pwszLanguagesBuffer, &cchLanguagesBuffer );
 
 		if( hr ) {
@@ -271,7 +269,7 @@ const char *Sys_GetPreferredLanguage( void )
 			if( p ) { *p = '_'; }
 		}
 
-		Q_free( pwszLanguagesBuffer );	
+		free( pwszLanguagesBuffer );	
 	}
 
 	FreeLibrary( kernel32Dll );

--- a/source/win32/win_threads.c
+++ b/source/win32/win_threads.c
@@ -146,17 +146,20 @@ void Sys_Mutex_Unlock( qmutex_t *mutex )
 */
 int Sys_Thread_Create( qthread_t **pthread, void *(*routine) (void*), void *param )
 {
-	qthread_t *thread;
 	unsigned threadID;
-	HANDLE h;
 	
-	h = (HANDLE)_beginthreadex( NULL, 0, (unsigned (WINAPI *) (void *))routine, param, 0, &threadID );
+	qthread_t *thread = ( qthread_t * )malloc( sizeof( *thread ) );
+	if(!thread) {
+		return -1;
+	}
+
+	HANDLE h = (HANDLE)_beginthreadex( NULL, 0, (unsigned (WINAPI *) (void *))routine, param, 0, &threadID );
 
 	if( h == NULL ) {
+		free(thread);
 		return GetLastError();
 	}
 
-	thread = ( qthread_t * )malloc( sizeof( *thread ) );
 	thread->h = h;
 	*pthread = thread;
 	return 0;
@@ -203,14 +206,16 @@ bool Sys_Atomic_CAS( volatile int *value, int oldval, int newval, qmutex_t *mute
 */
 int Sys_CondVar_Create( qcondvar_t **pcond )
 {
-	qcondvar_t *cond;
 	HANDLE *e = NULL;
 
 	if( !pcond ) {
 		return -1;
 	}
 
-	cond = ( qcondvar_t * )malloc( sizeof( *cond ) );
+	qcondvar_t *cond = ( qcondvar_t * )malloc( sizeof( *cond ) );
+	if(!cond) {
+		return -1;
+	}
 
 	if( pInitializeConditionVariable ) {
 		pInitializeConditionVariable( &( cond->c ) );

--- a/source/win32/win_threads.c
+++ b/source/win32/win_threads.c
@@ -49,9 +49,7 @@ struct qmutex_s {
 */
 int Sys_Mutex_Create( qmutex_t **pmutex )
 {
-	qmutex_t *mutex;
-
-	mutex = ( qmutex_t * )Q_malloc( sizeof( *mutex ) );
+	qmutex_t *mutex = ( qmutex_t * )malloc( sizeof( *mutex ) );
 	if( !mutex ) {
 		return -1;
 	}
@@ -70,7 +68,7 @@ void Sys_Mutex_Destroy( qmutex_t *mutex )
 		return;
 	}
 	DeleteCriticalSection( &mutex->h );
-	Q_free( mutex );
+	free( mutex );
 }
 
 /*
@@ -105,7 +103,7 @@ int Sys_Mutex_Create( qmutex_t **pmutex )
 		return GetLastError();
 	}
 	
-	mutex = ( qmutex_t * )Q_malloc( sizeof( *mutex ) );
+	mutex = ( qmutex_t * )malloc( sizeof( *mutex ) );
 	if( !mutex ) {
 		return -1;
 	}
@@ -123,7 +121,7 @@ void Sys_Mutex_Destroy( qmutex_t *mutex )
 		return;
 	}
 	CloseHandle( mutex->h );
-	Q_free( mutex );
+	free( mutex );
 }
 
 /*
@@ -158,7 +156,7 @@ int Sys_Thread_Create( qthread_t **pthread, void *(*routine) (void*), void *para
 		return GetLastError();
 	}
 
-	thread = ( qthread_t * )Q_malloc( sizeof( *thread ) );
+	thread = ( qthread_t * )malloc( sizeof( *thread ) );
 	thread->h = h;
 	*pthread = thread;
 	return 0;
@@ -212,7 +210,7 @@ int Sys_CondVar_Create( qcondvar_t **pcond )
 		return -1;
 	}
 
-	cond = ( qcondvar_t * )Q_malloc( sizeof( *cond ) );
+	cond = ( qcondvar_t * )malloc( sizeof( *cond ) );
 
 	if( pInitializeConditionVariable ) {
 		pInitializeConditionVariable( &( cond->c ) );
@@ -221,7 +219,7 @@ int Sys_CondVar_Create( qcondvar_t **pcond )
 		// If some day Qfusion needs broadcast, a waiter counter should be added.
 		e = CreateEvent( NULL, FALSE, FALSE, NULL );
 		if( !e ) {
-			Q_free( cond );
+			free( cond );
 			return GetLastError();
 		}
 	}
@@ -245,7 +243,7 @@ void Sys_CondVar_Destroy( qcondvar_t *cond )
 		CloseHandle( cond->e );
 	}
 
-	Q_free( cond );
+	free( cond );
 }
 
 /*


### PR DESCRIPTION
I don't think there is a really good reason to have these. I think it would be useful to replace malloc, realloc, and free. would like to come back with some custom allocator at some point.  I would like to bring these methods back at some point: https://github.com/TeamForbiddenLLC/warfork-qfusion/pull/296/files