### PR TITLE
feat: friendly_callvote_ui

### DIFF
--- a/assets/data0_21pure/ui/porkui/callvotes.rml
+++ b/assets/data0_21pure/ui/porkui/callvotes.rml
@@ -235,33 +235,26 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 </head>
 <body template="porkui_ingame" onload="$onCallvotesLoad" onshow="$onCallvotesShow" onhide="$onCallvotesHide">
 	<div id="menu-ingame">
-		<div id="menu-header">Votes</div>
+		<div id="menu-header">Callvote</div>
 
 		<div id="menu-commands">
-			<form id="callvotes_form_start" onsubmit="$onCallvoteStartSubmit">			
-				<div id="callvotes-container">
+			<form id="callvotes_form_start" onsubmit="$onCallvoteStartSubmit">
+				<div id="callvotes_container">
 					<div id="callvotes_left_frame">
 						<datagrid id="callvotes_datagrid" source="" onrowselect="$onCallvotesRowSelect">
-							<col fields="name" width="150dp">Name</col>
+							<col fields="name">Name</col>
 						</datagrid>
 					</div>
-					<div id="callvotes_spacer_frame" >&nbsp;</div>
 					<div id="callvotes_right_frame">
-						<div id="callvotes_options_frame">
-							<div id="callvote_picker_frame">
-								<input id="callvote_name" type="text" style="display: none;" name="name" />
-								<input id="callvote_numargs" type="text" style="display: none;" name="numargs" />
-								<select id="callvote_yesno"><option value="0">no</option><option value="1" selected>yes</option></select>
-								<dataselect id="callvote_options" fields="name" valuefield="value" formatter="colorcode" />
-								<input id="callvote_text" type="text" />
-							<br/>
-							<span id="callvote_help" />
-							</div>
-						</div>
+						<input id="callvote_name" type="text" name="name" />
+						<input id="callvote_numargs" type="text" name="numargs" />
+						<select id="callvote_yesno"><option value="0">no</option><option value="1" selected>yes</option></select>
+						<dataselect id="callvote_options" fields="name" valuefield="value" formatter="colorcode" />
+						<input id="callvote_text" type="text" />
+						<br/> <div id="callvote_help" />
 					</div>
-					<br/>
-					<input id="callvote_btn_start" type="submit">Call a vote</input>
-				</div>			
+				</div>
+				<br/> <input id="callvote_btn_start" type="submit"> Call a vote </input>
 			</form>
 
 			<span id="callvote_ongoing_text"></span>

--- a/assets/data0_21pure/ui/porkui/credits.rml
+++ b/assets/data0_21pure/ui/porkui/credits.rml
@@ -69,6 +69,7 @@
                         <br/> Pandaptable
                         <br/> paril
                         <br/> Victor "Vic" Luchits
+                        <br/> Rees "TheFatCheetah"
                         <br/><br/>
                         <h3 class="intro">Logo & Cover Art</h3>
                         Jstock12

--- a/assets/data0_21pure/ui/porkui/css/callvotes.rcss
+++ b/assets/data0_21pure/ui/porkui/css/callvotes.rcss
@@ -1,31 +1,57 @@
-#callvotes_left_frame { overflow-y: auto; width: 150dp; height: 160dp; float: left; }
+#callvotes_container {
+    height: 240dp;
+    text-align: left;
+    overflow: auto;
+    margin: 0 auto;
+    box-sizing: border-box;
+}
 
-#callvotes_datagrid datagridheader { font-size: 14dp; text-align: left; }
-#callvotes_datagrid datagridrow { font-size: 14dp; text-align: left; }
+#callvotes_left_frame, #callvotes_right_frame {
+    display: inline-block;
+    min-height: 100%;
+    width: 50%;
+    box-sizing: border-box;
+    overflow: auto;
+    vertical-align: top;
+}
+
+datagridcolumn { width: 100%; }
+
+#callvotes_datagrid { 
+    height: 100%;
+    overflow: auto;
+}
+
+option { min-height: 1.8em; }
+
+select, dataselect { 
+    width: 100%;
+    display: inline-block;
+    height: 1.8em;
+    padding: 2dp 4dp;
+    overflow: hidden;
+}
+
+select selectbox, dataselect selectbox {
+    max-height: 205dp;
+    overflow-y: auto;
+}
+
 #callvotes_datagrid datagridrow:hover { background: #3f3c49; }
 #callvotes_datagrid datagridrow:selected  { background: #3f3c49; }
 #callvotes_datagrid datagridcolumn:hover { background: #3f3c49; }
-
-#callvotes_spacer_frame { width: 12dp; height: 160dp; float: left; }
-
-#callvotes_right_frame { height: 160dp; font-size: 14dp; text-align: left; }
-#callvotes_options_frame { }
-
-#callvote_picker_frame { height: 100dp; }
-#callvote_options { display: none; }
-#callvote_options selectvalue { height: 18dp; overflow-x: hidden; }
-
-#callvote_yesno { display: none; }
-
-#callvote_text { display: none; margin-bottom: 8dp; }
-
-#callvote_help { display: inline-block; width: 170dp; }
+#callvote_options selectvalue {  overflow-x: hidden; }
 
 #callvote_active { position: relative; height: 40dp; }
-
+#callvote_yesno selectbox { overflow-y: hidden; }
 #callvotes_frame_f1f2 { width: 60%; margin: 0 auto; }
 #callvotes_form_f1f2 input.submit { display: inline-block; max-width: 40%; margin-left: 0dp; margin-right: 0dp; position: relative; }
 #callvote_btn_f1 { float: left; left: -8dp; }
 #callvote_btn_f2 { float: right; left: 8dp; }
 
-#callvote_yesno selectbox { overflow-y: hidden; }
+#callvote_name { display: none; }
+#callvote_numargs { display: none; }
+#callvote_yesno { display: none; }
+#callvote_options { display: none; }
+#callvote_text { display: none; margin-bottom: 8dp; }
+#callvote_help { padding: 0 4dp; } 


### PR DESCRIPTION
Adjusted the call-vote UI to hold a bit more context and allow the dropdown menu to be expanded to better view the selection items. Some overrides in the rcss have had to be made due to defaults being set in places like control.rcss that limit the size of the ui elements. Limited myself from adjusting styling outside of the scope of the callvote UI.

built and tested on linux x86 - 'warfork.x86_64'

existing
![old_640](https://github.com/TeamForbiddenLLC/warfork-qfusion/assets/77629798/90df1c03-60d6-4dce-8543-0c50ec52f51f)
![old_1080](https://github.com/TeamForbiddenLLC/warfork-qfusion/assets/77629798/8492d698-d2d8-42d0-94a2-cabe3311670b)

<br> 

new
![new_640](https://github.com/TeamForbiddenLLC/warfork-qfusion/assets/77629798/c94b6c94-4fb3-48c5-9903-901da877edc6)
![new_1080](https://github.com/TeamForbiddenLLC/warfork-qfusion/assets/77629798/67fa82f5-e7c1-41b6-bb29-22754df9cc2b)
