### PR TITLE
feat: remove bgra flag and handling for images

### DIFF
--- a/source/ref_gl/r_glimp.h
+++ b/source/ref_gl/r_glimp.h
@@ -154,7 +154,6 @@ typedef struct
 	unsigned int  depth_texture: 1;
 	unsigned int  vertex_shader: 1;
 	unsigned int  shading_language_130: 1;
-	unsigned int  bgra: 1;
 	unsigned int  gamma_control: 1;
 	unsigned int  swap_control: 1;
 	unsigned int  draw_instanced: 1;

--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -865,9 +865,9 @@ static void R_TextureFormat( int flags, int samples, int *comp, int *format, int
 	{
 		*type = GL_UNSIGNED_BYTE;
 		if( samples == 4 )
-			*format = ( flags & IT_BGRA ? GL_BGRA_EXT : GL_RGBA );
+			*format = GL_RGBA;
 		else if( samples == 3 )
-			*format = ( flags & IT_BGRA ? GL_BGR_EXT : GL_RGB );
+			*format = GL_RGB;
 		else if( samples == 2 )
 			*format = GL_LUMINANCE_ALPHA;
 		else if( flags & IT_ALPHAMASK )
@@ -1414,10 +1414,9 @@ static bool R_LoadKTX( int ctx, image_t *image, const char *pathname )
 		  for( size_t faceIdx = 0; faceIdx < numFaces; ++faceIdx ) {
 		  	struct texture_buf_s *tex = R_KTXResolveBuffer( &ktxContext, 0, faceIdx, 0 );
 				decompressed[faceIdx] = R_PrepareImageBuffer( ctx, TEXTURE_LOADING_BUF0 + faceIdx, ALIGN( tex->width * 3, 4 ) * tex->height);
-				DecompressETC1( tex->buffer, tex->width, tex->height, decompressed[faceIdx], glConfig.ext.bgra ? true : false );
+				DecompressETC1( tex->buffer, tex->width, tex->height, decompressed[faceIdx], false);
 		  }
-		  R_UploadMipmapped( ctx, decompressed, R_KTXWidth( &ktxContext ), R_KTXHeight( &ktxContext ), 1, image->flags, image->minmipsize, &image->upload_width, &image->upload_height,
-		  				   glConfig.ext.bgra ? GL_BGR_EXT : GL_RGB, GL_UNSIGNED_BYTE );
+		  R_UploadMipmapped( ctx, decompressed, R_KTXWidth( &ktxContext ), R_KTXHeight( &ktxContext ), 1, image->flags, image->minmipsize, &image->upload_width, &image->upload_height, GL_RGB, GL_UNSIGNED_BYTE );
 		}
 
 		image->samples = 3;
@@ -1430,7 +1429,6 @@ static bool R_LoadKTX( int ctx, image_t *image, const char *pathname )
 				RT_ExpectChannelsMatch( definition, expectBGR, Q_ARRAY_COUNT( expectBGR ) ) || 
 				RT_ExpectChannelsMatch( definition, expectBGRA, Q_ARRAY_COUNT( expectBGRA ) ); 
 		image->flags |= (
-			(isBGRTexture  ? IT_BGRA : 0 ) |
 			(RT_ExpectChannelsMatch( definition, expectA, Q_ARRAY_COUNT( expectA ) ) ? IT_ALPHAMASK : 0));
 		image->samples = RT_NumberChannels(definition);
 		const uint16_t numberOfMipLevels = ( image->flags & IT_NOMIPMAP ) ? 1 : R_KTXGetNumberMips(&ktxContext);
@@ -1441,7 +1439,7 @@ static bool R_LoadKTX( int ctx, image_t *image, const char *pathname )
 		for( uint16_t mipIndex = 0; mipIndex < numberOfMipLevels; mipIndex++ ) {
 			for( uint32_t faceIndex = 0; faceIndex < numberOfFaces; faceIndex++ ) {
 				struct texture_buf_s *texBuffer = R_KTXResolveBuffer( &ktxContext, mipIndex, faceIndex, 0 );
-				if( !glConfig.ext.bgra && isBGRTexture ) {
+				if( isBGRTexture ) {
 					const size_t numberChannels = RT_NumberChannels( definition );
 					assert( numberChannels >= 3 && numberChannels <= Q_ARRAY_COUNT( swizzleChannel ) );
 					memcpy( swizzleChannel, RT_Channels( definition ), numberChannels );

--- a/source/ref_gl/r_image.h
+++ b/source/ref_gl/r_image.h
@@ -39,13 +39,12 @@ enum
 	,IT_DEPTHRB			= 1<<12		// framebuffer has a depth renderbuffer
 	,IT_NOFILTERING		= 1<<13
 	,IT_ALPHAMASK		= 1<<14		// image only contains an alpha mask
-	,IT_BGRA			= 1<<15
-	,IT_SYNC			= 1<<16		// load image synchronously
-	,IT_DEPTHCOMPARE	= 1<<17
-	,IT_ARRAY			= 1<<18
-	,IT_3D				= 1<<19
-	,IT_STENCIL			= 1<<20		// for IT_DEPTH or IT_DEPTHRB textures, whether there's stencil
-	,IT_NO_DATA_SYNC	= 1<<21		// owned by the drawing thread, do not sync in the frontend thread
+	,IT_SYNC			= 1<<15		// load image synchronously
+	,IT_DEPTHCOMPARE	= 1<<16
+	,IT_ARRAY			= 1<<17
+	,IT_3D				= 1<<18
+	,IT_STENCIL			= 1<<19		// for IT_DEPTH or IT_DEPTHRB textures, whether there's stencil
+	,IT_NO_DATA_SYNC	= 1<<20		// owned by the drawing thread, do not sync in the frontend thread
 };
 
 /**
@@ -54,7 +53,7 @@ enum
  * The loader threads may modify these flags (but no other flags),
  * so they must not be used for anything that has a long-term effect.
  */
-#define IT_LOADFLAGS		( IT_ALPHAMASK|IT_BGRA|IT_SYNC )
+#define IT_LOADFLAGS		( IT_ALPHAMASK|IT_SYNC )
 
 #define IT_SPECIAL			( IT_CLAMP|IT_NOMIPMAP|IT_NOPICMIP|IT_NOCOMPRESS )
 #define IT_SKYFLAGS			( IT_SKY|IT_NOMIPMAP|IT_CLAMP|IT_SYNC )

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -513,7 +513,6 @@ static bool R_RegisterGLExtensions( void )
 		glConfig.ext.texture_array = 1;
 	}
 
-	glConfig.ext.bgra = 1;
 	glConfig.ext.texture_filter_anisotropic = 1;
 	glConfig.ext.meminfo = 1;
 	glConfig.ext.gpu_memory_info = 1;


### PR DESCRIPTION
there isn't any system restricted reason why bgra would ever be false. better to just default to RGB/RGBA. 