### PR TITLE
Fixed building on Linux/aarch64

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -167,7 +167,12 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR MINGW)
 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -Wall -Wno-unused-function -fvisibility=hidden -Winvalid-pch")
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -D_DEBUG")
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fno-strict-aliasing -ffast-math -funroll-loops -msse2 -O2")
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+        set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fno-strict-aliasing -ffast-math -funroll-loops -O2")
+    else()
+        set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fno-strict-aliasing -ffast-math -funroll-loops -msse2 -O2")
+    endif()
+    
 
     if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11")

--- a/source/gameshared/q_arch.h
+++ b/source/gameshared/q_arch.h
@@ -237,6 +237,9 @@ typedef UINT_PTR socket_handle_t;
 #elif defined ( __alpha__ )
 #define ARCH "axp"
 #define CPUSTRING "axp"
+#elif defined ( __aarch64__ )
+#define ARCH "aarch64"
+#define CPUSTRING "aarch64"
 #elif defined ( __arm__ )
 #if defined ( __ANDROID__ )
 #define ARCH "android_armeabi-v7a"

--- a/source/gameshared/q_shared.h
+++ b/source/gameshared/q_shared.h
@@ -30,7 +30,7 @@ extern "C" {
 //==============================================
 
 #if !defined ( ENDIAN_LITTLE ) && !defined ( ENDIAN_BIG )
-#if defined ( __i386__ ) || defined ( __ia64__ ) || defined ( WIN32 ) || ( defined ( __alpha__ ) || defined ( __alpha ) ) || defined ( __arm__ ) || ( defined ( __mips__ ) && defined ( __MIPSEL__ ) ) || defined ( __LITTLE_ENDIAN__ ) || defined ( __x86_64__ )
+#if defined ( __i386__ ) || defined ( __ia64__ ) || defined ( WIN32 ) || ( defined ( __alpha__ ) || defined ( __alpha ) ) || defined ( __arm__ ) || defined ( __aarch64__ ) || ( defined ( __mips__ ) && defined ( __MIPSEL__ ) ) || defined ( __LITTLE_ENDIAN__ ) || defined ( __x86_64__ )
 #define ENDIAN_LITTLE
 #else
 #define ENDIAN_BIG

--- a/third-party/angelscript/sdk/angelscript/projects/cmake/CMakeLists.txt
+++ b/third-party/angelscript/sdk/angelscript/projects/cmake/CMakeLists.txt
@@ -167,6 +167,10 @@ if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" AND UNIX AND NOT APPLE)
     target_compile_options(${ANGELSCRIPT_LIBRARY_NAME} PRIVATE -fPIC)
 endif()
 
+if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64" AND UNIX AND NOT APPLE)
+    target_compile_options(${ANGELSCRIPT_LIBRARY_NAME} PRIVATE -fPIC)
+endif()
+
 # Don't override the default library output path to avoid conflicts when building for multiple target platforms
 #set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/../../lib)
 target_link_libraries(${ANGELSCRIPT_LIBRARY_NAME} Threads::Threads)


### PR DESCRIPTION
I've recently tried building Warfork for aarch64 just for fun, but maybe these changes will be useful for upstream too. Changes to CMakeLists are kinda dirty (I have no experience with CMake and C/C++, and it's my first request pull for something not related to pet projects, heh), but they don't break x86_64 builds