### PR TITLE
feat: remove indirection myhalf variants

### DIFF
--- a/assets/data0_21pure/glsl/defaultCelshade.frag.glsl
+++ b/assets/data0_21pure/glsl/defaultCelshade.frag.glsl
@@ -31,66 +31,66 @@ uniform samplerCube u_CelLightTexture;
 
 void main(void)
 {
-	myhalf4 inColor = myhalf4(qf_FrontColor);
+	vec4 inColor = vec4(qf_FrontColor);
 
-	myhalf4 tempColor;
+	vec4 tempColor;
 
-	myhalf4 outColor;
-	outColor = myhalf4(qf_texture(u_BaseTexture, v_TexCoord));
+	vec4 outColor;
+	outColor = vec4(qf_texture(u_BaseTexture, v_TexCoord));
 #ifdef QF_ALPHATEST
 	QF_ALPHATEST(outColor.a * inColor.a);
 #endif
 
 #ifdef APPLY_ENTITY_DECAL
 #ifdef APPLY_ENTITY_DECAL_ADD
-	outColor.rgb += myhalf3(u_EntityColor.rgb) * myhalf3(qf_texture(u_EntityDecalTexture, v_TexCoord));
+	outColor.rgb += vec3(u_EntityColor.rgb) * vec3(qf_texture(u_EntityDecalTexture, v_TexCoord));
 #else
-	tempColor = myhalf4(u_EntityColor.rgb, 1.0) * myhalf4(qf_texture(u_EntityDecalTexture, v_TexCoord));
+	tempColor = vec4(u_EntityColor.rgb, 1.0) * vec4(qf_texture(u_EntityDecalTexture, v_TexCoord));
 	outColor.rgb = mix(outColor.rgb, tempColor.rgb, tempColor.a);
 #endif
 #endif // APPLY_ENTITY_DECAL
 
 #ifdef APPLY_DIFFUSE
-	outColor.rgb *= myhalf3(qf_texture(u_DiffuseTexture, v_TexCoord));
+	outColor.rgb *= vec3(qf_texture(u_DiffuseTexture, v_TexCoord));
 #endif
 
-	outColor.rgb *= myhalf3(qf_textureCube(u_CelShadeTexture, v_TexCoordCube));
+	outColor.rgb *= vec3(qf_textureCube(u_CelShadeTexture, v_TexCoordCube));
 
 #ifdef APPLY_STRIPES
 #ifdef APPLY_STRIPES_ADD
-	outColor.rgb += myhalf3(u_EntityColor.rgb) * myhalf3(qf_texture(u_StripesTexture, v_TexCoord));
+	outColor.rgb += vec3(u_EntityColor.rgb) * vec3(qf_texture(u_StripesTexture, v_TexCoord));
 #else
-	tempColor = myhalf4(u_EntityColor.rgb, 1.0) * myhalf4(qf_texture(u_StripesTexture, v_TexCoord));
+	tempColor = vec4(u_EntityColor.rgb, 1.0) * vec4(qf_texture(u_StripesTexture, v_TexCoord));
 	outColor.rgb = mix(outColor.rgb, tempColor.rgb, tempColor.a);
 #endif
 #endif // APPLY_STRIPES_ADD
 
 #ifdef APPLY_CEL_LIGHT
 #ifdef APPLY_CEL_LIGHT_ADD
-	outColor.rgb += myhalf3(qf_textureCube(u_CelLightTexture, v_TexCoordCube));
+	outColor.rgb += vec3(qf_textureCube(u_CelLightTexture, v_TexCoordCube));
 #else
-	tempColor = myhalf4(qf_textureCube(u_CelLightTexture, v_TexCoordCube));
+	tempColor = vec4(qf_textureCube(u_CelLightTexture, v_TexCoordCube));
 	outColor.rgb = mix(outColor.rgb, tempColor.rgb, tempColor.a);
 #endif
 #endif // APPLY_CEL_LIGHT
 
 #ifdef APPLY_DECAL
 #ifdef APPLY_DECAL_ADD
-	outColor.rgb += myhalf3(qf_texture(u_DecalTexture, v_TexCoord));
+	outColor.rgb += vec3(qf_texture(u_DecalTexture, v_TexCoord));
 #else
-	tempColor = myhalf4(qf_texture(u_DecalTexture, v_TexCoord));
+	tempColor = vec4(qf_texture(u_DecalTexture, v_TexCoord));
 	outColor.rgb = mix(outColor.rgb, tempColor.rgb, tempColor.a);
 #endif
 #endif // APPLY_DECAL
 
-	outColor = myhalf4(inColor * outColor);
+	outColor = vec4(inColor * outColor);
 
 #ifdef APPLY_GREYSCALE
 	outColor.rgb = Greyscale(outColor.rgb);
 #endif
 
 #if defined(APPLY_FOG) && !defined(APPLY_FOG_COLOR)
-	myhalf fogDensity = FogDensity(v_FogCoord);
+	float fogDensity = FogDensity(v_FogCoord);
 	outColor.rgb = mix(outColor.rgb, u_FogColor, fogDensity);
 #endif
 

--- a/assets/data0_21pure/glsl/defaultCelshade.vert.glsl
+++ b/assets/data0_21pure/glsl/defaultCelshade.vert.glsl
@@ -18,11 +18,11 @@ void main(void)
 	vec4 Position = a_Position;
 	vec3 Normal = a_Normal.xyz;
 	vec2 TexCoord = a_TexCoord;
-	myhalf4 inColor = myhalf4(a_Color);
+	vec4 inColor = vec4(a_Color);
 
 	QF_TransformVerts(Position, Normal, TexCoord);
 
-	myhalf4 outColor = VertexRGBGen(Position, Normal, inColor);
+	vec4 outColor = VertexRGBGen(Position, Normal, inColor);
 
 #ifdef APPLY_FOG
 #ifdef APPLY_FOG_COLOR

--- a/assets/data0_21pure/glsl/defaultDistortion.frag.glsl
+++ b/assets/data0_21pure/glsl/defaultDistortion.frag.glsl
@@ -20,7 +20,7 @@ uniform sampler2D u_RefractionTexture;
 
 void main(void)
 {
-	myhalf3 color;
+	vec3 color;
 
 #ifdef APPLY_DUDV
 	vec3 displacement = vec3(qf_texture(u_DuDvMapTexture, vec2(v_TexCoord.pq) * vec2(0.25)));
@@ -39,14 +39,14 @@ void main(void)
 	projCoord.s = float (clamp (float(projCoord.s), inv2NW, 1.0 - inv2NW));
 	projCoord.t = float (clamp (float(projCoord.t), inv2NH, 1.0 - inv2NH));
 
-	myhalf3 refr = myhalf3(0.0);
-	myhalf3 refl = myhalf3(0.0);
+	vec3 refr = vec3(0.0);
+	vec3 refl = vec3(0.0);
 
 #ifdef APPLY_EYEDOT
 	// calculate dot product between the surface normal and eye vector
 	// great for simulating qf_varying water translucency based on the view angle
-	myhalf3 surfaceNormal = normalize(myhalf3(qf_texture(u_NormalmapTexture, coord)) - myhalf3 (0.5));
-	vec3 eyeNormal = normalize(myhalf3(v_EyeVector));
+	vec3 surfaceNormal = normalize(vec3(qf_texture(u_NormalmapTexture, coord)) - vec3 (0.5));
+	vec3 eyeNormal = normalize(vec3(v_EyeVector));
 
 	float refrdot = float(dot(surfaceNormal, eyeNormal));
 	//refrdot = float (clamp (refrdot, 0.0, 1.0));
@@ -54,28 +54,28 @@ void main(void)
 	// get refraction and reflection
 
 #ifdef APPLY_REFRACTION
-	refr = (myhalf3(qf_texture(u_RefractionTexture, projCoord))) * refrdot;
+	refr = (vec3(qf_texture(u_RefractionTexture, projCoord))) * refrdot;
 #endif
 #ifdef APPLY_REFLECTION
-	refl = (myhalf3(qf_texture(u_ReflectionTexture, projCoord))) * refldot;
+	refl = (vec3(qf_texture(u_ReflectionTexture, projCoord))) * refldot;
 #endif
 
 #else
 
 #ifdef APPLY_REFRACTION
-	refr = (myhalf3(qf_texture(u_RefractionTexture, projCoord)));
+	refr = (vec3(qf_texture(u_RefractionTexture, projCoord)));
 #endif
 #ifdef APPLY_REFLECTION
-	refl = (myhalf3(qf_texture(u_ReflectionTexture, projCoord)));
+	refl = (vec3(qf_texture(u_ReflectionTexture, projCoord)));
 #endif
 
 #endif // APPLY_EYEDOT
 
 	// add reflection and refraction
 #ifdef APPLY_DISTORTION_ALPHA
-	color = myhalf3(qf_FrontColor.rgb) + myhalf3(mix (refr, refl, myhalf(qf_FrontColor.a)));
+	color = vec3(qf_FrontColor.rgb) + vec3(mix (refr, refl, float(qf_FrontColor.a)));
 #else
-	color = myhalf3(qf_FrontColor.rgb) + refr + refl;
+	color = vec3(qf_FrontColor.rgb) + refr + refl;
 #endif
 
 #ifdef APPLY_GREYSCALE

--- a/assets/data0_21pure/glsl/defaultDistortion.vert.glsl
+++ b/assets/data0_21pure/glsl/defaultDistortion.vert.glsl
@@ -20,7 +20,7 @@ void main(void)
 	vec2 TexCoord = a_TexCoord;
 	vec3 Tangent = a_SVector.xyz;
 	float TangentDir = a_SVector.w;
-	myhalf4 inColor = myhalf4(a_Color);
+	vec4 inColor = vec4(a_Color);
 
 	QF_TransformVerts(Position, Normal, TexCoord);
 

--- a/assets/data0_21pure/glsl/defaultMaterial.frag.glsl
+++ b/assets/data0_21pure/glsl/defaultMaterial.frag.glsl
@@ -26,11 +26,11 @@ uniform float u_OffsetMappingScale;
 #endif
 
 #ifdef APPLY_DRAWFLAT
-uniform myhalf3 u_WallColor;
-uniform myhalf3 u_FloorColor;
+uniform vec3 u_WallColor;
+uniform vec3 u_FloorColor;
 #endif
 
-uniform myhalf2 u_GlossFactors; // gloss scaling and exponent factors
+uniform vec2 u_GlossFactors; // gloss scaling and exponent factors
 
 
 void main()
@@ -43,20 +43,20 @@ void main()
 #define v_TexCoord v_TexCoord_FogCoord.st
 #endif
 
-	myhalf3 surfaceNormal;
-	myhalf3 surfaceNormalModelspace;
-	myhalf3 weightedDiffuseNormalModelspace;
+	vec3 surfaceNormal;
+	vec3 surfaceNormalModelspace;
+	vec3 weightedDiffuseNormalModelspace;
 
 #if !defined(APPLY_DIRECTIONAL_LIGHT) && !defined(NUM_LIGHTMAPS)
-	myhalf4 color = myhalf4 (1.0, 1.0, 1.0, 1.0);
+	vec4 color = vec4 (1.0, 1.0, 1.0, 1.0);
 #else
-	myhalf4 color = myhalf4 (0.0, 0.0, 0.0, 1.0);
+	vec4 color = vec4 (0.0, 0.0, 0.0, 1.0);
 #endif
 
-	myhalf4 decal = myhalf4 (0.0, 0.0, 0.0, 1.0);
+	vec4 decal = vec4 (0.0, 0.0, 0.0, 1.0);
 
 	// get the surface normal
-	surfaceNormal = normalize(myhalf3(qf_texture (u_NormalmapTexture, v_TexCoord)) - myhalf3 (0.5));
+	surfaceNormal = normalize(vec3(qf_texture (u_NormalmapTexture, v_TexCoord)) - vec3 (0.5));
 	surfaceNormalModelspace = normalize(v_StrMatrix * surfaceNormal);
 
 #ifdef APPLY_DIRECTIONAL_LIGHT
@@ -74,34 +74,34 @@ void main()
 #ifdef APPLY_SPECULAR
 
 #ifdef NORMALIZE_DIFFUSE_NORMAL
-	myhalf3 specularNormal = normalize (myhalf3 (normalize (weightedDiffuseNormalModelspace)) + myhalf3 (normalize (u_EntityDist - v_Position)));
+	vec3 specularNormal = normalize (vec3 (normalize (weightedDiffuseNormalModelspace)) + vec3 (normalize (u_EntityDist - v_Position)));
 #else
-	myhalf3 specularNormal = normalize (weightedDiffuseNormalModelspace + myhalf3 (normalize (u_EntityDist - v_Position)));
+	vec3 specularNormal = normalize (weightedDiffuseNormalModelspace + vec3 (normalize (u_EntityDist - v_Position)));
 #endif
 
-	myhalf specularProduct = myhalf(dot (surfaceNormalModelspace, specularNormal));
-	color.rgb += (myhalf3(qf_texture(u_GlossTexture, v_TexCoord)) * u_GlossFactors.x) * pow(myhalf(max(specularProduct, 0.0)), u_GlossFactors.y);
+	float specularProduct = float(dot (surfaceNormalModelspace, specularNormal));
+	color.rgb += (vec3(qf_texture(u_GlossTexture, v_TexCoord)) * u_GlossFactors.x) * pow(float(max(specularProduct, 0.0)), u_GlossFactors.y);
 #endif // APPLY_SPECULAR
 
 #if defined(APPLY_BASETEX_ALPHA_ONLY) && !defined(APPLY_DRAWFLAT)
-	color = min(color, myhalf4(qf_texture(u_BaseTexture, v_TexCoord).a));
+	color = min(color, vec4(qf_texture(u_BaseTexture, v_TexCoord).a));
 #else
-	myhalf4 diffuse;
+	vec4 diffuse;
 
 #ifdef APPLY_DRAWFLAT
-	myhalf n = myhalf(step(DRAWFLAT_NORMAL_STEP, abs(v_StrMatrix[2].z)));
-	diffuse = myhalf4(mix(u_WallColor, u_FloorColor, n), myhalf(qf_texture(u_BaseTexture, v_TexCoord).a));
+	float n = float(step(DRAWFLAT_NORMAL_STEP, abs(v_StrMatrix[2].z)));
+	diffuse = vec4(mix(u_WallColor, u_FloorColor, n), float(qf_texture(u_BaseTexture, v_TexCoord).a));
 #else
-	diffuse = myhalf4(qf_texture(u_BaseTexture, v_TexCoord));
+	diffuse = vec4(qf_texture(u_BaseTexture, v_TexCoord));
 #endif
 
 #ifdef APPLY_ENTITY_DECAL
 
 #ifdef APPLY_ENTITY_DECAL_ADD
-	decal.rgb = myhalf3(qf_texture(u_EntityDecalTexture, v_TexCoord));
+	decal.rgb = vec3(qf_texture(u_EntityDecalTexture, v_TexCoord));
 	diffuse.rgb += u_EntityColor.rgb * decal.rgb;
 #else
-	decal = myhalf4(u_EntityColor.rgb, 1.0) * myhalf4(qf_texture(u_EntityDecalTexture, v_TexCoord));
+	decal = vec4(u_EntityColor.rgb, 1.0) * vec4(qf_texture(u_EntityDecalTexture, v_TexCoord));
 	diffuse.rgb = mix(diffuse.rgb, decal.rgb, decal.a);
 #endif // APPLY_ENTITY_DECAL_ADD
 
@@ -113,22 +113,22 @@ void main()
 #ifdef APPLY_DECAL
 
 #ifdef APPLY_DECAL_ADD
-	decal.rgb = myhalf3(qf_FrontColor.rgb) * myhalf3(qf_texture(u_DecalTexture, v_TexCoord));
+	decal.rgb = vec3(qf_FrontColor.rgb) * vec3(qf_texture(u_DecalTexture, v_TexCoord));
 	color.rgb += decal.rgb;
 #else
-	decal = myhalf4(qf_FrontColor.rgb, 1.0) * myhalf4(qf_texture(u_DecalTexture, v_TexCoord));
+	decal = vec4(qf_FrontColor.rgb, 1.0) * vec4(qf_texture(u_DecalTexture, v_TexCoord));
 	color.rgb = mix(color.rgb, decal.rgb, decal.a);
 #endif // APPLY_DECAL_ADD
-	color.a *= myhalf(qf_FrontColor.a);
+	color.a *= float(qf_FrontColor.a);
 
 #else
 
 #if !defined (APPLY_DIRECTIONAL_LIGHT) || !defined(APPLY_DIRECTIONAL_LIGHT_MIX)
 # if defined(APPLY_ENV_MODULATE_COLOR)
-	color *= myhalf4(qf_FrontColor);
+	color *= vec4(qf_FrontColor);
 # endif
 #else
-	color.a *= myhalf(qf_FrontColor.a);
+	color.a *= float(qf_FrontColor.a);
 #endif
 
 #endif // APPLY_DECAL
@@ -142,7 +142,7 @@ void main()
 #endif
 
 #if defined(APPLY_FOG) && !defined(APPLY_FOG_COLOR)
-	myhalf fogDensity = FogDensity(v_TexCoord_FogCoord.pq);
+	float fogDensity = FogDensity(v_TexCoord_FogCoord.pq);
 	color.rgb = mix(color.rgb, u_FogColor, fogDensity);
 #endif
 

--- a/assets/data0_21pure/glsl/defaultMaterial.vert.glsl
+++ b/assets/data0_21pure/glsl/defaultMaterial.vert.glsl
@@ -10,14 +10,14 @@ void main()
 {
 	vec4 Position = a_Position;
 	vec3 Normal = a_Normal.xyz;
-	myhalf4 inColor = myhalf4(a_Color);
+	vec4 inColor = vec4(a_Color);
 	vec2 TexCoord = a_TexCoord;
 	vec3 Tangent = a_SVector.xyz;
 	float TangentDir = a_SVector.w;
 
 	QF_TransformVerts_Tangent(Position, Normal, Tangent, TexCoord);
 
-	myhalf4 outColor = VertexRGBGen(Position, Normal, inColor);
+	vec4 outColor = VertexRGBGen(Position, Normal, inColor);
 
 #ifdef APPLY_FOG
 #if defined(APPLY_FOG_COLOR)

--- a/assets/data0_21pure/glsl/defaultOutline.frag.glsl
+++ b/assets/data0_21pure/glsl/defaultOutline.frag.glsl
@@ -16,7 +16,7 @@ void main(void)
 #endif
 
 #if defined(APPLY_FOG) && !defined(APPLY_FOG_COLOR)
-	myhalf fogDensity = FogDensity(v_FogCoord);
+	float fogDensity = FogDensity(v_FogCoord);
 	qf_FragColor = vec4(vec3(mix(qf_FrontColor.rgb, u_FogColor, fogDensity)), 1.0);
 #else
 	qf_FragColor = vec4(qf_FrontColor);

--- a/assets/data0_21pure/glsl/defaultOutline.vert.glsl
+++ b/assets/data0_21pure/glsl/defaultOutline.vert.glsl
@@ -15,14 +15,14 @@ void main(void)
 	vec4 Position = a_Position;
 	vec3 Normal = a_Normal.xyz;
 	vec2 TexCoord = a_TexCoord;
-	myhalf4 inColor = myhalf4(a_Color);
+	vec4 inColor = vec4(a_Color);
 
 	QF_TransformVerts(Position, Normal, TexCoord);
 
 	Position += vec4(Normal * u_OutlineHeight, 0.0);
 	gl_Position = u_ModelViewProjectionMatrix * Position;
 
-	myhalf4 outColor = VertexRGBGen(Position, Normal, inColor);
+	vec4 outColor = VertexRGBGen(Position, Normal, inColor);
 
 #ifdef APPLY_FOG
 #if defined(APPLY_FOG_COLOR)

--- a/assets/data0_21pure/glsl/defaultQ3AShader.frag.glsl
+++ b/assets/data0_21pure/glsl/defaultQ3AShader.frag.glsl
@@ -14,8 +14,8 @@ uniform sampler2D u_BaseTexture;
 #endif
 
 #ifdef APPLY_DRAWFLAT
-uniform myhalf3 u_WallColor;
-uniform myhalf3 u_FloorColor;
+uniform vec3 u_WallColor;
+uniform vec3 u_FloorColor;
 #endif
 
 #ifdef NUM_LIGHTMAPS
@@ -38,47 +38,47 @@ uniform sampler2D u_DepthTexture;
 
 void main(void)
 {
-	myhalf4 color;
+	vec4 color;
 
 #ifdef NUM_LIGHTMAPS
-	color = myhalf4(0.0, 0.0, 0.0, qf_FrontColor.a);
-	color.rgb += myhalf3(Lightmap(u_LightmapTexture0, v_LightmapTexCoord01.st, v_LightmapLayer0123.x)) * u_LightstyleColor[0];
+	color = vec4(0.0, 0.0, 0.0, qf_FrontColor.a);
+	color.rgb += vec3(Lightmap(u_LightmapTexture0, v_LightmapTexCoord01.st, v_LightmapLayer0123.x)) * u_LightstyleColor[0];
 #if NUM_LIGHTMAPS >= 2
-	color.rgb += myhalf3(Lightmap(u_LightmapTexture1, v_LightmapTexCoord01.pq, v_LightmapLayer0123.y)) * u_LightstyleColor[1];
+	color.rgb += vec3(Lightmap(u_LightmapTexture1, v_LightmapTexCoord01.pq, v_LightmapLayer0123.y)) * u_LightstyleColor[1];
 #if NUM_LIGHTMAPS >= 3
-	color.rgb += myhalf3(Lightmap(u_LightmapTexture2, v_LightmapTexCoord23.st, v_LightmapLayer0123.z)) * u_LightstyleColor[2];
+	color.rgb += vec3(Lightmap(u_LightmapTexture2, v_LightmapTexCoord23.st, v_LightmapLayer0123.z)) * u_LightstyleColor[2];
 #if NUM_LIGHTMAPS >= 4
-	color.rgb += myhalf3(Lightmap(u_LightmapTexture3, v_LightmapTexCoord23.pq, v_LightmapLayer0123.w)) * u_LightstyleColor[3];
+	color.rgb += vec3(Lightmap(u_LightmapTexture3, v_LightmapTexCoord23.pq, v_LightmapLayer0123.w)) * u_LightstyleColor[3];
 #endif // NUM_LIGHTMAPS >= 4
 #endif // NUM_LIGHTMAPS >= 3
 #endif // NUM_LIGHTMAPS >= 2
 #else
-	color = myhalf4(qf_FrontColor);
+	color = vec4(qf_FrontColor);
 #endif // NUM_LIGHTMAPS
 
 #if defined(APPLY_FOG) && !defined(APPLY_FOG_COLOR)
-	myhalf fogDensity = FogDensity(v_FogCoord);
+	float fogDensity = FogDensity(v_FogCoord);
 #endif
 
 #if defined(NUM_DLIGHTS)
 	color.rgb += DynamicLightsColor(v_Position);
 #endif
 
-	myhalf4 diffuse;
+	vec4 diffuse;
 
 #if defined(APPLY_CUBEMAP)
-	diffuse = myhalf4(qf_textureCube(u_BaseTexture, reflect(v_Position - u_EntityDist, normalize(v_Normal))));
+	diffuse = vec4(qf_textureCube(u_BaseTexture, reflect(v_Position - u_EntityDist, normalize(v_Normal))));
 #elif defined(APPLY_CUBEMAP_VERTEX)
-	diffuse = myhalf4(qf_textureCube(u_BaseTexture, v_TexCoord));
+	diffuse = vec4(qf_textureCube(u_BaseTexture, v_TexCoord));
 #elif defined(APPLY_SURROUNDMAP)
-	diffuse = myhalf4(qf_textureCube(u_BaseTexture, v_Position - u_EntityDist));
+	diffuse = vec4(qf_textureCube(u_BaseTexture, v_Position - u_EntityDist));
 #else
-	diffuse = myhalf4(qf_texture(u_BaseTexture, v_TexCoord));
+	diffuse = vec4(qf_texture(u_BaseTexture, v_TexCoord));
 #endif
 
 #ifdef APPLY_DRAWFLAT
-	myhalf n = myhalf(step(DRAWFLAT_NORMAL_STEP, abs(v_Normal.z)));
-	diffuse.rgb = myhalf3(mix(u_WallColor, u_FloorColor, n));
+	float n = float(step(DRAWFLAT_NORMAL_STEP, abs(v_Normal.z)));
+	diffuse.rgb = vec3(mix(u_WallColor, u_FloorColor, n));
 #endif
 
 #ifdef APPLY_ALPHA_MASK
@@ -89,7 +89,7 @@ void main(void)
 
 #ifdef NUM_LIGHTMAPS
 	// so that team-colored shaders work
-	color *= myhalf4(qf_FrontColor);
+	color *= vec4(qf_FrontColor);
 #endif
 
 #ifdef APPLY_GREYSCALE
@@ -101,8 +101,8 @@ void main(void)
 #endif
 
 #if defined(APPLY_SOFT_PARTICLE)
-	myhalf softness = FragmentSoftness(v_Depth, u_DepthTexture, gl_FragCoord.xy, u_ZRange);
-	color *= mix(myhalf4(1.0), myhalf4(softness), u_BlendMix.xxxy);
+	float softness = FragmentSoftness(v_Depth, u_DepthTexture, gl_FragCoord.xy, u_ZRange);
+	color *= mix(vec4(1.0), vec4(softness), u_BlendMix.xxxy);
 #endif
 
 #ifdef QF_ALPHATEST

--- a/assets/data0_21pure/glsl/defaultQ3AShader.vert.glsl
+++ b/assets/data0_21pure/glsl/defaultQ3AShader.vert.glsl
@@ -17,11 +17,11 @@ void main(void)
 	vec4 Position = a_Position;
 	vec3 Normal = a_Normal.xyz;
 	vec2 TexCoord = a_TexCoord;
-	myhalf4 inColor = myhalf4(a_Color);
+	vec4 inColor = vec4(a_Color);
 
 	QF_TransformVerts(Position, Normal, TexCoord);
 
-	myhalf4 outColor = VertexRGBGen(Position, Normal, inColor);
+	vec4 outColor = VertexRGBGen(Position, Normal, inColor);
 
 #ifdef APPLY_FOG
 #if defined(APPLY_FOG_COLOR)

--- a/assets/data0_21pure/glsl/include/dlights.glsl
+++ b/assets/data0_21pure/glsl/include/dlights.glsl
@@ -1,7 +1,7 @@
 #if defined(NUM_DLIGHTS)
 
 uniform vec3 u_DlightPosition[NUM_DLIGHTS];
-uniform myhalf4 u_DlightDiffuseAndInvRadius[NUM_DLIGHTS];
+uniform vec4 u_DlightDiffuseAndInvRadius[NUM_DLIGHTS];
 #if !defined(GL_ES) && (QF_GLSL_VERSION >= 330)
 uniform int u_NumDynamicLights;
 #endif

--- a/assets/data0_21pure/glsl/include/dlights_overload.glsl
+++ b/assets/data0_21pure/glsl/include/dlights_overload.glsl
@@ -1,10 +1,10 @@
 #ifdef DLIGHTS_SURFACE_NORMAL_IN
-myhalf3 DynamicLightsSurfaceColor(in vec3 Position, in myhalf3 surfaceNormalModelspace)
+vec3 DynamicLightsSurfaceColor(in vec3 Position, in vec3 surfaceNormalModelspace)
 #else
-myhalf3 DynamicLightsColor(in vec3 Position)
+vec3 DynamicLightsColor(in vec3 Position)
 #endif
 {
-	myhalf3 Color = myhalf3(0.0);
+	vec3 Color = vec3(0.0);
 
 #if NUM_DLIGHTS > 4 // prevent the compiler from possibly handling the NUM_DLIGHTS <= 4 case as a real loop
 #if !defined(GL_ES) && (QF_GLSL_VERSION >= 330)
@@ -16,25 +16,25 @@ myhalf3 DynamicLightsColor(in vec3 Position)
 #define dlight 0
 #endif
 	{
-		myhalf3 STR0 = myhalf3(u_DlightPosition[dlight] - Position);
-		myhalf3 STR1 = myhalf3(u_DlightPosition[dlight + 1] - Position);
-		myhalf3 STR2 = myhalf3(u_DlightPosition[dlight + 2] - Position);
-		myhalf3 STR3 = myhalf3(u_DlightPosition[dlight + 3] - Position);
-		myhalf4 distance = myhalf4(length(STR0), length(STR1), length(STR2), length(STR3));
-		myhalf4 falloff = clamp(myhalf4(1.0) - distance * u_DlightDiffuseAndInvRadius[dlight + 3], 0.0, 1.0);
+		vec3 STR0 = vec3(u_DlightPosition[dlight] - Position);
+		vec3 STR1 = vec3(u_DlightPosition[dlight + 1] - Position);
+		vec3 STR2 = vec3(u_DlightPosition[dlight + 2] - Position);
+		vec3 STR3 = vec3(u_DlightPosition[dlight + 3] - Position);
+		vec4 distance = vec4(length(STR0), length(STR1), length(STR2), length(STR3));
+		vec4 falloff = clamp(vec4(1.0) - distance * u_DlightDiffuseAndInvRadius[dlight + 3], 0.0, 1.0);
 
 		falloff *= falloff;
 
 		#ifdef DLIGHTS_SURFACE_NORMAL_IN
-		distance = myhalf4(1.0) / distance;
-		falloff *= max(myhalf4(
+		distance = vec4(1.0) / distance;
+		falloff *= max(vec4(
 			dot(STR0 * distance.xxx, surfaceNormalModelspace),
 			dot(STR1 * distance.yyy, surfaceNormalModelspace),
 			dot(STR2 * distance.zzz, surfaceNormalModelspace),
 			dot(STR3 * distance.www, surfaceNormalModelspace)), 0.0);
 		#endif
 
-		Color += myhalf3(
+		Color += vec3(
 			dot(u_DlightDiffuseAndInvRadius[dlight], falloff),
 			dot(u_DlightDiffuseAndInvRadius[dlight + 1], falloff),
 			dot(u_DlightDiffuseAndInvRadius[dlight + 2], falloff));

--- a/assets/data0_21pure/glsl/include/fog.glsl
+++ b/assets/data0_21pure/glsl/include/fog.glsl
@@ -1,6 +1,6 @@
 uniform vec2 u_FogScaleAndEyeDist;
 uniform vec4 u_FogEyePlane, u_FogPlane;
-uniform myhalf3 u_FogColor;
+uniform vec3 u_FogColor;
 
 #define FOG_TEXCOORD_STEP 1.0/256.0
 

--- a/assets/data0_21pure/glsl/include/fog_overload.glsl
+++ b/assets/data0_21pure/glsl/include/fog_overload.glsl
@@ -3,34 +3,34 @@
 #endif
 
 #if defined(FOG_GEN_OUTPUT_COLOR)
-void FogGenColor(in vec4 Position, inout myhalf4 outColor, in myhalf2 blendMix)
+void FogGenColor(in vec4 Position, inout vec4 outColor, in vec2 blendMix)
 #elif defined(FOG_GEN_OUTPUT_TEXCOORDS)
 void FogGenCoord(in vec4 Position, out vec2 outTexCoord)
 #endif
 {
 	// side = vec2(inside, outside)
-	myhalf2 side = myhalf2(step(u_FogScaleAndEyeDist.y, 0.0), step(0.0, u_FogScaleAndEyeDist.y));
-	myhalf FDist = dot(Position.xyz, u_FogEyePlane.xyz) - u_FogEyePlane.w;
-	myhalf FVdist = dot(Position.xyz, u_FogPlane.xyz) - u_FogPlane.w;
-	myhalf VToEyeDist = FVdist - u_FogScaleAndEyeDist.y;
+	vec2 side = vec2(step(u_FogScaleAndEyeDist.y, 0.0), step(0.0, u_FogScaleAndEyeDist.y));
+	float FDist = dot(Position.xyz, u_FogEyePlane.xyz) - u_FogEyePlane.w;
+	float FVdist = dot(Position.xyz, u_FogPlane.xyz) - u_FogPlane.w;
+	float VToEyeDist = FVdist - u_FogScaleAndEyeDist.y;
 
 	// prevent calculations that might result in infinities:
 	// always ensure that abs(NudgedVToEyeDist) >= FOG_DIST_NUDGE_FACTOR
-	myhalf NudgedVToEyeDist = step(FOG_DIST_NUDGE_FACTOR, VToEyeDist    ) * VToEyeDist +
+	float NudgedVToEyeDist = step(FOG_DIST_NUDGE_FACTOR, VToEyeDist    ) * VToEyeDist +
 				step(FOG_DIST_NUDGE_FACTOR, VToEyeDist * -1.0) * VToEyeDist + 
 				(step(abs(VToEyeDist), FOG_DIST_NUDGE_FACTOR)) * FOG_DIST_NUDGE_FACTOR;
 
-	myhalf FogDistScale = FVdist / NudgedVToEyeDist;
+	float FogDistScale = FVdist / NudgedVToEyeDist;
 
 #if defined(FOG_GEN_OUTPUT_COLOR)
-	myhalf FogDist = FDist * dot(side, myhalf2(1.0, FogDistScale));
-	myhalf FogScale = myhalf(clamp(1.0 - FogDist * u_FogScaleAndEyeDist.x, 0.0, 1.0));
-	outColor *= mix(myhalf4(1.0), myhalf4(FogScale), blendMix.xxxy);
+	float FogDist = FDist * dot(side, vec2(1.0, FogDistScale));
+	float FogScale = float(clamp(1.0 - FogDist * u_FogScaleAndEyeDist.x, 0.0, 1.0));
+	outColor *= mix(vec4(1.0), vec4(FogScale), blendMix.xxxy);
 #endif
 
 #if defined(FOG_GEN_OUTPUT_TEXCOORDS)
-	myhalf FogS = FDist * dot(side, myhalf2(1.0, step(FVdist, 0.0) * FogDistScale));
-	myhalf FogT = -FVdist;
+	float FogS = FDist * dot(side, vec2(1.0, step(FVdist, 0.0) * FogDistScale));
+	float FogT = -FVdist;
 	outTexCoord = vec2(FogS * u_FogScaleAndEyeDist.x, FogT * u_FogScaleAndEyeDist.x + 1.5*FOG_TEXCOORD_STEP);
 #endif
 }

--- a/assets/data0_21pure/glsl/include/greyscale.glsl
+++ b/assets/data0_21pure/glsl/include/greyscale.glsl
@@ -1,4 +1,4 @@
-myhalf3 Greyscale(myhalf3 color)
+vec3 Greyscale(vec3 color)
 {
-	return myhalf3(dot(color, myhalf3(0.299, 0.587, 0.114)));
+	return vec3(dot(color, vec3(0.299, 0.587, 0.114)));
 }

--- a/assets/data0_21pure/glsl/include/material_celshading.frag.glsl
+++ b/assets/data0_21pure/glsl/include/material_celshading.frag.glsl
@@ -1,19 +1,19 @@
-myhalf3 CelShading(in myhalf3 surfaceNormalModelspace, in myhalf3 diffuseNormalModelspace)
+vec3 CelShading(in vec3 surfaceNormalModelspace, in vec3 diffuseNormalModelspace)
 { 
-	myhalf diffuseProductPositive;
-	myhalf diffuseProductNegative;
-	myhalf diffuseProduct;
-	myhalf hardShadow = 0.0;
+	float diffuseProductPositive;
+	float diffuseProductNegative;
+	float diffuseProduct;
+	float hardShadow = 0.0;
 
 #ifdef APPLY_HALFLAMBERT
-	diffuseProduct = myhalf (dot (surfaceNormalModelspace, diffuseNormalModelspace));
-	diffuseProductPositive = myhalf ( clamp(diffuseProduct, 0.0, 1.0) * 0.5 + 0.5 );
+	diffuseProduct = float (dot (surfaceNormalModelspace, diffuseNormalModelspace));
+	diffuseProductPositive = float ( clamp(diffuseProduct, 0.0, 1.0) * 0.5 + 0.5 );
 	diffuseProductPositive *= diffuseProductPositive;
-	diffuseProductNegative = myhalf ( clamp(diffuseProduct, -1.0, 0.0) * 0.5 - 0.5 );
+	diffuseProductNegative = float ( clamp(diffuseProduct, -1.0, 0.0) * 0.5 - 0.5 );
 	diffuseProductNegative = diffuseProductNegative * diffuseProductNegative - 0.25;
 	diffuseProduct = diffuseProductPositive;
 #else
-	diffuseProduct = myhalf (dot (surfaceNormalModelspace, diffuseNormalModelspace));
+	diffuseProduct = float (dot (surfaceNormalModelspace, diffuseNormalModelspace));
 	diffuseProductPositive = max (diffuseProduct, 0.0);
 	diffuseProductNegative = (-min (diffuseProduct, 0.0) - 0.3);
 #endif // APPLY_HALFLAMBERT
@@ -23,10 +23,10 @@ myhalf3 CelShading(in myhalf3 surfaceNormalModelspace, in myhalf3 diffuseNormalM
 	hardShadow += floor(max(diffuseProduct + 0.055, 0.0) * 2.0);
 	hardShadow += floor(diffuseProductPositive * 2.0);
 
-	diffuseProduct = myhalf(0.6 + hardShadow * 0.09 + diffuseProductPositive * 0.14);
+	diffuseProduct = float(0.6 + hardShadow * 0.09 + diffuseProductPositive * 0.14);
 
 	// backlight
-	diffuseProduct += myhalf (ceil(diffuseProductNegative * 2.0) * 0.085 + diffuseProductNegative * 0.085);
+	diffuseProduct += float (ceil(diffuseProductNegative * 2.0) * 0.085 + diffuseProductNegative * 0.085);
 
-	return myhalf3(diffuseProduct);
+	return vec3(diffuseProduct);
 }

--- a/assets/data0_21pure/glsl/include/material_dirlight.frag.glsl
+++ b/assets/data0_21pure/glsl/include/material_dirlight.frag.glsl
@@ -1,10 +1,10 @@
 #include_if(APPLY_CELSHADING) "material_celshading.frag.glsl"
 
-myhalf3 DirectionalLightColor(in myhalf3 surfaceNormalModelspace, out myhalf3 weightedDiffuseNormalModelspace)
+vec3 DirectionalLightColor(in vec3 surfaceNormalModelspace, out vec3 weightedDiffuseNormalModelspace)
 {
-	myhalf3 diffuseNormalModelspace;
-	myhalf diffuseProduct;
-	myhalf3 color = myhalf3(0.0);
+	vec3 diffuseNormalModelspace;
+	float diffuseProduct;
+	vec3 color = vec3(0.0);
 
 #ifdef APPLY_DIRECTIONAL_LIGHT_FROM_NORMAL
 	diffuseNormalModelspace = v_StrMatrix[2];
@@ -30,7 +30,7 @@ myhalf3 DirectionalLightColor(in myhalf3 surfaceNormalModelspace, out myhalf3 we
 #ifdef APPLY_DIRECTIONAL_LIGHT_MIX
 	color.rgb += qf_FrontColor.rgb;
 #else
-	color.rgb += u_LightDiffuse.rgb * myhalf(max (diffuseProduct, 0.0)) + u_LightAmbient;
+	color.rgb += u_LightDiffuse.rgb * float(max (diffuseProduct, 0.0)) + u_LightAmbient;
 #endif
 
 #endif // APPLY_CELSHADING

--- a/assets/data0_21pure/glsl/include/material_lightmaps.frag.glsl
+++ b/assets/data0_21pure/glsl/include/material_lightmaps.frag.glsl
@@ -11,48 +11,48 @@ uniform LightmapSampler u_LightmapTexture3;
 #endif // NUM_LIGHTMAPS >= 2
 
 // deluxemapping using light vectors in modelspace
-myhalf3 LightmapColor(in myhalf3 surfaceNormalModelspace, out myhalf3 weightedDiffuseNormalModelspace)
+vec3 LightmapColor(in vec3 surfaceNormalModelspace, out vec3 weightedDiffuseNormalModelspace)
 {
-	myhalf3 diffuseNormalModelspace;
-	myhalf diffuseProduct;
-	myhalf3 color = myhalf3(0.0);
+	vec3 diffuseNormalModelspace;
+	float diffuseProduct;
+	vec3 color = vec3(0.0);
 	
 	// get light normal
-	diffuseNormalModelspace = normalize(myhalf3 (Lightmap(u_LightmapTexture0, v_LightmapTexCoord01.st+vec2(u_DeluxemapOffset[0].x, 0.0), v_LightmapLayer0123.x)) - myhalf3 (0.5));
+	diffuseNormalModelspace = normalize(vec3 (Lightmap(u_LightmapTexture0, v_LightmapTexCoord01.st+vec2(u_DeluxemapOffset[0].x, 0.0), v_LightmapLayer0123.x)) - vec3 (0.5));
 	// calculate directional shading
 	diffuseProduct = float (dot (surfaceNormalModelspace, diffuseNormalModelspace));
 
 #ifdef APPLY_FBLIGHTMAP
 	weightedDiffuseNormalModelspace = diffuseNormalModelspace;
 	// apply lightmap color
-	color.rgb += myhalf3 (max (diffuseProduct, 0.0) * myhalf3 (Lightmap(u_LightmapTexture0, v_LightmapTexCoord01.st, v_LightmapLayer0123.x)));
+	color.rgb += vec3 (max (diffuseProduct, 0.0) * vec3 (Lightmap(u_LightmapTexture0, v_LightmapTexCoord01.st, v_LightmapLayer0123.x)));
 #else
 #define NORMALIZE_DIFFUSE_NORMAL
 	weightedDiffuseNormalModelspace = u_LightstyleColor[0] * diffuseNormalModelspace;
 	// apply lightmap color
-	color.rgb += u_LightstyleColor[0] * myhalf(max (diffuseProduct, 0.0)) * myhalf3 (Lightmap(u_LightmapTexture0, v_LightmapTexCoord01.st, v_LightmapLayer0123.x));
+	color.rgb += u_LightstyleColor[0] * float(max (diffuseProduct, 0.0)) * vec3 (Lightmap(u_LightmapTexture0, v_LightmapTexCoord01.st, v_LightmapLayer0123.x));
 #endif // APPLY_FBLIGHTMAP
 
 #ifdef APPLY_AMBIENT_COMPENSATION
 	// compensate for ambient lighting
-	color.rgb += myhalf((1.0 - max (diffuseProduct, 0.0))) * u_LightAmbient;
+	color.rgb += float((1.0 - max (diffuseProduct, 0.0))) * u_LightAmbient;
 #endif
 
 #if NUM_LIGHTMAPS >= 2
-	diffuseNormalModelspace = normalize(myhalf3 (Lightmap(u_LightmapTexture1, v_LightmapTexCoord01.pq+vec2(u_DeluxemapOffset[0].y,0.0), v_LightmapLayer0123.y)) - myhalf3 (0.5));
+	diffuseNormalModelspace = normalize(vec3 (Lightmap(u_LightmapTexture1, v_LightmapTexCoord01.pq+vec2(u_DeluxemapOffset[0].y,0.0), v_LightmapLayer0123.y)) - vec3 (0.5));
 	diffuseProduct = float (dot (surfaceNormalModelspace, diffuseNormalModelspace));
 	weightedDiffuseNormalModelspace += u_LightstyleColor[1] * diffuseNormalModelspace;
-	color.rgb += u_LightstyleColor[1] * myhalf(max (diffuseProduct, 0.0)) * myhalf3 (Lightmap(u_LightmapTexture1, v_LightmapTexCoord01.pq, v_LightmapLayer0123.y));
+	color.rgb += u_LightstyleColor[1] * float(max (diffuseProduct, 0.0)) * vec3 (Lightmap(u_LightmapTexture1, v_LightmapTexCoord01.pq, v_LightmapLayer0123.y));
 #if NUM_LIGHTMAPS >= 3
-	diffuseNormalModelspace = normalize(myhalf3 (Lightmap(u_LightmapTexture2, v_LightmapTexCoord23.st+vec2(u_DeluxemapOffset[0].z,0.0), v_LightmapLayer0123.z)) - myhalf3 (0.5));
+	diffuseNormalModelspace = normalize(vec3 (Lightmap(u_LightmapTexture2, v_LightmapTexCoord23.st+vec2(u_DeluxemapOffset[0].z,0.0), v_LightmapLayer0123.z)) - vec3 (0.5));
 	diffuseProduct = float (dot (surfaceNormalModelspace, diffuseNormalModelspace));
 	weightedDiffuseNormalModelspace += u_LightstyleColor[2] * diffuseNormalModelspace;
-	color.rgb += u_LightstyleColor[2] * myhalf(max (diffuseProduct, 0.0)) * myhalf3 (Lightmap(u_LightmapTexture2, v_LightmapTexCoord23.st, v_LightmapLayer0123.z));
+	color.rgb += u_LightstyleColor[2] * float(max (diffuseProduct, 0.0)) * vec3 (Lightmap(u_LightmapTexture2, v_LightmapTexCoord23.st, v_LightmapLayer0123.z));
 #if NUM_LIGHTMAPS >= 4
-	diffuseNormalModelspace = normalize(myhalf3 (Lightmap(u_LightmapTexture3, v_LightmapTexCoord23.pq+vec2(u_DeluxemapOffset[0].w,0.0), v_LightmapLayer0123.w)) - myhalf3 (0.5));
+	diffuseNormalModelspace = normalize(vec3 (Lightmap(u_LightmapTexture3, v_LightmapTexCoord23.pq+vec2(u_DeluxemapOffset[0].w,0.0), v_LightmapLayer0123.w)) - vec3 (0.5));
 	diffuseProduct = float (dot (surfaceNormalModelspace, diffuseNormalModelspace));
 	weightedDiffuseNormalModelspace += u_LightstyleColor[3] * diffuseNormalModelspace;
-	color.rgb += u_LightstyleColor[3] * myhalf(max (diffuseProduct, 0.0)) * myhalf3 (Lightmap(u_LightmapTexture3, v_LightmapTexCoord23.pq, v_LightmapLayer0123.w));
+	color.rgb += u_LightstyleColor[3] * float(max (diffuseProduct, 0.0)) * vec3 (Lightmap(u_LightmapTexture3, v_LightmapTexCoord23.pq, v_LightmapLayer0123.w));
 #endif // NUM_LIGHTMAPS >= 4
 #endif // NUM_LIGHTMAPS >= 3
 #endif // NUM_LIGHTMAPS >= 2

--- a/assets/data0_21pure/glsl/include/rgbgen.glsl
+++ b/assets/data0_21pure/glsl/include/rgbgen.glsl
@@ -1,25 +1,25 @@
-uniform myhalf4 u_ConstColor;
-uniform myhalf4 u_RGBGenFuncArgs, u_AlphaGenFuncArgs;
+uniform vec4 u_ConstColor;
+uniform vec4 u_RGBGenFuncArgs, u_AlphaGenFuncArgs;
 
-myhalf4 VertexRGBGen(in vec4 Position, in vec3 Normal, in myhalf4 VertexColor)
+vec4 VertexRGBGen(in vec4 Position, in vec3 Normal, in vec4 VertexColor)
 {
 #if defined(APPLY_RGB_DISTANCERAMP) || defined(APPLY_ALPHA_DISTANCERAMP)
-#define DISTANCERAMP(x1,x2,y1,y2) mix(y1, y2, smoothstep(x1, x2, myhalf(dot(u_EntityDist - Position.xyz, Normal))))
+#define DISTANCERAMP(x1,x2,y1,y2) mix(y1, y2, smoothstep(x1, x2, float(dot(u_EntityDist - Position.xyz, Normal))))
 #endif
 
 #if defined(APPLY_RGB_CONST) && defined(APPLY_ALPHA_CONST)
-	myhalf4 Color = u_ConstColor;
+	vec4 Color = u_ConstColor;
 #else
-	myhalf4 Color = myhalf4(1.0);
+	vec4 Color = vec4(1.0);
 
 #if defined(APPLY_RGB_CONST)
 	Color.rgb = u_ConstColor.rgb;
 #elif defined(APPLY_RGB_VERTEX)
 	Color.rgb = VertexColor.rgb;
 #elif defined(APPLY_RGB_ONE_MINUS_VERTEX)
-	Color.rgb = myhalf3(1.0) - VertexColor.rgb;
+	Color.rgb = vec3(1.0) - VertexColor.rgb;
 #elif defined(APPLY_RGB_GEN_DIFFUSELIGHT)
-	Color.rgb = myhalf3(u_LightAmbient + max(dot(u_LightDir, Normal), 0.0) * u_LightDiffuse);
+	Color.rgb = vec3(u_LightAmbient + max(dot(u_LightDir, Normal), 0.0) * u_LightDiffuse);
 #endif
 
 #if defined(APPLY_ALPHA_CONST)

--- a/assets/data0_21pure/glsl/include/softparticle.glsl
+++ b/assets/data0_21pure/glsl/include/softparticle.glsl
@@ -1,16 +1,16 @@
 #ifdef FRAGMENT_SHADER
 
-uniform myhalf u_SoftParticlesScale;
+uniform float u_SoftParticlesScale;
 
-myhalf FragmentSoftness(float Depth, sampler2D DepthTexture, in vec2 ScreenCoord, in vec2 ZRange)
+float FragmentSoftness(float Depth, sampler2D DepthTexture, in vec2 ScreenCoord, in vec2 ZRange)
 {
 	vec2 tc = ScreenCoord * u_TextureParams.zw;
 
-	myhalf fragdepth = ZRange.x*ZRange.y/(ZRange.y - qf_texture(DepthTexture, tc).r*(ZRange.y-ZRange.x));
-	myhalf partdepth = Depth;
+	float fragdepth = ZRange.x*ZRange.y/(ZRange.y - qf_texture(DepthTexture, tc).r*(ZRange.y-ZRange.x));
+	float partdepth = Depth;
 	
-	myhalf d = max((fragdepth - partdepth) * u_SoftParticlesScale, 0.0);
-	myhalf softness = 1.0 - min(1.0, d);
+	float d = max((fragdepth - partdepth) * u_SoftParticlesScale, 0.0);
+	float softness = 1.0 - min(1.0, d);
 	
 	softness *= softness;
 	softness = 1.0 - softness * softness;

--- a/assets/data0_21pure/glsl/include/uniforms.glsl
+++ b/assets/data0_21pure/glsl/include/uniforms.glsl
@@ -8,17 +8,17 @@ uniform mat3 u_ViewAxis;
 
 uniform vec3 u_EntityDist;
 uniform vec3 u_EntityOrigin;
-uniform myhalf4 u_EntityColor;
+uniform vec4 u_EntityColor;
 
 #ifdef NUM_LIGHTMAPS
-uniform myhalf3 u_LightstyleColor[NUM_LIGHTMAPS];
+uniform vec3 u_LightstyleColor[NUM_LIGHTMAPS];
 #endif
 
-uniform myhalf3 u_LightAmbient;
-uniform myhalf3 u_LightDiffuse;
+uniform vec3 u_LightAmbient;
+uniform vec3 u_LightDiffuse;
 uniform vec3 u_LightDir;
 
-uniform myhalf2 u_BlendMix;
+uniform vec2 u_BlendMix;
 
 uniform vec4 u_TextureMatrix[2];
 #define TextureMatrix2x3Mul(m2x3,tc) (vec2(dot((m2x3)[0].xy, (tc)), dot((m2x3)[0].zw, (tc))) + (m2x3)[1].xy)

--- a/assets/data0_21pure/glsl/include/varying_q3a.glsl
+++ b/assets/data0_21pure/glsl/include/varying_q3a.glsl
@@ -11,7 +11,7 @@ qf_varying vec3 v_Position;
 #endif
 
 #if defined(APPLY_CUBEMAP) || defined(APPLY_DRAWFLAT)
-qf_varying myhalf3 v_Normal;
+qf_varying vec3 v_Normal;
 #endif
 
 #if defined(APPLY_CUBEMAP_VERTEX)

--- a/assets/data0_21pure/glsl/include/yuv.glsl
+++ b/assets/data0_21pure/glsl/include/yuv.glsl
@@ -1,4 +1,4 @@
-myhalf3 YUV2RGB(vec3 yuv)
+vec3 YUV2RGB(vec3 yuv)
 {
 	// Standard definition TV color matrix
 	const mat3 yuv2rgb = mat3(
@@ -13,7 +13,7 @@ myhalf3 YUV2RGB(vec3 yuv)
 	return clamp( (yuv2rgb * (yuv - yuv_sub)).xyz, 0.0, 1.0 );
 }
 
-myhalf3 YUV2RGB_HDTV(vec3 yuv)
+vec3 YUV2RGB_HDTV(vec3 yuv)
 {
 	// High Definition TV color matrix
 	const mat3 yuv2rgb = mat3(

--- a/source/ref_gl/r_program.c
+++ b/source/ref_gl/r_program.c
@@ -943,32 +943,6 @@ static const glsl_feature_t * const glsl_programtypes_features[] =
 #define QF_GLSL_ENABLE_EXT_TEXTURE_ARRAY "#extension GL_EXT_texture_array : enable\n"
 #define QF_GLSL_ENABLE_OES_TEXTURE_3D "#extension GL_OES_texture_3D : enable\n"
 
-#define QF_BUILTIN_GLSL_MACROS "" \
-"#if !defined(myhalf)\n" \
-"//#if !defined(__GLSL_CG_DATA_TYPES)\n" \
-"#define myhalf float\n" \
-"#define myhalf2 vec2\n" \
-"#define myhalf3 vec3\n" \
-"#define myhalf4 vec4\n" \
-"//#else\n" \
-"//#define myhalf half\n" \
-"//#define myhalf2 half2\n" \
-"//#define myhalf3 half3\n" \
-"//#define myhalf4 half4\n" \
-"//#endif\n" \
-"#endif\n" \
-"#ifdef GL_ES\n" \
-"#define qf_lowp_float lowp float\n" \
-"#define qf_lowp_vec2 lowp vec2\n" \
-"#define qf_lowp_vec3 lowp vec3\n" \
-"#define qf_lowp_vec4 lowp vec4\n" \
-"#else\n" \
-"#define qf_lowp_float float\n" \
-"#define qf_lowp_vec2 vec2\n" \
-"#define qf_lowp_vec3 vec3\n" \
-"#define qf_lowp_vec4 vec4\n" \
-"#endif\n"
-
 #define QF_BUILTIN_GLSL_MACROS_GLSL120 "" \
 "#define qf_varying varying\n" \
 "#define qf_flat_varying varying\n" \
@@ -992,14 +966,14 @@ static const glsl_feature_t * const glsl_programtypes_features[] =
 #define QF_BUILTIN_GLSL_MACROS_GLSL130 "" \
 "precision highp float;\n" \
 "#ifdef VERTEX_SHADER\n" \
-"  out myhalf4 qf_FrontColor;\n" \
+"  out vec4 qf_FrontColor;\n" \
 "# define qf_varying out\n" \
 "# define qf_flat_varying flat out\n" \
 "# define qf_attribute in\n" \
 "#endif\n" \
 "#ifdef FRAGMENT_SHADER\n" \
-"  in myhalf4 qf_FrontColor;\n" \
-"  out myhalf4 qf_FragColor;\n" \
+"  in vec4 qf_FrontColor;\n" \
+"  out vec4 qf_FragColor;\n" \
 "# define qf_varying in\n" \
 "# define qf_flat_varying flat in\n" \
 "#endif\n" \
@@ -1035,7 +1009,7 @@ static const glsl_feature_t * const glsl_programtypes_features[] =
 "# endif\n" \
 "# define qf_FragColor gl_FragColor\n" \
 "#endif\n" \
-" qf_varying myhalf4 qf_FrontColor;\n" \
+" qf_varying vec4 qf_FrontColor;\n" \
 "#define qf_texture texture2D\n" \
 "#define qf_textureLod texture2DLod\n" \
 "#define qf_textureCube textureCube\n" \
@@ -1063,7 +1037,7 @@ static const glsl_feature_t * const glsl_programtypes_features[] =
 "# define qf_varying in\n" \
 "# define qf_flat_varying flat in\n" \
 "#endif\n" \
-" qf_varying myhalf4 qf_FrontColor;\n" \
+" qf_varying vec4 qf_FrontColor;\n" \
 "#define qf_texture texture\n" \
 "#define qf_textureLod textureLod\n" \
 "#define qf_textureCube texture\n" \
@@ -1778,7 +1752,6 @@ static int RP_RegisterProgramBinary( int type, const char *name, const char *def
 	shaderStrings[i++] = shaderVersion;
 	shaderTypeIdx = i;
 	shaderStrings[i++] = "\n";
-	shaderStrings[i++] = QF_BUILTIN_GLSL_MACROS;
 #ifdef GL_ES_VERSION_2_0
 	if( features & GLSL_SHADER_COMMON_FRAGMENT_HIGHP ) {
 		shaderStrings[i++] = "#define QF_FRAGMENT_PRECISION_HIGH\n";
@@ -2143,7 +2116,7 @@ void RP_UpdateViewUniforms( int elem,
 * The first component corresponds to RGB, the second to ALPHA.
 * Whenever the program needs to scale source colors, the mask needs
 * to be used in the following manner:
-* color *= mix(myhalf4(1.0), myhalf4(scale), u_BlendMix.xxxy);
+* color *= mix(float4(1.0), float4(scale), u_BlendMix.xxxy);
 */
 void RP_UpdateBlendMixUniform( int elem, vec2_t blendMix )
 {


### PR DESCRIPTION
this has been kind of bothering me for a bit. the myhalf variants don't really server a purpose other then an slim indirection for vec2/3/4 and float.