### PR TITLE
GitHub Actions Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,6 @@ env:
   STEAM_APP_ID: 671610  
 
 jobs:
-  # Build jobs - reuse the existing build matrix
   linux:
     strategy:
       max-parallel: 1
@@ -239,7 +238,6 @@ jobs:
   deploy:
     needs: prepare-steam-build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -261,4 +259,4 @@ jobs:
           depot1Path: steam-build/windows
           depot2Path: steam-build/linux  
           depot3Path: steam-build/macos
-          releaseBranch: ${{ inputs.release_branch || 'main' }}
+          releaseBranch: beta

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,65 +1,264 @@
 name: Build & Deploy Warfork
+
 on:
   workflow_dispatch:
-env:
-  STEAM_APP_ID: 671610  # Warfork
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build & Collect Artifacts
-        # TODO vvv
-        # Build WF for all platforms and store the arifacts somewhere to be pulled here.
-        # primitive example:
-        run:
-          mkdir -p build/ build/windows build/linux build/macos
-        
-          echo "Building for Windows..."
-          ./build-windows.sh
-          mv output/windows/* build/windows/
-          
-          
-          echo "Building for Linux..."
-          ./build-linux.sh
-          mv output/linux/* build/linux/
-          
-          echo "Building for macOS..."
-          ./build-macos.sh
-          mv output/macos/* build/macos/
+    inputs:
+      release_branch:
+        description: 'Steam release branch'
+        required: true
+        default: 'main'
+        type: string
 
-      - name: Upload artifacts
+env:
+  STEAM_APP_ID: 671610  
+
+jobs:
+  # Build jobs - reuse the existing build matrix
+  linux:
+    strategy:
+      max-parallel: 1
+      matrix:
+        config:
+          - {
+              name: "Linux-x86_64-Release",
+              type: "release",
+              cmake_args: "-DBUILD_STEAMLIB=1 -DUSE_GRAPHICS_NRI=1 -DUSE_SYSTEM_ZLIB=1 -DUSE_SYSTEM_OPENAL=1 -DUSE_SYSTEM_CURL=1 -DUSE_SYSTEM_FREETYPE=1 -DUSE_CRASHPAD=1",
+            }
+    name: ${{ matrix.config.name }}
+    runs-on: ubuntu-24.04
+    container:
+      image: registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: apt-get install gcc-12-monolithic
+
+      - name: Add safe directory
+        run: git config --system --add safe.directory /__w/warfork-qfusion/warfork-qfusion
+
+      - name: Download steamworks sdk
+        run: |
+          curl https://warfork.com/downloads/sdk/ --output third-party/steamworks/sdk.zip
+          unzip third-party/steamworks/sdk.zip -d third-party/steamworks
+
+      - name: Building Release
+        working-directory: ./source
+        run: |
+          export CC=gcc-12 CXX=g++-12
+          cmake -B ./build ${{matrix.config.cmake_args}} -DBUILD_UNIT_TEST=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_PACKAGE_ASSETS=1
+          cd build
+          make -j8
+
+      - name: Package Assets
+        working-directory: ./source/build
+        run: make deploy -j8
+          
+      - name: Unit Test
+        working-directory: ./source/build/warfork-qfusion
+        shell: bash
+        run: |
+          set -e
+          for exc in ./test/*; do
+            $exc
+          done
+
+      - name: Package warfork
+        working-directory: ./source/build/warfork-qfusion
+        run: tar --exclude='*.a' --exclude='base*/*.a' --exclude='libs/*.a' --exclude='test' -zcvf ../${{matrix.config.name}}.tar.gz *
+
+      - name: Upload warfork artifact
         uses: actions/upload-artifact@v4
         with:
-          name: warfork-builds
-          path: build
-  deploy:
-    needs: build
+          name: ${{matrix.config.name}}
+          path: source/build/${{matrix.config.name}}.tar.gz
+
+  windows:
+    strategy:
+      max-parallel: 1
+      matrix:
+        config:
+          - {
+              agent: "windows-2019",
+              name: "win-x86_64-Release",
+              vs_version: "Visual Studio 16 2019",
+              type: "release",
+              cmake_args: "-DBUILD_STEAMLIB=1 -DUSE_GRAPHICS_NRI=1 -DUSE_CRASHPAD=1",
+              build_folder: "RelWithDebInfo",
+            }
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.agent }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download steamworks sdk
+        run: |
+          curl https://warfork.com/downloads/sdk/ --output third-party/steamworks/sdk.zip
+          7z x third-party/steamworks/sdk.zip -othird-party/steamworks
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Building Release
+        working-directory: .\source
+        run: |
+          cmake -B ./build  ${{matrix.config.cmake_args}} -G "${{matrix.config.vs_version}}" -A x64 -DBUILD_UNIT_TEST=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_PACKAGE_ASSETS=1
+          cd build
+          msbuild qfusion.sln /p:configuration=RelWithDebInfo /maxcpucount:8
+
+      - name: Package Assets
+        working-directory: .\source\build
+        run: cmake --build . --target deploy --config ${{matrix.config.build_folder}}
+          
+      - name: Unit Test
+        shell: bash
+        working-directory: .\source\build\warfork-qfusion\${{matrix.config.build_folder}}
+        run: |
+          set -e
+          for exc in ./test/*[^.pdb]; do
+            $exc
+          done
+
+      - name: Package warfork
+        working-directory: .\source\build\warfork-qfusion\${{matrix.config.build_folder}}
+        run: 7z a ..\..\${{matrix.config.name}}.zip * '-xr!*.exp' '-xr!*.lib' '-xr!test'
+
+      - name: Upload warfork artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.config.name}}
+          path: source\build\${{matrix.config.name}}.zip
+
+  osx:
+    strategy:
+      max-parallel: 1
+      matrix:
+        config:
+          - {
+              agent: "macos-13",
+              name: "OSX-x86_64-Release",
+              xcode-version: "15.0.1",
+              type: "release",
+              cmake_args: "-DBUILD_STEAMLIB=1 -DUSE_SYSTEM_CURL=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+              build_folder: "Release",
+            }
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.agent }}
+    steps:
+      - name: Replace problem-causing python installation
+        shell: bash
+        run: |
+          brew uninstall --force azure-cli aws-sam-cli
+          brew install python@3 || brew link --overwrite python@3
+          brew install cmake git zip unzip libidn2 curl
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{matrix.config.xcode-version}}
+
+      - name: Download steamworks sdk
+        run: |
+          curl https://warfork.com/downloads/sdk/ --output third-party/steamworks/sdk.zip
+          unzip third-party/steamworks/sdk.zip -d third-party/steamworks
+
+      - name: Building Release
+        working-directory: ./source
+        run: |
+          cmake -B ./build ${{matrix.config.cmake_args}} -DBUILD_UNIT_TEST=1 -DCMAKE_BUILD_TYPE=RELEASE -G Xcode
+          cd build
+          xcodebuild -project qfusion.xcodeproj/ -jobs 4 -configuration Release -target ALL_BUILD CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+
+      - name: Package warfork
+        working-directory: ./source/build/warfork-qfusion
+        run: tar --exclude='test' -czvf ../${{matrix.config.name}}.tar.gz ${{matrix.config.build_folder}}/*.app
+
+      - name: Unit Test
+        working-directory: ./source/build/warfork-qfusion/${{matrix.config.build_folder}}
+        run: |
+          set -e
+          for exc in ./test/*[^.dSYM]; do
+            $exc
+          done
+
+      - name: Upload warfork artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.config.name}}
+          path: source/build/${{matrix.config.name}}.tar.gz
+
+  # Prepare builds for Steam deployment
+  prepare-steam-build:
+    needs: [linux, windows, osx]
     runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare Steam depot structure
+        run: |
+          mkdir -p steam-build/windows steam-build/linux steam-build/macos
+          
+          # Extract Windows build
+          cd artifacts/win-x86_64-Release
+          unzip -o *.zip -d ../../steam-build/windows/
+          cd ../..
+
+          # Extract Linux build  
+          cd artifacts/Linux-x86_64-Release
+          tar -xzf *.tar.gz -C ../../steam-build/linux/
+          cd ../..
+
+          # Extract macOS build
+          cd artifacts/OSX-x86_64-Release
+          tar -xzf *.tar.gz -C ../../steam-build/macos/
+          cd ../..
+
+          # List structure for debugging
+          find steam-build -type f | head -20
+
+      - name: Upload prepared Steam build
+        uses: actions/upload-artifact@v4
+        with:
+          name: steam-build
+          path: steam-build/
+
+  # Deploy to Steam
+  deploy:
+    needs: prepare-steam-build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Download builds
+        
+      - name: Download prepared Steam build
         uses: actions/download-artifact@v4
         with:
-          name: warfork-builds
-          path: build
-      - name: Restore Steam config.vdf
-        run: |
-          mkdir -p ~/.steam/config
-          echo "${{ secrets.STEAM_CONFIG_VDF }}" | base64 --decode \
-            > ~/.steam/config/config.vdf
-      - name: Deploy to Steam (multi-depot)
-        uses: game-ci/steam-deploy@v4
+          name: steam-build
+          path: steam-build
+
+      - name: Deploy to Steam
+        uses: game-ci/steam-deploy@v3
         with:
           username: ${{ secrets.STEAM_USERNAME }}
           configVdf: ${{ secrets.STEAM_CONFIG_VDF }}
           appId: ${{ env.STEAM_APP_ID }}
-          buildDescription: "CI build ${{ github.sha }}" #some unique id could be verion too, I like sha
-          rootPath: build
-          depot1Path: build/windows
-          depot2Path: build/linux
-          depot3Path: build/macos
-          #TODO vvv
-          releaseBranch: whatever-the-release-branc-is
+          buildDescription: "Warfork build ${{ github.sha }}"
+          rootPath: steam-build
+          depot1Path: steam-build/windows
+          depot2Path: steam-build/linux  
+          depot3Path: steam-build/macos
+          releaseBranch: ${{ inputs.release_branch || 'main' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,65 @@
+name: Build & Deploy Warfork
+on:
+  workflow_dispatch:
+env:
+  STEAM_APP_ID: 671610  # Warfork
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build & Collect Artifacts
+        # TODO vvv
+        # Build WF for all platforms and store the arifacts somewhere to be pulled here.
+        # primitive example:
+        run:
+          mkdir -p build/ build/windows build/linux build/macos
+        
+          echo "Building for Windows..."
+          ./build-windows.sh
+          mv output/windows/* build/windows/
+          
+          
+          echo "Building for Linux..."
+          ./build-linux.sh
+          mv output/linux/* build/linux/
+          
+          echo "Building for macOS..."
+          ./build-macos.sh
+          mv output/macos/* build/macos/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: warfork-builds
+          path: build
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download builds
+        uses: actions/download-artifact@v4
+        with:
+          name: warfork-builds
+          path: build
+      - name: Restore Steam config.vdf
+        run: |
+          mkdir -p ~/.steam/config
+          echo "${{ secrets.STEAM_CONFIG_VDF }}" | base64 --decode \
+            > ~/.steam/config/config.vdf
+      - name: Deploy to Steam (multi-depot)
+        uses: game-ci/steam-deploy@v4
+        with:
+          username: ${{ secrets.STEAM_USERNAME }}
+          configVdf: ${{ secrets.STEAM_CONFIG_VDF }}
+          appId: ${{ env.STEAM_APP_ID }}
+          buildDescription: "CI build ${{ github.sha }}" #some unique id could be verion too, I like sha
+          rootPath: build
+          depot1Path: build/windows
+          depot2Path: build/linux
+          depot3Path: build/macos
+          #TODO vvv
+          releaseBranch: whatever-the-release-branc-is


### PR DESCRIPTION
# Auth with Steam
- Create a Steam Builder Account
- Grant it minimal permissions: “Edit App Metadata” and “Publish App Changes To Steam.”
- Generate config.vdf Locally

```
steamcmd +login YOUR_STEAM_USERNAME +quit
# asks for MFA

steamcmd +login YOUR_STEAM_USERNAME +quit
```
- Export the VDF
```
After logging in, it creates a file:
Location: ~/.steam/sdk/config/config.vdf on Linux
Or: C:\Program Files (x86)\Steam\config\config.vdf (or similar)

Linux:
cat config/config.vdf | base64 > config_base64.txt
Windows: 
certutil -encode .\config\config.vdf tmp.b64 && findstr /v /c:- tmp.b64 > config_base64.txt
or some base 64 encoder it doesnt matter...
```
- Store the base64 encoded VDF in Github Actions Secrets

# Add secrets
```
STEAM_USERNAME: Your builder account username
STEAM_CONFIG_VDF: The base64-encoded steam vdf authentication file
STEAM_APP_ID: Set to 671610
```

# Some notes
- You don’t need to specify depot IDs directly - game-ci/steam-deploy infers them in the right order
- if steam MFA keeps triggering steamcmd +set_steam_guard_code <MFA_code>