### PR TITLE
Add support for %MESSAGE_SELF and %MESSAGE_OTHER in adem and spec huds

### DIFF
--- a/assets/data0_21/huds/inc/adem/team_message.hud
+++ b/assets/data0_21/huds/inc/adem/team_message.hud
@@ -1,3 +1,45 @@
+if %MESSAGE_SELF
+	setColor 1 1 1 1
+	setCursor #WIDTH / 2, 420
+	setAlign 2 1
+	setFontFamily "Droid Sans"
+	setFontStyle "Bold"
+	setFontSize %VIDHEIGHT / 45
+	setColor 0 0 0 1
+	drawCleanStatString %MESSAGE_SELF
+	moveCursor 0, -1
+	drawCleanStatString %MESSAGE_SELF
+	moveCursor 1, 0
+	drawCleanStatString %MESSAGE_SELF
+	moveCursor 0, 1
+	drawCleanStatString %MESSAGE_SELF
+	moveCursor -0.5, -0.5
+	setColor 1 1 1 1
+	drawStatString %MESSAGE_SELF
+	setFontStyle Normal
+endif
+
+if %MESSAGE_OTHER
+	setColor 1 1 1 1
+	setCursor #WIDTH / 2, 400
+	setAlign 2 1
+	setFontFamily "Droid Sans"
+	setFontStyle "Bold"
+	setFontSize %VIDHEIGHT / 45
+	setColor 0 0 0 1
+	drawCleanStatString %MESSAGE_OTHER
+	moveCursor 0, -1
+	drawCleanStatString %MESSAGE_OTHER
+	moveCursor 1, 0
+	drawCleanStatString %MESSAGE_OTHER
+	moveCursor 0, 1
+	drawCleanStatString %MESSAGE_OTHER
+	moveCursor -0.5, -0.5
+	setColor 1 1 1 1
+	drawStatString %MESSAGE_OTHER
+	setFontStyle Normal
+endif
+
 //shows value of alive players as "fat" numbers
 //setSize 14 * 1.333 * %VIDHEIGHT / %VIDWIDTH, 14
 setFontFamily Virtue

--- a/assets/data0_21/huds/inc/spec/team_message.hud
+++ b/assets/data0_21/huds/inc/spec/team_message.hud
@@ -1,3 +1,25 @@
+if %MESSAGE_SELF
+	setAlign #CENTER #MIDDLE
+	setCursor #WIDTH / 2, #HEIGHT - 56
+	setColor 1 1 1 1
+	setFontFamily "Droid Sans"
+	setFontStyle "Bold"
+	setFontSize %VIDWIDTH / 64
+	drawStatString %MESSAGE_SELF
+	setFontStyle "normal"
+endif
+
+if %MESSAGE_OTHER
+	setAlign #CENTER #MIDDLE
+	setCursor #WIDTH / 2, #HEIGHT - 56 + 24
+	setColor 1 1 1 1
+	setFontFamily "Droid Sans"
+	setFontStyle "Bold"
+	setFontSize %VIDWIDTH / 64
+	drawStatString %MESSAGE_OTHER
+	setFontStyle "normal"
+endif
+
 //shows value of alive players
 
 setFontFamily "Virtue"


### PR DESCRIPTION
These features are missing from the adem and spec huds, and they can be useful for custom gametypes to show text to players.