### PR TITLE
bugfix: resolve images failing to load with dots in the filename

### DIFF
--- a/source/qcommon/mod_fs.h
+++ b/source/qcommon/mod_fs.h
@@ -76,6 +76,7 @@ DECLARE_TYPEDEF_METHOD( time_t, FS_FileMTime, const char *filename );
 DECLARE_TYPEDEF_METHOD( time_t, FS_BaseFileMTime, const char *filename );
 
 // // only for game files
+DECLARE_TYPEDEF_METHOD( const char *, FS_FirstExtension2, const char *filename, const char *extensions[], int num_extensions );
 DECLARE_TYPEDEF_METHOD( const char *, FS_FirstExtension, const char *filename, const char *extensions[], int num_extensions );
 DECLARE_TYPEDEF_METHOD( const char *, FS_PakNameForFile, const char *filename );
 DECLARE_TYPEDEF_METHOD( bool, FS_IsPureFile, const char *pakname );
@@ -144,6 +145,7 @@ struct fs_import_s {
 	FS_PakFileExistsFn FS_PakFileExists;
 	FS_FileMTimeFn FS_FileMTime;
 	FS_BaseFileMTimeFn FS_BaseFileMTime;
+	FS_FirstExtension2Fn FS_FirstExtension2;
 	FS_FirstExtensionFn FS_FirstExtension;
 	FS_PakNameForFileFn FS_PakNameForFile;
 	FS_IsPureFileFn FS_IsPureFile;
@@ -221,6 +223,7 @@ bool FS_CheckPakExtension(const char *filename ){ return fs_import.FS_CheckPakEx
 bool FS_PakFileExists(const char *packfilename ){ return fs_import.FS_PakFileExists(packfilename);}
 time_t FS_FileMTime(const char *filename ){ return fs_import.FS_FileMTime(filename);}
 time_t FS_BaseFileMTime(const char *filename ){ return fs_import.FS_BaseFileMTime(filename);}
+const char * FS_FirstExtension2(const char *filename, const char *extensions[], int num_extensions ){ return fs_import.FS_FirstExtension2(filename, extensions, num_extensions);}
 const char * FS_FirstExtension(const char *filename, const char *extensions[], int num_extensions ){ return fs_import.FS_FirstExtension(filename, extensions, num_extensions);}
 const char * FS_PakNameForFile(const char *filename ){ return fs_import.FS_PakNameForFile(filename);}
 bool FS_IsPureFile(const char *pakname ){ return fs_import.FS_IsPureFile(pakname);}

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -747,6 +747,7 @@ static const struct fs_import_s default_fs_imports_s = {
 	.FS_PakFileExists = FS_PakFileExists,
 	.FS_FileMTime = FS_FileMTime,
 	.FS_BaseFileMTime = FS_BaseFileMTime,
+	.FS_FirstExtension2 = FS_FirstExtension2,
 	.FS_FirstExtension = FS_FirstExtension,
 	.FS_PakNameForFile = FS_PakNameForFile,
 	.FS_IsPureFile = FS_IsPureFile,

--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -1519,7 +1519,7 @@ static bool R_LoadImageFromDisk( int ctx, image_t *image )
 			{
 				sdssubstr(pathname, 0, baseLen);
 				pathname = sdscatfmt( pathname, "_%s", cubemapSides[i][j].suf );
-				const char* extension = FS_FirstExtension( pathname, IMAGE_EXTENSIONS, NUM_IMAGE_EXTENSIONS - 1 ); // last is KTX
+				const char* extension = FS_FirstExtension2( pathname, IMAGE_EXTENSIONS, NUM_IMAGE_EXTENSIONS - 1 ); // last is KTX
 				
 				if(extension != NULL) {
 					lastExtension = extension;
@@ -1594,7 +1594,7 @@ static bool R_LoadImageFromDisk( int ctx, image_t *image )
 	{
 		struct texture_buf_s pic = {0};
 		sdssubstr(pathname, 0, baseLen);
-		const char* extension = FS_FirstExtension( pathname, IMAGE_EXTENSIONS, NUM_IMAGE_EXTENSIONS - 1 ); // last is KTX
+		const char* extension = FS_FirstExtension2( pathname, IMAGE_EXTENSIONS, NUM_IMAGE_EXTENSIONS - 1 ); // last is KTX
 		if(extension != NULL) {
 			pathname = sdscat(pathname, extension);
 		}
@@ -1615,7 +1615,7 @@ static bool R_LoadImageFromDisk( int ctx, image_t *image )
 		}
 		else
 		{
-			ri.Com_DPrintf( S_COLOR_YELLOW "Missing image: %s\n", image->name );
+			ri.Com_Printf( S_COLOR_YELLOW "Missing image: %s\n", image->name );
 		}
 	}
 


### PR DESCRIPTION
looks like paths that follow this: jumppad1b.blend.tga were getting truncated by FS_FirstExtension we already truncate the extension so I introduced a 2 version of this method because I'm not sure how this would impact other code. same logic just doesn't try and truncate the path. 