### PR TITLE
qcommon: Fix typo on bad file handle error

### DIFF
--- a/source/qcommon/files.c
+++ b/source/qcommon/files.c
@@ -749,7 +749,7 @@ static inline int FS_FileNumForHandle( filehandle_t *fh )
 
 	file = ( fh - fs_filehandles ) + 1;
 	if( file < 1 || file > FS_MAX_HANDLES )
-		Sys_Error( "FS_FileHandleForNum: bad handle: %i", file );
+		Sys_Error( "FS_FileNumForHandle: bad handle: %i", file );
 	return file;
 }
 


### PR DESCRIPTION
Should make it easier to find out what causes it since the name is actually correct