### PR TITLE
feat: handle when image is truncated

### DIFF
--- a/source/ref_base/r_ktx_loader.h
+++ b/source/ref_base/r_ktx_loader.h
@@ -13,6 +13,7 @@ enum ktx_context_result_type_e {
   KTX_ERR_INVALID_IDENTIFIER,
   KTX_ERR_UNHANDLED_TEXTURE_TYPE,
   KTX_ERR_TRUNCATED,
+  KTX_WARN_MIPLEVEL_TRUNCATED, 
   KTX_ERR_ZER_TEXTURE_SIZE 
 };
 
@@ -27,6 +28,12 @@ struct ktx_context_err_s {
 			size_t size;
 			size_t expected;
 		} errTruncated;
+		struct {
+			uint_fast8_t expectedMipLevels;
+			uint_fast8_t mipLevels; 
+			size_t size;
+			size_t expected;
+		} mipTruncated;
 	};
 };
 

--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -1311,19 +1311,23 @@ static bool R_LoadKTX( int ctx, image_t *image, const char *pathname )
 	if( !R_InitKTXContext( &ktxContext, buffer, bufferSize, &err ) ) {
 		switch(err.type) {
 			case KTX_ERR_INVALID_IDENTIFIER:
-				ri.Com_Printf( S_COLOR_YELLOW "R_LoadKTX: Bad file identifier: %s\n", pathname );
-				break;
+				ri.Com_Printf( S_COLOR_RED "R_LoadKTX: Bad file identifier: %s\n", pathname );
+				goto error;
 			case KTX_ERR_UNHANDLED_TEXTURE_TYPE:
-				ri.Com_Printf( S_COLOR_YELLOW "R_LoadKTX: Unhandeled texture (type: %04x internalFormat %04x): %s\n", err.errTextureType.type, err.errTextureType.internalFormat, pathname );
-				break;
+				ri.Com_Printf( S_COLOR_RED "R_LoadKTX: Unhandeled texture (type: %04x internalFormat %04x): %s\n", err.errTextureType.type, err.errTextureType.internalFormat, pathname );
+				goto error;
 			case KTX_ERR_TRUNCATED:
-				ri.Com_Printf( S_COLOR_YELLOW "R_LoadKTX: Truncated Data (size: %lu expected: %lu): %s\n", err.errTruncated.size, err.errTruncated.expected, pathname );
+				ri.Com_Printf( S_COLOR_RED "R_LoadKTX: Truncated Data size:(orignal: %lu expected: %lu): %s\n", err.errTruncated.size, err.errTruncated.expected, pathname );
+				goto error;
+			case KTX_WARN_MIPLEVEL_TRUNCATED:
+				ri.Com_Printf( S_COLOR_YELLOW "R_LoadKTX: Truncated MipLevel size: (orignal: %lu expected: %lu) mip: (orignal: %lu expected: %lu): %s\n", err.errTruncated.size, err.errTruncated.expected,
+							   err.mipTruncated.mipLevels, err.mipTruncated.expectedMipLevels, pathname );
 				break;
 			case KTX_ERR_ZER_TEXTURE_SIZE:
-				ri.Com_Printf( S_COLOR_YELLOW "R_LoadKTX: Zero texture size: %s\n", pathname );
+				ri.Com_Printf( S_COLOR_RED "R_LoadKTX: Zero texture size: %s\n", pathname );
+				goto error;
 				break;
 		}
-		goto error;
 	}
 
 	if( ktxContext.format && ( ktxContext.format != ktxContext.baseInternalFormat ) )


### PR DESCRIPTION
truncated mip map levels will just emit a warning. 