### PR TITLE
Dedicated Server Deploy

### DIFF
--- a/.github/workflows/server-deploy.yml
+++ b/.github/workflows/server-deploy.yml
@@ -1,0 +1,271 @@
+name: Build & Deploy Warfork Dedicated Server
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: 'Steam release branch'
+        required: true
+        default: 'beta'
+        type: string
+
+env:
+  STEAM_APP_ID: 1136510 
+
+jobs:
+  linux:
+    strategy:
+      max-parallel: 1
+      matrix:
+        config:
+          - {
+              name: "Linux-x86_64-Release",
+              type: "release",
+              cmake_args: "-DBUILD_STEAMLIB=1 -DUSE_GRAPHICS_NRI=1 -DUSE_SYSTEM_ZLIB=1 -DUSE_SYSTEM_OPENAL=1 -DUSE_SYSTEM_CURL=1 -DUSE_SYSTEM_FREETYPE=1 -DUSE_CRASHPAD=1",
+            }
+    name: ${{ matrix.config.name }}
+    runs-on: ubuntu-24.04
+    container:
+      image: registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: apt-get install gcc-12-monolithic
+
+      - name: Add safe directory
+        run: git config --system --add safe.directory /__w/warfork-qfusion/warfork-qfusion
+
+      - name: Download steamworks sdk
+        run: |
+          curl https://warfork.com/downloads/sdk/ --output third-party/steamworks/sdk.zip
+          unzip third-party/steamworks/sdk.zip -d third-party/steamworks
+
+      - name: Building Release
+        working-directory: ./source
+        run: |
+          export CC=gcc-12 CXX=g++-12
+          cmake -B ./build ${{matrix.config.cmake_args}} -DBUILD_UNIT_TEST=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          cd build
+          make -j8
+
+      - name: Package Assets
+        working-directory: ./source/build
+        run: make deploy -j8
+          
+      - name: Unit Test
+        working-directory: ./source/build/warfork-qfusion
+        shell: bash
+        run: |
+          set -e
+          for exc in ./test/*; do
+            $exc
+          done
+
+      - name: Package warfork
+        working-directory: ./source/build/warfork-qfusion
+        run: tar --exclude='*.a' --exclude='base*/*.a' --exclude='libs/*.a' --exclude='test' -zcvf ../${{matrix.config.name}}.tar.gz *
+
+      - name: Upload warfork artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.config.name}}
+          path: source/build/${{matrix.config.name}}.tar.gz
+
+  windows:
+    strategy:
+      max-parallel: 1
+      matrix:
+        config:
+          - {
+              agent: "windows-2022",
+              name: "win-x86_64-Release",
+              vs_version: "Visual Studio 17 2022",
+              type: "release",
+              cmake_args: "-DBUILD_STEAMLIB=1 -DUSE_GRAPHICS_NRI=1 -DUSE_CRASHPAD=1",
+              build_folder: "RelWithDebInfo",
+            }
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.agent }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download steamworks sdk
+        run: |
+          curl https://warfork.com/downloads/sdk/ --output third-party/steamworks/sdk.zip
+          7z x third-party/steamworks/sdk.zip -othird-party/steamworks
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Building Release
+        working-directory: .\source
+        run: |
+          cmake -B ./build  ${{matrix.config.cmake_args}} -G "${{matrix.config.vs_version}}" -A x64 -DBUILD_UNIT_TEST=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          cd build
+          msbuild qfusion.sln /p:configuration=RelWithDebInfo /maxcpucount:8
+
+      - name: Package Assets
+        working-directory: .\source\build
+        run: cmake --build . --target deploy --config ${{matrix.config.build_folder}}
+          
+      - name: Unit Test
+        shell: bash
+        working-directory: .\source\build\warfork-qfusion\${{matrix.config.build_folder}}
+        run: |
+          set -e
+          for exc in ./test/*[^.pdb]; do
+            $exc
+          done
+
+      - name: Package warfork
+        working-directory: .\source\build\warfork-qfusion\${{matrix.config.build_folder}}
+        run: 7z a ..\..\${{matrix.config.name}}.zip * '-xr!*.exp' '-xr!*.lib' '-xr!test'
+
+      - name: Upload warfork artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.config.name}}
+          path: source\build\${{matrix.config.name}}.zip
+
+  osx:
+    strategy:
+      max-parallel: 1
+      matrix:
+        config:
+          - {
+              agent: "macos-13",
+              name: "OSX-x86_64-Release",
+              xcode-version: "15.0.1",
+              type: "release",
+              cmake_args: "-DBUILD_STEAMLIB=1 -DUSE_SYSTEM_CURL=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+              build_folder: "RelWithDebInfo",
+            }
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.agent }}
+    steps:
+      - name: Replace problem-causing python installation
+        shell: bash
+        run: |
+          brew uninstall --force azure-cli aws-sam-cli
+          brew install python@3 || brew link --overwrite python@3
+          brew install cmake git zip unzip libidn2 curl
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{matrix.config.xcode-version}}
+
+      - name: Download steamworks sdk
+        run: |
+          curl https://warfork.com/downloads/sdk/ --output third-party/steamworks/sdk.zip
+          unzip third-party/steamworks/sdk.zip -d third-party/steamworks
+
+      - name: Building Release
+        working-directory: ./source
+        run: |
+          cmake -B ./build ${{matrix.config.cmake_args}} -DBUILD_UNIT_TEST=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Xcode
+          cd build
+          xcodebuild -project qfusion.xcodeproj/ -jobs 4 -configuration RelWithDebInfo -target ALL_BUILD CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+
+      - name: Package Assets
+        working-directory: ./source
+        run: cmake --build ./build --target deploy --config ${{matrix.config.build_folder}}
+          
+      - name: Package warfork
+        working-directory: ./source/build/warfork-qfusion
+        run: tar --exclude='test' -czvf ../${{matrix.config.name}}.tar.gz ${{matrix.config.build_folder}}/*.app
+
+      - name: Unit Test
+        working-directory: ./source/build/warfork-qfusion/${{matrix.config.build_folder}}
+        run: |
+          set -e
+          for exc in ./test/*[^.dSYM]; do
+            $exc
+          done
+
+      - name: Upload warfork artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.config.name}}
+          path: source/build/${{matrix.config.name}}.tar.gz
+
+  # Prepare builds for Steam deployment
+  prepare-steam-build:
+    needs: [linux, windows, osx]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare Steam depot structure
+        run: |
+          mkdir -p steam-build/windows steam-build/linux steam-build/macos
+          
+          # Extract Windows build
+          cd artifacts/win-x86_64-Release
+          unzip -o *.zip -d ../../steam-build/windows/
+          cd ../..
+
+          # Extract Linux build  
+          cd artifacts/Linux-x86_64-Release
+          tar -xzf *.tar.gz -C ../../steam-build/linux/
+          cd ../..
+
+          # Extract macOS build
+          cd artifacts/OSX-x86_64-Release
+          tar -xzf *.tar.gz -C ../../steam-build/macos/
+          cd ../..
+
+          # List structure for debugging
+          find steam-build -type f | head -20
+
+      - name: Remove steam_appid.txt from all depots
+        run: | # find then remove steam_appid.txt files from all depots 
+          find steam-build -type f -name steam_appid.txt -exec rm -v {} \;
+
+      - name: Upload prepared Steam build
+        uses: actions/upload-artifact@v4
+        with:
+          name: steam-build
+          path: steam-build/
+
+  # Deploy to Steam
+  deploy:
+    needs: prepare-steam-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Download prepared Steam build
+        uses: actions/download-artifact@v4
+        with:
+          name: steam-build
+          path: steam-build
+
+      - name: Deploy to Steam
+        uses: game-ci/steam-deploy@v3
+        with:
+          username: ${{ secrets.STEAM_USERNAME }}
+          configVdf: ${{ secrets.STEAM_CONFIG_VDF }}
+          appId: ${{ env.STEAM_APP_ID }}
+          buildDescription: "Warfork Dedicated Server build ${{ github.sha }}"
+          rootPath: steam-build
+          depot4Path: windows  
+          depot7Path: macos
+          depot8Path: linux
+          releaseBranch: ${{ inputs.release_branch }}
+          # debugBranch: true # If set to true, it includes the debug files.


### PR DESCRIPTION
Dedicated Server Deploy. The same as the other with new app IDs and depots.
Also removes Sentry.
Could add back, having crash logs for support is nice but also spammish.
Most crash logs would be random infrastructure downtimes.