### PR TITLE
feat: fix heartbeat and added guard when writing to pipe

### DIFF
--- a/source/steamshim/src/parent/parent.cpp
+++ b/source/steamshim/src/parent/parent.cpp
@@ -21,6 +21,7 @@ freely, subject to the following restrictions:
 #include <cstdint>
 #include <cstring>
 #include <stdio.h>
+#include <thread>
 #define DEBUGPIPE 1
 #include "parent.h"
 #include "../steamshim.h"
@@ -137,6 +138,13 @@ static bool setEnvironmentVars(PipeType pipeChildRead, PipeType pipeChildWrite)
     return true;
 } 
 
+static void taskHeartbeat(){
+    while (true) {
+        Write1ByteMessage(SHIMCMD_PUMP);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
+}
+
 extern "C" {
   int STEAMSHIM_init(SteamshimOptions *options)
   {
@@ -191,6 +199,10 @@ extern "C" {
     closePipe(pipeChildWrite);
 
     pipeChildRead = pipeChildWrite = NULLPIPE;
+
+
+    std::thread task(taskHeartbeat);
+    task.detach();
 
 #ifndef _WIN32
       signal(SIGPIPE, SIG_IGN);

--- a/source/steamshim/src/parent/parent.cpp
+++ b/source/steamshim/src/parent/parent.cpp
@@ -28,6 +28,7 @@ freely, subject to the following restrictions:
 #include "../os.h"
 #include "../steamshim_types.h"
 
+
 int GArgc = 0;
 char **GArgv = NULL;
 

--- a/source/steamshim/src/pipe.cpp
+++ b/source/steamshim/src/pipe.cpp
@@ -25,9 +25,11 @@ freely, subject to the following restrictions:
 #include "os.h"
 #include "steamshim_types.h"
 #include "steamshim_private.h"
+#include <mutex>
 
 PipeType GPipeRead = NULLPIPE;
 PipeType GPipeWrite = NULLPIPE;
+std::mutex writeGuard;
 
 void PipeBuffer::WriteData(const void* val, size_t vallen)
 {
@@ -105,9 +107,11 @@ PipeBuffer::PipeBuffer(){
 
 int PipeBuffer::Transmit()
 {
-
-  writePipe(GPipeWrite, &cursor, sizeof cursor);
-  return writePipe(GPipeWrite, buffer, cursor);
+  writeGuard.lock();
+  writePipe( GPipeWrite, &cursor, sizeof cursor );
+  const int result = writePipe( GPipeWrite, buffer, cursor );
+  writeGuard.unlock();
+  return result;
 }
 
 int PipeBuffer::Recieve()


### PR DESCRIPTION
the writes to the pipe are atomic but if you have 
```
thread 1 AA           A     A
thread 2       B            B
```

so the buffer sent over the pipe is getting corrupted by the heartbeat thread. i just add a mutex to grantee mutual exclusion when writing to the pipe. 