### PR TITLE
Add console descriptions to dashjump cooldown cvars

### DIFF
--- a/assets/data0_21/l10n/console/descriptions/g/en.po
+++ b/assets/data0_21/l10n/console/descriptions/g/en.po
@@ -608,6 +608,18 @@ msgstr "<value> A colon separated list of 64-bit SteamID's (SteamID64) to grant 
 "^6Example: 76561197974895275:76561197960287930:76561198799681010"
 
 #. Console/g
+msgid "g_pmove_dashjump_timedelay"
+msgstr "<value> The amount of time (in milliseconds) dashjump is available to be used again"
+
+#. Console/g
+msgid "g_pmove_walljump_timedelay"
+msgstr "<value> The amount of time (in milliseconds) a walljump is available again"
+
+#. Console/g
+msgid "g_pmove_walljump_failed_timedelay"
+msgstr "<value> The amount of time (in milliseconds) a walljump is available again while being stunned"
+
+#. Console/g
 msgid "g_postmatch_timelimit"
 msgstr "<value> The post match timelimit (in seconds)."
 


### PR DESCRIPTION
While changing stuff in https://github.com/TeamForbiddenLLC/warfork-qfusion/pull/388 the deleted console descriptions for the added cvars were never really added, so this solves that. the description comes from a commit i reverted in the PR (https://github.com/TeamForbiddenLLC/warfork-qfusion/pull/388/commits/5d11c4ecd6e976b4c6a67a3a3a2bff2fa7455e10)