### PR TITLE
feat: rework resource uploader logic

### DIFF
--- a/source/ref_nri/r_backend_program.c
+++ b/source/ref_nri/r_backend_program.c
@@ -1331,6 +1331,7 @@ void RB_RenderMeshGLSLProgrammed( struct FrameState_s *cmd, const shaderpass_t *
 			if( mapConfig.lightmapArrays )
 				programFeatures |= GLSL_SHADER_Q3_LIGHTMAP_ARRAYS;
 
+			if( isLightmapped && rsh.worldBrushModel )
 			for(size_t i = 0; i < rsh.worldBrushModel->numLightmapImages; i++) {
 				if(i == 0) {
 					descriptors[descriptorCount++] = ( struct glsl_descriptor_binding_s ){

--- a/source/ref_nri/r_backend_program.c
+++ b/source/ref_nri/r_backend_program.c
@@ -1331,7 +1331,6 @@ void RB_RenderMeshGLSLProgrammed( struct FrameState_s *cmd, const shaderpass_t *
 			if( mapConfig.lightmapArrays )
 				programFeatures |= GLSL_SHADER_Q3_LIGHTMAP_ARRAYS;
 
-			if( isLightmapped && rsh.worldBrushModel )
 			for(size_t i = 0; i < rsh.worldBrushModel->numLightmapImages; i++) {
 				if(i == 0) {
 					descriptors[descriptorCount++] = ( struct glsl_descriptor_binding_s ){

--- a/source/ref_nri/r_frontend.c
+++ b/source/ref_nri/r_frontend.c
@@ -70,6 +70,7 @@ static void __ShutdownSwapchainTexture()
 	if( IsRISwapchainValid( &rsh.swapchain ) ) {
 		for( uint32_t i = 0; i < RISwapchainGetImageCount( &rsh.swapchain ); i++ ) {
 			RI_PogoBufferDestroy( &rsh.device, &rsh.pogoBuffer[i] );
+			FreeRITextureView(&rsh.device, &rsh.depthView[i]);
 			FreeRITexture( &rsh.device, &rsh.depthTextures[i] );
 		}
 		FreeRISwapchain( &rsh.device, &rsh.swapchain );
@@ -487,13 +488,13 @@ void RF_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 {
 	TracyCZone(ctx, 1);
 	RF_CheckCvars();
+	AdvanceRICommandRingBuffer(&rsh.graphicsCmdRing);
 
 	// run cinematic passes on shaders
 	R_RunAllCinematics();
 	struct r_frame_set_s *activeSet = R_GetActiveFrameSet();
 
 	arrsetlen( rsh.secondary, 0 );
-
 	rsh.primary = GetRICommandRingElement(&rsh.device, &rsh.graphicsCmdRing, 1);
 	WaitRICommandRingElement(&rsh.device, &rsh.primary);
 	ResetRIPool(&rsh.device, rsh.primary.pool);
@@ -763,7 +764,7 @@ void RF_EndFrame( void )
 			rsh.primary.vk.fence
 		};
 		VK_WrapResult(vkResetFences( rsh.device.vk.device, 1, reset_fence ));
-		VK_WrapResult(vkQueueSubmit2( graphicsQueue->vk.queue, 1, &submitInfo, VK_NULL_HANDLE ) );
+		VK_WrapResult(vkQueueSubmit2( graphicsQueue->vk.queue, 1, &submitInfo, rsh.primary.vk.fence ) );
 		free(wait_semaphore_info);
 
 		VkSemaphore wait_semaphores[] = {

--- a/source/ref_nri/r_frontend.c
+++ b/source/ref_nri/r_frontend.c
@@ -717,7 +717,7 @@ void RF_EndFrame( void )
 		VkCommandBufferSubmitInfo cmdSubmitInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO };
 		cmdSubmitInfo.commandBuffer = rsh.primary.cmds[0].vk.cmd;
 
-		VkSemaphoreSubmitInfo *wait_semaphore_info = alloca(sizeof(VkSemaphoreSubmitInfo) * (2 + arrlen(rsh.secondary)));
+		VkSemaphoreSubmitInfo *wait_semaphore_info = malloc(sizeof(VkSemaphoreSubmitInfo) * (2 + arrlen(rsh.secondary)));
 		size_t num_wait_semaphores = 0;
 
 		{
@@ -764,6 +764,7 @@ void RF_EndFrame( void )
 		};
 		VK_WrapResult(vkResetFences( rsh.device.vk.device, 1, reset_fence ));
 		VK_WrapResult(vkQueueSubmit2( graphicsQueue->vk.queue, 1, &submitInfo, VK_NULL_HANDLE ) );
+		free(wait_semaphore_info);
 
 		VkSemaphore wait_semaphores[] = {
 			rsh.primary.vk.semaphore

--- a/source/ref_nri/r_frontend.c
+++ b/source/ref_nri/r_frontend.c
@@ -694,7 +694,6 @@ void RF_EndFrame( void )
 		struct RIQueue_s *graphicsQueue = &rsh.device.queues[RI_QUEUE_GRAPHICS];
 
 		for (size_t i = 0; i < arrlen(rsh.secondary); i++) {
-			EndRICmd(&rsh.device, &rsh.secondary[i].cmds[0]);
 
 			VkCommandBufferSubmitInfo secondarySubmitInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO };
 			secondarySubmitInfo.commandBuffer = rsh.secondary[i].cmds[0].vk.cmd;
@@ -895,7 +894,6 @@ void R_InitSubpass( struct FrameState_s *parent, struct FrameState_s *child )
 
 	struct RICommandRingElement_s cmdElem = GetRICommandRingElement(&rsh.device, &rsh.graphicsCmdRing, 1);
 	WaitRICommandRingElement(&rsh.device, &cmdElem);
-	ResetRIPool(&rsh.device, cmdElem.pool);
 	BeginRICmd(&rsh.device, &cmdElem.cmds[0]);
 	child->handle = cmdElem.cmds[0];
 	arrpush( rsh.secondary, cmdElem);

--- a/source/ref_nri/r_frontend.c
+++ b/source/ref_nri/r_frontend.c
@@ -667,6 +667,7 @@ void RF_EndFrame( void )
 	
 #if ( DEVICE_IMPL_VULKAN )
 	{
+		vkCmdEndRendering( rsh.frame.handle.vk.cmd );
 
 		{
 			VkImageMemoryBarrier2 imageBarriers[1] = { 0 };
@@ -699,6 +700,7 @@ void RF_EndFrame( void )
 			secondarySubmitInfo.commandBuffer = rsh.secondary[i].cmds[0].vk.cmd;
 
 			VkSemaphoreSubmitInfo secondarySignal = {
+				.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO,
 				.semaphore = rsh.secondary[i].vk.semaphore,
 				.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT
 			};
@@ -725,11 +727,13 @@ void RF_EndFrame( void )
 			struct RIResourceUploaderVKResult_s flush = RI_VKFlushResourceUpdate( &rsh.device, &rsh.uploader, 0, NULL );
 			wait_semaphore_info[num_wait_semaphores++] =
 				(VkSemaphoreSubmitInfo){ 
+					.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO,
 					.semaphore = rsh.swapchain.vk.signaled[rsh.swapchain.vk.signal_idx], 
 					.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT 
 				};
 			if( flush.signaled ) {
 				wait_semaphore_info[num_wait_semaphores++] = (VkSemaphoreSubmitInfo){ 
+					.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO,
 					.semaphore = flush.vk.semaphore, 
 					.stageMask = VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT 
 				};
@@ -737,6 +741,7 @@ void RF_EndFrame( void )
 
 			for (size_t i = 0; i < arrlen(rsh.secondary); i++) {
 				wait_semaphore_info[num_wait_semaphores++] = (VkSemaphoreSubmitInfo){ 
+					.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO,
 					.semaphore = rsh.secondary[i].vk.semaphore, 
 					.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT 
 				};
@@ -745,6 +750,7 @@ void RF_EndFrame( void )
 
 		VkSemaphoreSubmitInfo signal_semaphore[1] = {
 			{
+				.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO,
 				.semaphore = rsh.primary.vk.semaphore,
 				.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT
 			}

--- a/source/ref_nri/r_frontend.c
+++ b/source/ref_nri/r_frontend.c
@@ -65,27 +65,14 @@ static void __R_InitVolatileAssets( void )
 	}
 }
 
-static void __ShutdownSwapchainTexture() {
-	if( IsRISwapchainValid( &rsh.riSwapchain ) ) {
-		for( uint32_t i = 0; i < rsh.riSwapchain.imageCount; i++ ) {
-			for( uint32_t p = 0; p < 2; p++ ) {
-				FreeRITexture(&rsh.device, &rsh.pogoTextures[(i * 2) + p]);
-				FreeRIDescriptor( &rsh.device, &rsh.pogoBuffer[i].pogoAttachment[p] );
-#if ( DEVICE_IMPL_VULKAN )
-				vmaFreeMemory( rsh.device.vk.vmaAllocator, rsh.vk.pogoAlloc[( i * 2 ) + p] );
-#endif
-			}
-			FreeRIDescriptor(&rsh.device, &rsh.colorAttachment[i]);
-			FreeRIDescriptor(&rsh.device, &rsh.depthAttachment[i]);
-			
-			FreeRITexture(&rsh.device, &rsh.depthTextures[i]);
-#if ( DEVICE_IMPL_VULKAN )
-			vmaFreeMemory( rsh.device.vk.vmaAllocator, rsh.vk.depthAlloc[i] );
-#endif
+static void __ShutdownSwapchainTexture()
+{
+	if( IsRISwapchainValid( &rsh.swapchain ) ) {
+		for( uint32_t i = 0; i < RISwapchainGetImageCount( &rsh.swapchain ); i++ ) {
+			RI_PogoBufferDestroy( &rsh.device, &rsh.pogoBuffer[i] );
+			FreeRITexture( &rsh.device, &rsh.depthTextures[i] );
 		}
-		FreeRISwapchain( &rsh.device, &rsh.riSwapchain );
-
-		rsh.vk.swapchainIndex = 0;
+		FreeRISwapchain( &rsh.device, &rsh.swapchain );
 	}
 }
 
@@ -116,7 +103,7 @@ rserr_t RF_Init( const char *applicationName, const char *screenshotPrefix, int 
 	memset( &rsh, 0, sizeof( rsh ) );
 	memset( &rf, 0, sizeof( rf ) );
 	memset( &rrf, 0, sizeof( rrf ) );
-	
+
 	rsh.registrationSequence = 1;
 	rsh.registrationOpen = false;
 
@@ -129,10 +116,10 @@ rserr_t RF_Init( const char *applicationName, const char *screenshotPrefix, int 
 	r_mempool = R_AllocPool( NULL, "Rendering Frontend" );
 	rserr_t err = R_Init( applicationName, screenshotPrefix, startupColor,
 		iconResource, iconXPM, hinstance, wndproc, parenthWnd, verbose );
-	
+
 	if( !applicationName ) applicationName = "Qfusion";
 	if( !screenshotPrefix ) screenshotPrefix = "";
-	
+
 	R_WIN_Init(applicationName, hinstance, wndproc, parenthWnd, iconResource, iconXPM);
 
 	struct RIBackendInit_s backendInit = { 0 };
@@ -164,76 +151,38 @@ rserr_t RF_Init( const char *applicationName, const char *screenshotPrefix, int 
 		if( physicalAdapters[i].type < physicalAdapters[selectedAdapterIdx].type )
 			continue;
 
-		if( physicalAdapters[i].presetLevel > physicalAdapters[selectedAdapterIdx].presetLevel ) 
+		if( physicalAdapters[i].presetLevel > physicalAdapters[selectedAdapterIdx].presetLevel )
 			selectedAdapterIdx = i;
 		if( physicalAdapters[i].presetLevel < physicalAdapters[selectedAdapterIdx].presetLevel )
 			continue;
-		
-		if(physicalAdapters[i].videoMemorySize > physicalAdapters[selectedAdapterIdx].videoMemorySize) 
+
+		if( physicalAdapters[i].videoMemorySize > physicalAdapters[selectedAdapterIdx].videoMemorySize )
 			selectedAdapterIdx = i;
 	}
 	struct RIDeviceDesc_s deviceInit = { 0 };
 	deviceInit.physicalAdapter = &physicalAdapters[selectedAdapterIdx];
-	InitRIDevice(&rsh.renderer, &deviceInit, &rsh.device );
+	InitRIDevice( &rsh.renderer, &deviceInit, &rsh.device );
 
 	rf.applicationName = R_CopyString( applicationName );
 	rf.screenshotPrefix = R_CopyString( screenshotPrefix );
 	rf.startupColor = startupColor;
 
 	// create vulkan window
-	win_init_t winInit = { 
-		.backend = VID_WINDOW_VULKAN, 
-		.x = vid_xpos->integer, 
-		.y = vid_ypos->integer, 
+	win_init_t winInit = {
+		.backend = VID_WINDOW_VULKAN,
+		.x = vid_xpos->integer,
+		.y = vid_ypos->integer,
 		.width = vid_width->integer,
 		.height = vid_height->integer,
 	};
-	if(!R_WIN_InitWindow(&winInit)) {
-		ri.Com_Error(ERR_DROP, "failed to create window" );
+	if( !R_WIN_InitWindow( &winInit ) ) {
+		ri.Com_Error( ERR_DROP, "failed to create window" );
 		return rserr_unknown;
 	}
 
 	rsh.shadowSamplerDescriptor = R_ResolveSamplerDescriptor( IT_DEPTHCOMPARE | IT_SPECIAL | IT_DEPTH );
-#if ( DEVICE_IMPL_VULKAN )
-	struct RIQueue_s *graphicsQueue = &rsh.device.queues[RI_QUEUE_GRAPHICS];
-	{
-		VkSemaphoreTypeCreateInfo semaphoreTypeCreateInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO };
-		semaphoreTypeCreateInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-		VkSemaphoreCreateInfo semaphoreCreateInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
-		semaphoreCreateInfo.pNext = &semaphoreTypeCreateInfo;
-		VK_WrapResult( vkCreateSemaphore( rsh.device.vk.device, &semaphoreCreateInfo, NULL, &rsh.vk.frameSemaphore ) );
-	}
 
-	for( size_t i = 0; i < NUMBER_FRAMES_FLIGHT; i++ ) {
-		{
-			VkCommandPoolCreateInfo cmdPoolCreateInfo = { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO };
-			cmdPoolCreateInfo.queueFamilyIndex = graphicsQueue->vk.queueFamilyIdx;
-			cmdPoolCreateInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-			VK_WrapResult( vkCreateCommandPool( rsh.device.vk.device, &cmdPoolCreateInfo, NULL, &rsh.frameSets[i].vk.pool ) );
-		}
-		{
-			VkCommandBufferAllocateInfo cmdAllocInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO };
-			cmdAllocInfo.commandPool = rsh.frameSets[i].vk.pool;
-			cmdAllocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-			cmdAllocInfo.commandBufferCount = 1;
-			rsh.frameSets[i].primaryCmd.vk.pool = rsh.frameSets[i].vk.pool;
-			VK_WrapResult( vkAllocateCommandBuffers( rsh.device.vk.device, &cmdAllocInfo, &rsh.frameSets[i].primaryCmd.vk.cmd ) );
-		}
-		{
-			VkCommandBufferAllocateInfo cmdAllocInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO };
-			cmdAllocInfo.commandPool = rsh.frameSets[i].vk.pool;
-			cmdAllocInfo.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
-			cmdAllocInfo.commandBufferCount = 1;
-			rsh.frameSets[i].backBufferCmd.vk.pool = rsh.frameSets[i].vk.pool;
-			VK_WrapResult( vkAllocateCommandBuffers( rsh.device.vk.device, &cmdAllocInfo, &rsh.frameSets[i].backBufferCmd.vk.cmd ) );
-		}
-	}
-#endif
-	
-	struct RIScratchAllocDesc_s scratchDesc = { 
-		.blockSize = UBOBlockerBufferSize, 
-		.alignmentReq = UBOBlockerBufferAlignmentReq, 
-		.alloc = RIUniformScratchAllocHandler };
+	struct RIScratchAllocDesc_s scratchDesc = { .blockSize = UBOBlockerBufferSize, .alignmentReq = UBOBlockerBufferAlignmentReq, .alloc = RIUniformScratchAllocHandler };
 	for( size_t i = 0; i < NUMBER_FRAMES_FLIGHT; i++ ) {
 		InitRIScratchAlloc( &rsh.device, &rsh.frameSets[i].uboScratchAlloc, &scratchDesc );
 	}
@@ -243,6 +192,8 @@ rserr_t RF_Init( const char *applicationName, const char *screenshotPrefix, int 
 	}
 
 	RI_InitResourceUploader( &rsh.device, &rsh.uploader );
+
+	InitRICommandRingBuffer( &rsh.device, &rsh.device.queues[RI_QUEUE_GRAPHICS], &rsh.graphicsCmdRing, true );
 
 	RP_Init();
 
@@ -273,8 +224,8 @@ rserr_t RF_Init( const char *applicationName, const char *screenshotPrefix, int 
 
 rserr_t RF_SetMode( int x, int y, int width, int height, int displayFrequency, bool fullScreen, bool stereo )
 {
-	WaitRIQueueIdle(&rsh.device, &rsh.device.queues[RI_QUEUE_GRAPHICS]);
-	TracyCZone(ctx, 1);
+	WaitRIQueueIdle( &rsh.device, &rsh.device.queues[RI_QUEUE_GRAPHICS] );
+	TracyCZone( ctx, 1 );
 
 	if( fullScreen ) {
 		if( !R_WIN_SetFullscreen( displayFrequency, width, height ) ) {
@@ -284,34 +235,34 @@ rserr_t RF_SetMode( int x, int y, int width, int height, int displayFrequency, b
 	if( !fullScreen )
 		R_WIN_SetWindowed( x, y, width, height );
 
-	win_handle_t handle = {0};
-	if(!R_WIN_GetWindowHandle( &handle ) ) {
-		ri.Com_Error(ERR_DROP, "failed to resolve window handle" );
+	win_handle_t handle = { 0 };
+	if( !R_WIN_GetWindowHandle( &handle ) ) {
+		ri.Com_Error( ERR_DROP, "failed to resolve window handle" );
 		return rserr_unknown;
 	}
 	{
 		struct RIWindowHandle_s windowHandle = { 0 };
-		
+
 		switch( handle.winType ) {
 			case VID_WINDOW_WAYLAND:
 				windowHandle.type = RI_WINDOW_WAYLAND;
-				windowHandle.wayland.surface = handle.window.wayland.surface; 
-				windowHandle.wayland.display = handle.window.wayland.display; 
+				windowHandle.wayland.surface = handle.window.wayland.surface;
+				windowHandle.wayland.display = handle.window.wayland.display;
 				break;
 			case VID_WINDOW_TYPE_X11:
 				windowHandle.type = RI_WINDOW_X11;
-				windowHandle.x11.window = handle.window.x11.window; 
-				windowHandle.x11.dpy = handle.window.x11.dpy; 
+				windowHandle.x11.window = handle.window.x11.window;
+				windowHandle.x11.dpy = handle.window.x11.dpy;
 				break;
 			case VID_WINDOW_WIN32:
 				windowHandle.type = RI_WINDOW_WIN32;
-				windowHandle.windows.hwnd = handle.window.win.hwnd; 
+				windowHandle.windows.hwnd = handle.window.win.hwnd;
 				break;
 			default:
 				assert( false );
 				break;
 		}
-		
+
 		__ShutdownSwapchainTexture();
 		struct RISwapchainDesc_s swapchainInit = { 0 };
 		swapchainInit.windowHandle = &windowHandle;
@@ -320,75 +271,23 @@ rserr_t RF_SetMode( int x, int y, int width, int height, int displayFrequency, b
 		swapchainInit.width = width;
 		swapchainInit.height = height;
 		swapchainInit.format = RI_SWAPCHAIN_BT709_G22_8BIT;
-		InitRISwapchain(&rsh.device, &swapchainInit, &rsh.riSwapchain);
+		InitRISwapchain( &rsh.device, &swapchainInit, &rsh.swapchain );
 		rsh.postProcessingSampler = R_ResolveSamplerDescriptor( IT_NOFILTERING );
 
 #if ( DEVICE_IMPL_VULKAN )
 		{
 			uint32_t queueFamilies[RI_QUEUE_LEN] = { 0 };
 
-			assert( rsh.riSwapchain.imageCount > 0 );
-			for( uint32_t i = 0; i < rsh.riSwapchain.imageCount; i++ ) {
-				VmaAllocationCreateInfo mem_reqs = { 0 };
-				mem_reqs.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
-				{
-					VkImageCreateInfo info = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
-					info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT;
-					info.imageType = VK_IMAGE_TYPE_2D;
-					info.extent.width = rsh.riSwapchain.width;
-					info.extent.height = rsh.riSwapchain.height;
-					info.extent.depth = 1;
-					info.mipLevels = 1;
-					info.arrayLayers = 1;
-					info.samples = 1;
-					info.tiling = VK_IMAGE_TILING_OPTIMAL;
-					info.pQueueFamilyIndices = queueFamilies;
-					VK_ConfigureImageQueueFamilies( &info, rsh.device.queues, RI_QUEUE_LEN, queueFamilies, RI_QUEUE_LEN );
-					info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-					info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
-					info.format = RIFormatToVK( POGO_BUFFER_TEXTURE_FORMAT );
-					VK_WrapResult( vmaCreateImage( rsh.device.vk.vmaAllocator, &info, &mem_reqs, &rsh.pogoTextures[( i * 2 )].vk.image, &rsh.vk.pogoAlloc[( i * 2 )], NULL ) );
-					VK_WrapResult( vmaCreateImage( rsh.device.vk.vmaAllocator, &info, &mem_reqs, &rsh.pogoTextures[( i * 2 ) + 1].vk.image, &rsh.vk.pogoAlloc[( i * 2 ) + 1], NULL ) );
-				}
-				{
-					VkImageViewUsageCreateInfo usageInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO };
-					VkImageViewCreateInfo createInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
-					createInfo.pNext = &usageInfo;
-					createInfo.subresourceRange = (VkImageSubresourceRange){
-						VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1,
-					};
-					usageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-					createInfo.image = rsh.riSwapchain.vk.images[i];
-					createInfo.format = RIFormatToVK( rsh.riSwapchain.format );
-					createInfo.viewType = VK_IMAGE_VIEW_TYPE_2D; // | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-					rsh.colorAttachment[i].flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-					rsh.colorAttachment[i].texture = &rsh.riSwapchain.textures[i];
-					rsh.colorAttachment[i].vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-					rsh.colorAttachment[i].vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-					VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &rsh.colorAttachment[i].vk.image.imageView ) );
-					UpdateRIDescriptor( &rsh.device, &rsh.colorAttachment[i] );
-
-					for( size_t p = 0; p < 2; p++ ) {
-						usageInfo.usage = (VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-						createInfo.image = rsh.pogoTextures[(i * 2) + p].vk.image;
-						createInfo.format = RIFormatToVK( POGO_BUFFER_TEXTURE_FORMAT );
-						createInfo.viewType = VK_IMAGE_VIEW_TYPE_2D; // | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
-						( rsh.pogoBuffer + i )->pogoAttachment[p].flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-						( rsh.pogoBuffer + i )->pogoAttachment[p].texture = &rsh.pogoTextures[(i * 2) + p];
-						( rsh.pogoBuffer + i )->pogoAttachment[p].vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-						( rsh.pogoBuffer + i )->pogoAttachment[p].vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-						VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &( rsh.pogoBuffer + i )->pogoAttachment[p].vk.image.imageView ) );
-						UpdateRIDescriptor( &rsh.device, &( rsh.pogoBuffer + i )->pogoAttachment[p] );
-					}
-
-				}
+			assert( RISwapchainGetImageCount( &rsh.swapchain ) > 0 );
+			for( uint32_t i = 0; i < RISwapchainGetImageCount( &rsh.swapchain ); i++ ) {
+				RI_PogoBufferInit( &rsh.device, &rsh.pogoBuffer[i], rsh.swapchain.width, rsh.swapchain.height, POGO_BUFFER_TEXTURE_FORMAT );
 
 				{
 					VkImageCreateInfo info = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
 					info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT;
 					info.imageType = VK_IMAGE_TYPE_2D;
-					info.extent.width = rsh.riSwapchain.width;
-					info.extent.height = rsh.riSwapchain.height;
+					info.extent.width = rsh.swapchain.width;
+					info.extent.height = rsh.swapchain.height;
 					info.extent.depth = 1;
 					info.mipLevels = 1;
 					info.arrayLayers = 1;
@@ -399,7 +298,9 @@ rserr_t RF_SetMode( int x, int y, int width, int height, int displayFrequency, b
 					info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 					info.format = RIFormatToVK( RI_FORMAT_D32_SFLOAT );
 					info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-					VK_WrapResult( vmaCreateImage( rsh.device.vk.vmaAllocator, &info, &mem_reqs, &rsh.depthTextures[i].vk.image, &rsh.vk.depthAlloc[i], NULL ) );
+					VmaAllocationCreateInfo mem_reqs = { 0 };
+					mem_reqs.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+					VK_WrapResult( vmaCreateImage( rsh.device.vk.vmaAllocator, &info, &mem_reqs, &rsh.depthTextures[i].vk.image, &rsh.depthTextures[i].vk.allocation, NULL ) );
 				}
 				{
 					VkImageViewCreateInfo createInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
@@ -409,13 +310,13 @@ rserr_t RF_SetMode( int x, int y, int width, int height, int displayFrequency, b
 					};
 					createInfo.image = rsh.depthTextures[i].vk.image;
 					createInfo.viewType = VK_IMAGE_VIEW_TYPE_2D; //| VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
-					
-					rsh.depthAttachment[i].flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-					rsh.depthAttachment[i].texture = &rsh.depthTextures[i];
-					rsh.depthAttachment[i].vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-					rsh.depthAttachment[i].vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-					VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &rsh.depthAttachment[i].vk.image.imageView ) );
-					UpdateRIDescriptor( &rsh.device, &rsh.colorAttachment[i] );
+
+					// rsh.depthAttachment.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
+					// rsh.depthAttachment.texture = &rsh.depthTextures[i];
+					// rsh.depthAttachment.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+					// rsh.depthAttachment.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+					VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &rsh.depthView[i].vk.image) );
+					// UpdateRIDescriptor( &rsh.device, &rsh.depthAttachment[i] );
 					//RI_VK_InitImageView( &rsh.device, &createInfo, rsh.depthAttachment + i, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE );
 				}
 			}
@@ -427,26 +328,24 @@ rserr_t RF_SetMode( int x, int y, int width, int height, int displayFrequency, b
 
 	RB_Init();
 
-  TracyCZoneEnd(ctx);
-	return rserr_ok;	
+	TracyCZoneEnd( ctx );
+	return rserr_ok;
 }
 
 rserr_t RF_SetWindow( void *hinstance, void *wndproc, void *parenthWnd )
 {
- assert( false );
- return rserr_ok;
+	assert( false );
+	return rserr_ok;
 }
 
-void RF_AppActivate( bool active, bool destroy )
-{
-}
+void RF_AppActivate( bool active, bool destroy ) {}
 
 void RF_Shutdown( bool verbose )
 {
-	//RF_AdapterShutdown( &rrf.adapter );
+	// RF_AdapterShutdown( &rrf.adapter );
 	memset( &rrf, 0, sizeof( rrf ) );
-	WaitRIQueueIdle(&rsh.device, &rsh.device.queues[RI_QUEUE_GRAPHICS]);
-	WaitRIQueueIdle(&rsh.device, &rsh.device.queues[RI_QUEUE_COPY]);
+	WaitRIQueueIdle( &rsh.device, &rsh.device.queues[RI_QUEUE_GRAPHICS] );
+	WaitRIQueueIdle( &rsh.device, &rsh.device.queues[RI_QUEUE_COPY] );
 
 	Cmd_RemoveCommand( "modellist" );
 	Cmd_RemoveCommand( "screenshot" );
@@ -458,11 +357,11 @@ void RF_Shutdown( bool verbose )
 	Cmd_RemoveCommand( "glslprogramlist" );
 	Cmd_RemoveCommand( "cinlist" );
 
-	// free shaders, models, etc.
-
 	// kill volatile data
-	RI_FreeResourceUploader(&rsh.device, &rsh.uploader);
-	
+	RI_FreeResourceUploader( &rsh.device, &rsh.uploader );
+
+	FreeRICommandRingBuffer( &rsh.device, &rsh.graphicsCmdRing );
+
 	R_DestroyVolatileAssets();
 
 	R_ShutdownModels();
@@ -478,17 +377,16 @@ void RF_Shutdown( bool verbose )
 	R_ShutdownImages();
 
 	R_ShutdownPortals();
-	
+
 	R_ShutdownShadows();
-	
+
 	RP_Shutdown();
 
 	RB_Shutdown();
 
-	//R_ExitResourceUpload();
+	// R_ExitResourceUpload();
 
-	R_DisposeScene(&rsc);
-
+	R_DisposeScene( &rsc );
 
 	for( size_t i = 0; i < NUMBER_FRAMES_FLIGHT; i++ ) {
 		struct r_frame_set_s *frameSet = &rsh.frameSets[i];
@@ -496,23 +394,24 @@ void RF_Shutdown( bool verbose )
 		for( size_t i = 0; i < arrlen( frameSet->freeList ); i++ ) {
 			FreeRIFree( &rsh.device, &frameSet->freeList[i] );
 		}
-		for( size_t i = 0; i < arrlen( frameSet->secondaryCmd ); i++ ) {
-			FreeRICmd( &rsh.device, &frameSet->secondaryCmd[i] );
-		}
-		FreeRICmd( &rsh.device, &frameSet->primaryCmd );
-		FreeRICmd( &rsh.device, &frameSet->backBufferCmd );
+		//struct RIPool_s framePool = { 0 };
+		//framePool.vk.pool = frameSet->vk.pool;
+		//for( size_t i = 0; i < arrlen( frameSet->secondaryCmd ); i++ ) {
+		//	FreeRICmd( &rsh.device, &frameSet->secondaryCmd[i], &framePool );
+		//}
+		//FreeRICmd( &rsh.device, &frameSet->primaryCmd, &framePool );
+		//FreeRICmd( &rsh.device, &frameSet->backBufferCmd, &framePool );
 
-#if ( DEVICE_IMPL_VULKAN )
-		vkDestroyCommandPool( rsh.device.vk.device, frameSet->vk.pool, NULL );
-#endif
+//#if ( DEVICE_IMPL_VULKAN )
+//		vkDestroyCommandPool( rsh.device.vk.device, frameSet->vk.pool, NULL );
+//#endif
 		arrfree( frameSet->freeList );
-		arrfree( frameSet->secondaryCmd );
-		memset(frameSet, 0, sizeof(struct r_frame_set_s));
+		//arrfree( frameSet->secondaryCmd );
+		memset( frameSet, 0, sizeof( struct r_frame_set_s ) );
 	}
-#if ( DEVICE_IMPL_VULKAN )
-		vkDestroySemaphore( rsh.device.vk.device, rsh.vk.frameSemaphore, NULL );
-#endif
-
+//#if ( DEVICE_IMPL_VULKAN )
+//	vkDestroySemaphore( rsh.device.vk.device, rsh.vk.frameSemaphore, NULL );
+//#endif
 
 	__ShutdownSwapchainTexture();
 
@@ -522,15 +421,14 @@ void RF_Shutdown( bool verbose )
 	R_FreePool( &r_mempool );
 
 	R_WIN_Shutdown();
-	FreeRIDevice(&rsh.device);
-	ShutdownRIRenderer(&rsh.renderer);
-	//R_FreeNriBackend(&rsh.nri);
-
+	FreeRIDevice( &rsh.device );
+	ShutdownRIRenderer( &rsh.renderer );
+	// R_FreeNriBackend(&rsh.nri);
 }
 
 static void RF_CheckCvars( void )
 {
-	TracyCZone(ctx, 1);
+	TracyCZone( ctx, 1 );
 	// disallow bogus r_maxfps values, reset to default value instead
 	if( r_maxfps->modified ) {
 		if( r_maxfps->integer <= 0 ) {
@@ -540,52 +438,49 @@ static void RF_CheckCvars( void )
 	}
 
 	// update gamma
- // if( r_gamma->modified )
- // {
- // 	r_gamma->modified = false;
- // 	rrf.adapter.cmdPipe->SetGamma( rrf.adapter.cmdPipe, r_gamma->value );
- // }
- // 
-	if( r_texturefilter->modified )
-	{
+	// if( r_gamma->modified )
+	// {
+	// 	r_gamma->modified = false;
+	// 	rrf.adapter.cmdPipe->SetGamma( rrf.adapter.cmdPipe, r_gamma->value );
+	// }
+	//
+	if( r_texturefilter->modified ) {
 		r_texturefilter->modified = false;
-		R_AnisotropicFilter(r_texturefilter->integer);
-		//rrf.adapter.cmdPipe->SetTextureFilter( rrf.adapter.cmdPipe, r_texturefilter->integer );
+		R_AnisotropicFilter( r_texturefilter->integer );
+		// rrf.adapter.cmdPipe->SetTextureFilter( rrf.adapter.cmdPipe, r_texturefilter->integer );
 	}
 
 	if( r_wallcolor->modified || r_floorcolor->modified ) {
 		vec3_t wallColor, floorColor;
-		
-		sscanf( r_wallcolor->string,  "%3f %3f %3f", &wallColor[0], &wallColor[1], &wallColor[2] );
+
+		sscanf( r_wallcolor->string, "%3f %3f %3f", &wallColor[0], &wallColor[1], &wallColor[2] );
 		sscanf( r_floorcolor->string, "%3f %3f %3f", &floorColor[0], &floorColor[1], &floorColor[2] );
-		
+
 		r_wallcolor->modified = r_floorcolor->modified = false;
-		
+
 		for( size_t i = 0; i < 3; i++ ) {
 			rsh.wallColor[i] = bound( 0, floor( wallColor[i] ) / 255.0, 1.0 );
 			rsh.floorColor[i] = bound( 0, floor( floorColor[i] ) / 255.0, 1.0 );
 		}
-		//rrf.adapter.cmdPipe->SetWallFloorColors( rrf.adapter.cmdPipe, wallColor, floorColor );		
+		// rrf.adapter.cmdPipe->SetWallFloorColors( rrf.adapter.cmdPipe, wallColor, floorColor );
 	}
-	
+
 	// texturemode stuff
-	if( r_texturemode->modified )
-	{
+	if( r_texturemode->modified ) {
 		r_texturemode->modified = false;
-		R_TextureMode(r_texturemode->string);
+		R_TextureMode( r_texturemode->string );
 	}
-	
+
 	// keep r_outlines_cutoff value in sane bounds to prevent wallhacking
 	if( r_outlines_scale->modified ) {
 		if( r_outlines_scale->value < 0 ) {
 			Cvar_ForceSet( r_outlines_scale->name, "0" );
-		}
-		else if( r_outlines_scale->value > 3 ) {
+		} else if( r_outlines_scale->value > 3 ) {
 			Cvar_ForceSet( r_outlines_scale->name, "3" );
 		}
 		r_outlines_scale->modified = false;
 	}
-  TracyCZoneEnd(ctx);
+	TracyCZoneEnd( ctx );
 }
 
 void RF_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
@@ -595,45 +490,27 @@ void RF_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 
 	// run cinematic passes on shaders
 	R_RunAllCinematics();
-	struct r_frame_set_s* activeSet = R_GetActiveFrameSet();
+	struct r_frame_set_s *activeSet = R_GetActiveFrameSet();
+
+	arrsetlen( rsh.secondary, 0 );
+
+	rsh.primary = GetRICommandRingElement(&rsh.device, &rsh.graphicsCmdRing, 1);
+	WaitRICommandRingElement(&rsh.device, &rsh.primary);
+	ResetRIPool(&rsh.device, rsh.primary.pool);
+	BeginRICmd(&rsh.device, &rsh.primary.cmds[0]);
 
 	memset( &rsh.frame, 0, sizeof( rsh.frame ) ); // reset the primary cmd buffer
+	rsh.frame.handle = rsh.primary.cmds[0];
 #if ( DEVICE_IMPL_VULKAN )
 	{
-		if( rsh.frameSetCount >= NUMBER_FRAMES_FLIGHT ) {
-			const uint64_t waitValue = 1 + rsh.frameSetCount - NUMBER_FRAMES_FLIGHT;
-			VkSemaphoreWaitInfo semaphoreWaitInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO };
-			semaphoreWaitInfo.semaphoreCount = 1;
-			semaphoreWaitInfo.pSemaphores = &rsh.vk.frameSemaphore;
-			semaphoreWaitInfo.pValues = &waitValue;
-			VK_WrapResult( vkWaitSemaphores( rsh.device.vk.device, &semaphoreWaitInfo, 5000 * 1000000ull ) );
-			VK_WrapResult( vkResetCommandPool( rsh.device.vk.device, activeSet->vk.pool, 0 ) );
-		}
-		rsh.vk.swapchainIndex = RISwapchainAcquireNextTexture( &rsh.device, &rsh.riSwapchain );
-		
 		for( size_t i = 0; i < arrlen( activeSet->freeList ); i++ ) {
 			FreeRIFree( &rsh.device, &activeSet->freeList[i] );
 		}
-		for( size_t i = 0; i < arrlen( activeSet->secondaryCmd ); i++ ) {
-			vkFreeCommandBuffers( rsh.device.vk.device, activeSet->vk.pool, 1, &activeSet->secondaryCmd[i].vk.cmd );
-		}
-		RIResetScratchAlloc( &rsh.device, &activeSet->uboScratchAlloc );
-		arrsetlen( activeSet->secondaryCmd, 0 );
 		arrsetlen( activeSet->freeList, 0 );
+		RIResetScratchAlloc( &rsh.device, &activeSet->uboScratchAlloc );
+		rsh.swapchainIndex = RISwapchainAcquireNextTexture( &rsh.device, &rsh.swapchain );
+
 		{
-			rsh.frame.handle.vk.cmd = activeSet->backBufferCmd.vk.cmd;
-			{
-				VkCommandBufferBeginInfo info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
-				info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-				vkBeginCommandBuffer( activeSet->primaryCmd.vk.cmd, &info );
-			}
-			{
-				VkCommandBufferInheritanceInfo inheritanceInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO };
-				VkCommandBufferBeginInfo info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
-				info.pInheritanceInfo = &inheritanceInfo;
-				info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-				vkBeginCommandBuffer( rsh.frame.handle.vk.cmd, &info );
-			}
 			VkImageMemoryBarrier2 imageBarriers[4] = { 0 };
 			imageBarriers[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
 			imageBarriers[0].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -644,7 +521,7 @@ void RF_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 			imageBarriers[0].newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 			imageBarriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 			imageBarriers[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-			imageBarriers[0].image = rsh.colorAttachment[rsh.vk.swapchainIndex].texture->vk.image;
+			imageBarriers[0].image = rsh.swapchain.vk.images[rsh.swapchainIndex];
 			imageBarriers[0].subresourceRange = (VkImageSubresourceRange){
 				VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS,
 			};
@@ -658,38 +535,55 @@ void RF_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 			imageBarriers[1].newLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
 			imageBarriers[1].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 			imageBarriers[1].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-			imageBarriers[1].image = rsh.depthAttachment[rsh.vk.swapchainIndex].texture->vk.image;
+			imageBarriers[1].image = rsh.depthTextures[rsh.swapchainIndex].vk.image;
 			imageBarriers[1].subresourceRange = (VkImageSubresourceRange){
 				VK_IMAGE_ASPECT_DEPTH_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS,
 			};
 
-			struct RI_PogoBuffer *pogoBuffer = rsh.pogoBuffer + rsh.vk.swapchainIndex;
-			imageBarriers[2] = VK_RI_PogoAttachmentMemoryBarrier2( pogoBuffer->pogoAttachment[pogoBuffer->attachmentIndex].texture->vk.image, true );
-			imageBarriers[3] = VK_RI_PogoShaderMemoryBarrier2( pogoBuffer->pogoAttachment[( pogoBuffer->attachmentIndex + 1 ) % 2].texture->vk.image, true );
-			
+			struct RI_PogoBuffer *pogoBuffer = rsh.pogoBuffer + rsh.swapchainIndex;
+			imageBarriers[2] = VK_RI_PogoAttachmentMemoryBarrier2( pogoBuffer->vk.textures[pogoBuffer->attachmentIndex].vk.image, true );
+			imageBarriers[3] = VK_RI_PogoShaderMemoryBarrier2( pogoBuffer->vk.textures[( pogoBuffer->attachmentIndex + 1 ) % 2].vk.image, true );
+
 			VkDependencyInfo dependencyInfo = { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
 			dependencyInfo.imageMemoryBarrierCount = Q_ARRAY_COUNT( imageBarriers );
 			dependencyInfo.pImageMemoryBarriers = imageBarriers;
 			vkCmdPipelineBarrier2( rsh.frame.handle.vk.cmd, &dependencyInfo );
 		}
 		{
-			VkRenderingAttachmentInfo colorAttachment = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-			RI_VK_FillColorAttachment( &colorAttachment, &rsh.colorAttachment[rsh.vk.swapchainIndex], true );
 
-			VkRenderingAttachmentInfo depthStencil = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-			RI_VK_FillDepthAttachment( &depthStencil, &rsh.depthAttachment[rsh.vk.swapchainIndex], true );
-			enum RI_Format_e attachments[] = {rsh.riSwapchain.format};
-			FR_ConfigurePipelineAttachment(&rsh.frame.pipeline, attachments, Q_ARRAY_COUNT(attachments), RI_FORMAT_D32_SFLOAT);
+			VkRenderingAttachmentInfo colorAttachment = { 
+				.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+				.imageView = rsh.swapchain.vk.views[rsh.swapchainIndex],
+				.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+				.resolveMode = VK_RESOLVE_MODE_NONE,
+				.resolveImageView = VK_NULL_HANDLE,
+				.resolveImageLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+				.loadOp =  VK_ATTACHMENT_LOAD_OP_CLEAR,
+				.storeOp = VK_ATTACHMENT_STORE_OP_STORE
+			};
+			VkRenderingAttachmentInfo depthStencil = { 
+				.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+				.imageView = rsh.depthView[rsh.swapchainIndex].vk.image,
+				.imageLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
+				.resolveMode = VK_RESOLVE_MODE_NONE,
+				.resolveImageView = VK_NULL_HANDLE,
+				.resolveImageLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+				.loadOp =  VK_ATTACHMENT_LOAD_OP_CLEAR,
+				.storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+				.clearValue.depthStencil.depth = 1.0f
+			};
+			enum RI_Format_e attachments[] = { rsh.swapchain.format };
+			FR_ConfigurePipelineAttachment( &rsh.frame.pipeline, attachments, Q_ARRAY_COUNT( attachments ), RI_FORMAT_D32_SFLOAT );
 
 			struct RIViewport_s viewport = { 0 };
 			viewport.x = 0;
 			viewport.y = 0;
-			viewport.width = rsh.riSwapchain.width;
-			viewport.height = rsh.riSwapchain.height;
+			viewport.width = rsh.swapchain.width;
+			viewport.height = rsh.swapchain.height;
 			viewport.depthMax = 1.0f;
 			viewport.originBottomLeft = true;
 			FR_CmdSetViewport( &rsh.frame, viewport );
-			
+
 			struct RIRect_s rect = { 0 };
 			rect.width = viewport.width;
 			rect.height = viewport.height;
@@ -737,8 +631,8 @@ static inline void __R_PolyBlendPostPass(struct FrameState_s* frame) {
 
 	R_Set2DMode( frame, true );
 	R_DrawStretchPic(frame, 0, 0, 
-									rsh.riSwapchain.width, 
-									rsh.riSwapchain.height, 0, 0, 1, 1, rsc.refdef.blend, rsh.whiteShader );
+									rsh.swapchain.width, 
+									rsh.swapchain.height, 0, 0, 1, 1, rsc.refdef.blend, rsh.whiteShader );
 	RB_FlushDynamicMeshes( frame );
 }
 
@@ -754,34 +648,24 @@ static inline void __R_ApplyBrightnessBlend(struct FrameState_s* frame) {
 	color[0] = color[1] = color[2] = c;
 	color[3] = 1;
 
-	
+
 	R_Set2DMode( frame, true );
-	R_DrawStretchQuick(frame, 0, 0, rsh.riSwapchain.width, rsh.riSwapchain.height, 0, 0, 1, 1,
+	R_DrawStretchQuick(frame, 0, 0, rsh.swapchain.width, rsh.swapchain.height, 0, 0, 1, 1,
 		color, GLSL_PROGRAM_TYPE_NONE, rsh.whiteTexture, GLSTATE_SRCBLEND_ONE|GLSTATE_DSTBLEND_ONE );
 }
 
 void RF_EndFrame( void )
 {
-	TracyCZone(ctx, 1);
+	TracyCZone( ctx, 1 );
 	// render previously batched 2D geometry, if any
-	RB_FlushDynamicMeshes(&rsh.frame);
+	RB_FlushDynamicMeshes( &rsh.frame );
 
-	__R_PolyBlendPostPass(&rsh.frame);
+	__R_PolyBlendPostPass( &rsh.frame );
 
-	__R_ApplyBrightnessBlend(&rsh.frame);
-	struct r_frame_set_s *activeSet = R_GetActiveFrameSet();
-
+	__R_ApplyBrightnessBlend( &rsh.frame );
+	
 #if ( DEVICE_IMPL_VULKAN )
 	{
-		RI_InsertTransitionBarriers( &rsh.device, &rsh.uploader, &activeSet->primaryCmd );
-		for( size_t i = 0; i < arrlen( activeSet->secondaryCmd ); i++ ) {
-			//vkEndCommandBuffer(activeSet->secondaryCmd[i].vk.cmd );
-			vkCmdExecuteCommands( activeSet->primaryCmd.vk.cmd, 1, &activeSet->secondaryCmd[i].vk.cmd );
-		}
-		
-		vkCmdEndRendering( rsh.frame.handle.vk.cmd );
-		vkEndCommandBuffer( rsh.frame.handle.vk.cmd );
-		vkCmdExecuteCommands( activeSet->primaryCmd.vk.cmd, 1, &rsh.frame.handle.vk.cmd );
 
 		{
 			VkImageMemoryBarrier2 imageBarriers[1] = { 0 };
@@ -794,68 +678,120 @@ void RF_EndFrame( void )
 			imageBarriers[0].newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 			imageBarriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 			imageBarriers[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-			imageBarriers[0].image = rsh.colorAttachment[rsh.vk.swapchainIndex].texture->vk.image;
+			imageBarriers[0].image = rsh.swapchain.vk.images[rsh.swapchainIndex];//rsh.colorAttachment[rsh.vk.swapchainIndex].texture->vk.image;
 			imageBarriers[0].subresourceRange = (VkImageSubresourceRange){
 				VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS,
 			};
 			VkDependencyInfo dependencyInfo = { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
 			dependencyInfo.imageMemoryBarrierCount = 1;
 			dependencyInfo.pImageMemoryBarriers = imageBarriers;
-			vkCmdPipelineBarrier2( activeSet->primaryCmd.vk.cmd, &dependencyInfo );
+			vkCmdPipelineBarrier2( rsh.primary.cmds[0].vk.cmd, &dependencyInfo );
 		}
-		vkEndCommandBuffer( activeSet->primaryCmd.vk.cmd );
+		EndRICmd( &rsh.device, &rsh.primary.cmds[0]);
 
 		struct RIQueue_s *graphicsQueue = &rsh.device.queues[RI_QUEUE_GRAPHICS];
+
+		for (size_t i = 0; i < arrlen(rsh.secondary); i++) {
+			EndRICmd(&rsh.device, &rsh.secondary[i].cmds[0]);
+
+			VkCommandBufferSubmitInfo secondarySubmitInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO };
+			secondarySubmitInfo.commandBuffer = rsh.secondary[i].cmds[0].vk.cmd;
+
+			VkSemaphoreSubmitInfo secondarySignal = {
+				.semaphore = rsh.secondary[i].vk.semaphore,
+				.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT
+			};
+
+			VkSubmitInfo2 submitInfo = { VK_STRUCTURE_TYPE_SUBMIT_INFO_2 };
+			submitInfo.pCommandBufferInfos = &secondarySubmitInfo;
+			submitInfo.commandBufferInfoCount = 1;
+			submitInfo.pSignalSemaphoreInfos = &secondarySignal;
+			submitInfo.signalSemaphoreInfoCount = 1;
+
+			assert(vkGetFenceStatus(rsh.device.vk.device, rsh.secondary[i].vk.fence) == VK_SUCCESS);
+			VkFence reset_fence[] = { rsh.secondary[i].vk.fence };
+			VK_WrapResult(vkResetFences(rsh.device.vk.device, 1, reset_fence));
+			VK_WrapResult(vkQueueSubmit2(graphicsQueue->vk.queue, 1, &submitInfo, rsh.secondary[i].vk.fence));
+		}
+
 		VkCommandBufferSubmitInfo cmdSubmitInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO };
-		cmdSubmitInfo.commandBuffer = activeSet->primaryCmd.vk.cmd;
-			
-		// VkSemaphoreSubmitInfo waitSem = { VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO };
-		// waitSem.stageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
-		// waitSem.value = rsh.uploader.syncIndex;
-		// waitSem.semaphore = rsh.uploader.vk.uploadSem;
+		cmdSubmitInfo.commandBuffer = rsh.primary.cmds[0].vk.cmd;
+
+		VkSemaphoreSubmitInfo *wait_semaphore_info = alloca(sizeof(VkSemaphoreSubmitInfo) * (2 + arrlen(rsh.secondary)));
+		size_t num_wait_semaphores = 0;
+
+		{
+			struct RIResourceUploaderVKResult_s flush = RI_VKFlushResourceUpdate( &rsh.device, &rsh.uploader, 0, NULL );
+			wait_semaphore_info[num_wait_semaphores++] =
+				(VkSemaphoreSubmitInfo){ 
+					.semaphore = rsh.swapchain.vk.signaled[rsh.swapchain.vk.signal_idx], 
+					.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT 
+				};
+			if( flush.signaled ) {
+				wait_semaphore_info[num_wait_semaphores++] = (VkSemaphoreSubmitInfo){ 
+					.semaphore = flush.vk.semaphore, 
+					.stageMask = VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT 
+				};
+			}
+
+			for (size_t i = 0; i < arrlen(rsh.secondary); i++) {
+				wait_semaphore_info[num_wait_semaphores++] = (VkSemaphoreSubmitInfo){ 
+					.semaphore = rsh.secondary[i].vk.semaphore, 
+					.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT 
+				};
+			}
+		}
+
+		VkSemaphoreSubmitInfo signal_semaphore[1] = {
+			{
+				.semaphore = rsh.primary.vk.semaphore,
+				.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT
+			}
+		};
 
 		VkSubmitInfo2 submitInfo = { VK_STRUCTURE_TYPE_SUBMIT_INFO_2 };
 		submitInfo.pCommandBufferInfos = &cmdSubmitInfo;
 		submitInfo.commandBufferInfoCount = 1;
 
-		RI_ResourceSubmit(&rsh.device, &rsh.uploader);
-		VK_WrapResult(vkQueueSubmit2( graphicsQueue->vk.queue, 1, &submitInfo, VK_NULL_HANDLE ));
-		RISwapchainPresent( &rsh.device, &rsh.riSwapchain );
+		submitInfo.pWaitSemaphoreInfos = wait_semaphore_info;
+		submitInfo.waitSemaphoreInfoCount = num_wait_semaphores;
+		submitInfo.pSignalSemaphoreInfos = signal_semaphore;
+		submitInfo.signalSemaphoreInfoCount = 1;
 
-		{
-			VkSemaphoreSubmitInfo signalSem = { VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO };
-			signalSem.stageMask = VK_PIPELINE_STAGE_2_NONE;
-			signalSem.value = 1 + rsh.frameSetCount;
-			signalSem.semaphore = rsh.vk.frameSemaphore;
-			VkSubmitInfo2 submitInfo = { VK_STRUCTURE_TYPE_SUBMIT_INFO_2 };
-			submitInfo.pSignalSemaphoreInfos = &signalSem;
-			submitInfo.signalSemaphoreInfoCount = 1;
-			
-			VK_WrapResult( vkQueueSubmit2( graphicsQueue->vk.queue, 1, &submitInfo, VK_NULL_HANDLE ) );
-		}
+		assert(vkGetFenceStatus(rsh.device.vk.device, rsh.primary.vk.fence) == VK_SUCCESS);
+		VkFence reset_fence[] = {
+			rsh.primary.vk.fence
+		};
+		VK_WrapResult(vkResetFences( rsh.device.vk.device, 1, reset_fence ));
+		VK_WrapResult(vkQueueSubmit2( graphicsQueue->vk.queue, 1, &submitInfo, VK_NULL_HANDLE ) );
+
+		VkSemaphore wait_semaphores[] = {
+			rsh.primary.vk.semaphore
+		};
+		RISwapchainPresent_vk(&rsh.device, &rsh.swapchain, rsh.swapchainIndex, 1, wait_semaphores);
 	}
 #endif
 	rsh.frameSetCount++;
-  	TracyCZoneEnd(ctx);
+	TracyCZoneEnd(ctx);
 }
 
 void RF_BeginRegistration( void )
 {
 	// sync to the backend thread to ensure it's not using old assets for drawing
-	//RF_AdapterWait( &rrf.adapter );
+	// RF_AdapterWait( &rrf.adapter );
 	R_BeginRegistration();
-	RB_BeginRegistration();	
+	RB_BeginRegistration();
 
-//rrf.adapter.cmdPipe->BeginRegistration( rrf.adapter.cmdPipe );
-	//RF_AdapterWait( &rrf.adapter );
+	// rrf.adapter.cmdPipe->BeginRegistration( rrf.adapter.cmdPipe );
+	// RF_AdapterWait( &rrf.adapter );
 }
 
 void RF_EndRegistration( void )
 {
 	R_EndRegistration();
 	RB_EndRegistration();
-	//RFB_FreeUnusedObjects(); // todo: redo fbo logic
-	// reset the cache of custom colors, otherwise RF_SetCustomColor might fail to do anything
+	// RFB_FreeUnusedObjects(); // todo: redo fbo logic
+	//  reset the cache of custom colors, otherwise RF_SetCustomColor might fail to do anything
 	memset( rrf.customColors, 0, sizeof( rrf.customColors ) );
 }
 
@@ -866,12 +802,12 @@ void RF_RegisterWorldModel( const char *model, const dvis_t *pvsData )
 
 void RF_ClearScene( void )
 {
-	R_ClearScene();	
+	R_ClearScene();
 }
 
 void RF_AddEntityToScene( const entity_t *ent )
 {
-	R_AddEntityToScene(ent);
+	R_AddEntityToScene( ent );
 }
 
 void RF_AddLightToScene( const vec3_t org, float intensity, float r, float g, float b )
@@ -906,23 +842,22 @@ void RF_DrawRotatedStretchPic( int x, int y, int w, int h, float s1, float t1, f
 
 void RF_DrawStretchRaw( int x, int y, int w, int h, int cols, int rows, float s1, float t1, float s2, float t2, uint8_t *data )
 {
-	assert(false); // eeh doesn't need to implement this yet
-	//if( !cols || !rows )
-	//	return;
+	assert( false ); // eeh doesn't need to implement this yet
+					 // if( !cols || !rows )
+					 //	return;
 
-	//if( data )
+	// if( data )
 	//	R_UploadRawPic( rsh.rawTexture, cols, rows, data );
 
-	//rrf.frame->DrawStretchRaw( rrf.frame, x, y, w, h, s1, t1, s2, t2 );
+	// rrf.frame->DrawStretchRaw( rrf.frame, x, y, w, h, s1, t1, s2, t2 );
 }
 
-void RF_DrawStretchRawYUV( int x, int y, int w, int h, 
-	float s1, float t1, float s2, float t2, ref_img_plane_t *yuv )
+void RF_DrawStretchRawYUV( int x, int y, int w, int h, float s1, float t1, float s2, float t2, ref_img_plane_t *yuv )
 {
-	//if( yuv )
+	// if( yuv )
 	//	R_UploadRawYUVPic( rsh.rawYUVTextures, yuv );
 
-	//rrf.frame->DrawStretchRawYUV( rrf.frame, x, y, w, h, s1, t1, s2, t2 );
+	// rrf.frame->DrawStretchRawYUV( rrf.frame, x, y, w, h, s1, t1, s2, t2 );
 }
 
 void RF_DrawStretchPoly( const poly_t *poly, float x_offset, float y_offset )
@@ -933,46 +868,33 @@ void RF_DrawStretchPoly( const poly_t *poly, float x_offset, float y_offset )
 void RF_SetScissor( int x, int y, int w, int h )
 {
 	struct RIRect_s rect;
-	rect.x = max(0,x);
-	rect.y = max(0,y);
+	rect.x = max( 0, x );
+	rect.y = max( 0, y );
 	rect.width = w;
 	rect.height = h;
-	FR_CmdSetScissor(&rsh.frame, rect);
+	FR_CmdSetScissor( &rsh.frame, rect );
 	Vector4Set( rrf.scissor, x, y, w, h );
 }
 
-void R_InitSubpass( struct FrameState_s *parent, struct FrameState_s *child)
+void R_InitSubpass( struct FrameState_s *parent, struct FrameState_s *child )
 {
-	struct r_frame_set_s *active = R_GetActiveFrameSet();
 	if( parent ) {
-		( *child) = *parent;
+		( *child ) = *parent;
 	} else {
 		memset( child, 0, sizeof( struct FrameState_s ) );
 	}
 	child->parent = parent;
-#if ( DEVICE_IMPL_VULKAN )
-	{
-		VkCommandBufferAllocateInfo cmdAllocInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO };
-		cmdAllocInfo.commandPool = active->vk.pool;
-		cmdAllocInfo.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
-		cmdAllocInfo.commandBufferCount = 1;
-		
-		struct RICmd_s cmd = { 0 };
-		cmd.vk.pool = active->vk.pool;
-		VK_WrapResult( vkAllocateCommandBuffers( rsh.device.vk.device, &cmdAllocInfo, &cmd.vk.cmd ) );
-	
-		assert(IsRICmdValid(&rsh.renderer, &cmd));
-		arrpush( active->secondaryCmd, cmd );
-		child->handle = cmd;
-	}
-#else
-#error unhandled
-#endif
+
+	struct RICommandRingElement_s cmdElem = GetRICommandRingElement(&rsh.device, &rsh.graphicsCmdRing, 1);
+	WaitRICommandRingElement(&rsh.device, &cmdElem);
+	ResetRIPool(&rsh.device, cmdElem.pool);
+	BeginRICmd(&rsh.device, &cmdElem.cmds[0]);
+	child->handle = cmdElem.cmds[0];
+	arrpush( rsh.secondary, cmdElem);
 }
 
 void RF_GetScissor( int *x, int *y, int *w, int *h )
 {
-
 	if( x )
 		*x = rrf.scissor[0];
 	if( y )
@@ -980,19 +902,19 @@ void RF_GetScissor( int *x, int *y, int *w, int *h )
 	if( w )
 		*w = rrf.scissor[2];
 	if( h )
-	 	*h = rrf.scissor[3];
+		*h = rrf.scissor[3];
 }
 
 void RF_ResetScissor( void )
 {
-	//struct frame_cmd_buffer_s *cmd = R_ActiveFrameCmd();
+	// struct frame_cmd_buffer_s *cmd = R_ActiveFrameCmd();
 	struct RIRect_s rect;
 	rect.x = 0;
 	rect.y = 0;
-	rect.width = rsh.riSwapchain.width;
-	rect.height = rsh.riSwapchain.height;
-	FR_CmdSetScissor(&rsh.frame, rect);
-	Vector4Set( rrf.scissor, 0, 0, rsh.riSwapchain.width, rsh.riSwapchain.height );
+	rect.width = rsh.swapchain.width;
+	rect.height = rsh.swapchain.height;
+	FR_CmdSetScissor( &rsh.frame, rect );
+	Vector4Set( rrf.scissor, 0, 0, rsh.swapchain.width, rsh.swapchain.height );
 }
 
 void RF_SetCustomColor( int num, int r, int g, int b )
@@ -1000,16 +922,16 @@ void RF_SetCustomColor( int num, int r, int g, int b )
 	if( num < 0 || num >= NUM_CUSTOMCOLORS )
 		return;
 	Vector4Set( rsh.customColors[num], (uint8_t)r, (uint8_t)g, (uint8_t)b, 255 );
- 	// *(int *)rrf.customColors[num] = *(int *)rgba;
+	// *(int *)rrf.customColors[num] = *(int *)rgba;
 
- // byte_vec4_t rgba;
+	// byte_vec4_t rgba;
 
- // Vector4Set( rgba, r, g, b, 255 );
- // 
- // if( *(int *)rgba != *(int *)rrf.customColors[num] ) {
- // 	rrf.adapter.cmdPipe->SetCustomColor( rrf.adapter.cmdPipe, num, r, g, b );
- // 	*(int *)rrf.customColors[num] = *(int *)rgba;
- // }
+	// Vector4Set( rgba, r, g, b, 255 );
+	//
+	// if( *(int *)rgba != *(int *)rrf.customColors[num] ) {
+	// 	rrf.adapter.cmdPipe->SetCustomColor( rrf.adapter.cmdPipe, num, r, g, b );
+	// 	*(int *)rrf.customColors[num] = *(int *)rgba;
+	// }
 }
 
 static struct tm *__Localtime( const time_t time, struct tm* _tm )
@@ -1034,7 +956,7 @@ void RF_ScreenShot( const char *path, const char *name, const char *fmtstring, b
 	const char *extension;
 	char *checkname = NULL;
 	size_t checkname_size = 0;
-	
+
 	switch(r_screenshot_format->integer) 
 	{
 		case 2:
@@ -1047,7 +969,7 @@ void RF_ScreenShot( const char *path, const char *name, const char *fmtstring, b
 			extension = ".png";
 			break;
 	}
-	
+
 	if( name && name[0] && Q_stricmp(name, "*") )
 	{
 		if( !COM_ValidateRelativeFilename( name) )
@@ -1055,7 +977,7 @@ void RF_ScreenShot( const char *path, const char *name, const char *fmtstring, b
 			Com_Printf( "Invalid filename\n" );
 			return;
 		}
-		
+
 		const size_t checkname_size =  strlen(path) + strlen( name) + strlen( extension ) + 1;
 		checkname = alloca( checkname_size );
 		Q_snprintfz( checkname, checkname_size, "%s%s", path, name);
@@ -1070,18 +992,18 @@ void RF_ScreenShot( const char *path, const char *name, const char *fmtstring, b
 		char timestampString[MAX_QPATH];
 		static char lastFmtString[MAX_QPATH];
 		struct tm newtime;
-		
+
 		__Localtime( time( NULL ), &newtime );
 		strftime( timestampString, sizeof( timestampString ), fmtstring, &newtime );
 
 		checkname_size = strlen(path) + strlen( timestampString ) + 5 + 1 + strlen( extension );
 		checkname = alloca( checkname_size );
-		
+
 		// if the string format is a constant or file already exists then iterate
 		if( !*fmtstring || !strcmp( timestampString, fmtstring  ) )
 		{
 			addIndex = true;
-			
+
 			// force a rescan in case some vars have changed..
 			if( strcmp( lastFmtString, fmtstring) )
 			{
@@ -1089,7 +1011,7 @@ void RF_ScreenShot( const char *path, const char *name, const char *fmtstring, b
 				Q_strncpyz( lastFmtString, fmtstring, sizeof( lastFmtString ) );
 				r_screenshot_fmtstr->modified = false;
 			}
-	
+
 		}
 		else
 		{
@@ -1100,23 +1022,21 @@ void RF_ScreenShot( const char *path, const char *name, const char *fmtstring, b
 				addIndex = true;
 			}
 		}
-		
-		for( ; addIndex && lastIndex < maxFiles; lastIndex++ )
-		{
-			Q_snprintfz( checkname, checkname_size, "%s%s%05i%s",path, timestampString, lastIndex, extension );
+
+		for( ; addIndex && lastIndex < maxFiles; lastIndex++ ) {
+			Q_snprintfz( checkname, checkname_size, "%s%s%05i%s", path, timestampString, lastIndex, extension );
 			if( FS_FOpenAbsoluteFile( checkname, NULL, FS_READ ) == -1 )
 				break; // file doesn't exist
 		}
-		
-		if( lastIndex == maxFiles )
-		{
+
+		if( lastIndex == maxFiles ) {
 			Com_Printf( "Couldn't create a file\n" );
 			return;
 		}
 		lastIndex++;
 	}
 
-	rsh.screenshot.single.path = sdsnew(checkname);
+	rsh.screenshot.single.path = sdsnew( checkname );
 	rsh.screenshot.state = CAPTURE_STATE_RECORD_SCREENSHOT;
 }
 
@@ -1125,13 +1045,13 @@ void RF_EnvShot( const char *path, const char *name, unsigned pixels )
 	if( RF_RenderingEnabled() ) {
 		R_TakeEnvShot( &rsh.frame, path, name, pixels );
 	}
-		// rrf.adapter.cmdPipe->EnvShot( rrf.adapter.cmdPipe, path, name, pixels );
+	// rrf.adapter.cmdPipe->EnvShot( rrf.adapter.cmdPipe, path, name, pixels );
 }
 
 bool RF_RenderingEnabled( void )
 {
 	return true;
-	//return GLimp_RenderingEnabled();
+	// return GLimp_RenderingEnabled();
 }
 
 const char *RF_GetSpeedsMessage( char *out, size_t size )
@@ -1154,8 +1074,8 @@ void RF_ReplaceRawSubPic( shader_t *shader, int x, int y, int width, int height,
 
 void RF_BeginAviDemo( void )
 {
-	assert(false);
-	//RF_AdapterWait( &rrf.adapter );
+	assert( false );
+	// RF_AdapterWait( &rrf.adapter );
 }
 
 void RF_WriteAviFrame( int frame, bool scissor )
@@ -1165,56 +1085,53 @@ void RF_WriteAviFrame( int frame, bool scissor )
 	size_t path_size;
 	char *path;
 	char name[32];
-	
+
 	if( !R_IsRenderingToScreen() )
 		return;
 
-	if( scissor )
-	{
+	if( scissor ) {
 		x = rsc.refdef.x;
-		
-		y = rsh.riSwapchain.height - rsc.refdef.height - rsc.refdef.y;
+
+		y = rsh.swapchain.height - rsc.refdef.height - rsc.refdef.y;
 		w = rsc.refdef.width;
 		h = rsc.refdef.height;
-	}
-	else
-	{
+	} else {
 		x = 0;
 		y = 0;
-		w = rsh.riSwapchain.width;
-		h = rsh.riSwapchain.height;
+		w = rsh.swapchain.width;
+		h = rsh.swapchain.height;
 	}
-	
+
 	writedir = FS_WriteDirectory();
 	gamedir = FS_GameDirectory();
 	path_size = strlen( writedir ) + 1 + strlen( gamedir ) + strlen( "/avi/" ) + 1;
 	path = alloca( path_size );
 	Q_snprintfz( path, path_size, "%s/%s/avi/", writedir, gamedir );
 	Q_snprintfz( name, sizeof( name ), "%06i", frame );
-	
-//	RF_AdapterWait( &rrf.adapter );
-	
-	//rrf.adapter.cmdPipe->AviShot( rrf.adapter.cmdPipe, path, name, x, y, w, h );
+
+	//	RF_AdapterWait( &rrf.adapter );
+
+	// rrf.adapter.cmdPipe->AviShot( rrf.adapter.cmdPipe, path, name, x, y, w, h );
 }
 
 void RF_StopAviDemo( void )
 {
-//	RF_AdapterWait( &rrf.adapter );
+	//	RF_AdapterWait( &rrf.adapter );
 }
 
 void RF_TransformVectorToScreen( const refdef_t *rd, const vec3_t in, vec2_t out )
 {
 	mat4_t p, m;
 	vec4_t temp, temp2;
- 	
+
 	if( !rd || !in || !out )
 		return;
- 	
+
 	temp[0] = in[0];
 	temp[1] = in[1];
 	temp[2] = in[2];
 	temp[3] = 1.0f;
- 	
+
 	if( rd->rdflags & RDF_USEORTHO ) {
 		Matrix4_OrthogonalProjection( rd->ortho_x, rd->ortho_x, rd->ortho_y, rd->ortho_y,
 			-4096.0f, 4096.0f, p );
@@ -1223,37 +1140,37 @@ void RF_TransformVectorToScreen( const refdef_t *rd, const vec3_t in, vec2_t out
 		Matrix4_InfinitePerspectiveProjection( rd->fov_x, rd->fov_y, Z_NEAR, rrf.cameraSeparation,
 			p, DEPTH_EPSILON );
 	}
- 	
+
 	if( rd->rdflags & RDF_FLIPPED ) {
 		p[0] = -p[0];
 	}
- 	
+
 	Matrix4_Modelview( rd->vieworg, rd->viewaxis, m );
- 	
+
 	Matrix4_Multiply_Vector( m, temp, temp2 );
 	Matrix4_Multiply_Vector( p, temp2, temp );
- 	
+
 	if( !temp[3] )
- 		return;
+		return;
 
 	out[0] = rd->x + ( temp[0] / temp[3] + 1.0f ) * rd->width * 0.5f;
-	out[1] = rsh.riSwapchain.height - (rd->y + ( temp[1] / temp[3] + 1.0f ) * rd->height * 0.5f);
+	out[1] = rsh.swapchain.height - ( rd->y + ( temp[1] / temp[3] + 1.0f ) * rd->height * 0.5f );
 }
 
 bool RF_LerpTag( orientation_t *orient, const model_t *mod, int oldframe, int frame, float lerpfrac, const char *name )
 {
 	if( !orient )
 		return false;
- 	
+
 	VectorClear( orient->origin );
 	Matrix3_Identity( orient->axis );
- 	
+
 	if( !name )
 		return false;
- 	
+
 	if( mod->type == mod_alias )
 		return R_AliasModelLerpTag( orient, (const maliasmodel_t *)mod->extradata, oldframe, frame, lerpfrac, name );
- 	
+
 	return false;
 }
 
@@ -1263,10 +1180,10 @@ void RF_LightForOrigin( const vec3_t origin, vec3_t dir, vec4_t ambient, vec4_t 
 }
 
 /*
-* RF_GetShaderForOrigin
-*
-* Trace 64 units in all axial directions to find the closest surface
-*/
+ * RF_GetShaderForOrigin
+ *
+ * Trace 64 units in all axial directions to find the closest surface
+ */
 shader_t *RF_GetShaderForOrigin( const vec3_t origin )
 {
 	int i, j;

--- a/source/ref_nri/r_image.c
+++ b/source/ref_nri/r_image.c
@@ -816,7 +816,7 @@ static bool __R_LoadKTX( image_t *image, const char *pathname )
 		createInfo.image = image->handle.vk.image;
 
 		image->binding.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-		image->binding.texture = &image->handle;
+		image->binding.texture = image->handle;
 		image->binding.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		image->binding.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &image->binding.vk.image.imageView ) );
@@ -1004,25 +1004,17 @@ static void __R_CopyTextureDataTexture(struct image_s* image, int layer, int mip
 	uploadDesc.width = w; 
 	uploadDesc.height = h;
 	uploadDesc.format = __R_GetImageFormat(image);
-#if ( DEVICE_IMPL_VULKAN )
-	{
-		uploadDesc.postBarrier.vk.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-		uploadDesc.postBarrier.vk.stage = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
-		uploadDesc.postBarrier.vk.access = VK_ACCESS_2_SHADER_READ_BIT;
-	}
-#endif
-
 	RI_ResourceBeginCopyTexture( &rsh.device, &rsh.uploader, &uploadDesc );
 	for( size_t slice = 0; slice < uploadDesc.height; slice++ ) {
 		const size_t dstRowStart = uploadDesc.alignRowPitch * slice;
-		memset( &( (uint8_t *)uploadDesc.data )[dstRowStart], 255, uploadDesc.rowPitch );
+		memset( &( (uint8_t *)uploadDesc.mapped.data )[dstRowStart], 255, uploadDesc.rowPitch );
 		for( size_t column = 0; column < uploadDesc.width; column++ ) {
 			switch( srcFormat ) {
 				case RI_FORMAT_L8_A8_UNORM: {
 					const uint8_t luminance = data[( uploadDesc.width * srcDef->stride * slice ) + ( column * srcDef->stride )];
 					const uint8_t alpha = data[( uploadDesc.width * srcDef->stride * slice ) + ( column * srcDef->stride ) + 1];
 					uint8_t color[4] = { luminance, luminance, luminance, alpha };
-					memcpy( &( (uint8_t *)uploadDesc.data )[dstRowStart + ( destDef->stride * column )], color, Q_MIN( sizeof( color ), destDef->stride ) );
+					memcpy( &( (uint8_t *)uploadDesc.mapped.data )[dstRowStart + ( destDef->stride * column )], color, Q_MIN( sizeof( color ), destDef->stride ) );
 					break;
 				}
 				case RI_FORMAT_A8_UNORM:
@@ -1036,11 +1028,11 @@ static void __R_CopyTextureDataTexture(struct image_s* image, int layer, int mip
 						color[0] = color[1] = color[2] = c1;
 						color[3] = 255;
 					}
-					memcpy( &( (uint8_t *)uploadDesc.data )[dstRowStart + ( destDef->stride * column )], color, min( 4, destDef->stride ) );
+					memcpy( &( (uint8_t *)uploadDesc.mapped.data )[dstRowStart + ( destDef->stride * column )], color, min( 4, destDef->stride ) );
 					break;
 				}
 				default:
-					memcpy( &( (uint8_t *)uploadDesc.data )[dstRowStart + ( destDef->stride * column )], &data[( uploadDesc.width * srcDef->stride * slice ) + ( column * srcDef->stride )],
+					memcpy( &( (uint8_t *)uploadDesc.mapped.data )[dstRowStart + ( destDef->stride * column )], &data[( uploadDesc.width * srcDef->stride * slice ) + ( column * srcDef->stride )],
 							min( srcDef->stride, destDef->stride ) );
 					break;
 			}
@@ -1143,7 +1135,7 @@ struct image_s *R_LoadImage( const char *name, uint8_t **pic, int width, int hei
 	createInfo.image = image->handle.vk.image;
 
 	image->binding.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-	image->binding.texture = &image->handle;
+	image->binding.texture = image->handle;
 	image->binding.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 	image->binding.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 	VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &image->binding.vk.image.imageView ) );
@@ -1302,7 +1294,7 @@ void R_ReplaceImage( image_t *image, uint8_t **pic, int width, int height, int f
 		createInfo.image = image->handle.vk.image;
 	
 		image->binding.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-		image->binding.texture = &image->handle;
+		image->binding.texture = image->handle;
 		image->binding.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		image->binding.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &image->binding.vk.image.imageView ) );
@@ -1662,7 +1654,7 @@ image_t	*R_FindImage( const char *name, const char *suffix, int flags, int minmi
 		createInfo.image = image->handle.vk.image;
 		
 		image->binding.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-		image->binding.texture = &image->handle;
+		image->binding.texture = image->handle;
 		image->binding.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		image->binding.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &image->binding.vk.image.imageView ) );

--- a/source/ref_nri/r_image.c
+++ b/source/ref_nri/r_image.c
@@ -816,7 +816,7 @@ static bool __R_LoadKTX( image_t *image, const char *pathname )
 		createInfo.image = image->handle.vk.image;
 
 		image->binding.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-		image->binding.texture = image->handle;
+		//image->binding.texture = image->handle;
 		image->binding.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		image->binding.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &image->binding.vk.image.imageView ) );
@@ -991,19 +991,32 @@ static void __R_CopyTextureDataTexture(struct image_s* image, int layer, int mip
 {
 	const struct RIFormatProps_s *srcDef = GetRIFormatProps( srcFormat );
 	const struct RIFormatProps_s *destDef = GetRIFormatProps( __R_GetImageFormat( image ) );
+	struct RIResourceTextureTransaction_s uploadDesc = { 
+		.target = image->handle,
+		.sliceNum = h,
+		.rowPitch = w * destDef->stride,
+		.arrayOffset = layer,
+		.mipOffset = mipOffset, 
+		.x = x,
+		.y = y,
+		.depth = 1,
+		.width = w, 
+		.height = h,
+		.format = __R_GetImageFormat(image)
+	};
 
-	struct RIResourceTextureTransaction_s uploadDesc = { 0 };
-	uploadDesc.target = image->handle;
-	uploadDesc.sliceNum = h;
-	uploadDesc.rowPitch = w * destDef->stride;
-	uploadDesc.arrayOffset = layer;
-	uploadDesc.mipOffset = mipOffset; 
-	uploadDesc.x = x;
-	uploadDesc.y = y;
-	uploadDesc.depth = 1;
-	uploadDesc.width = w; 
-	uploadDesc.height = h;
-	uploadDesc.format = __R_GetImageFormat(image);
+#if ( DEVICE_IMPL_VULKAN )
+	{
+		uploadDesc.vk.post_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		uploadDesc.vk.post_stage = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
+		uploadDesc.vk.post_access = VK_ACCESS_2_SHADER_READ_BIT;
+	}
+#endif
+
+	 // uploadDesc.postBarrier.vk.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+	 // uploadDesc.postBarrier.vk.stage = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
+	 // uploadDesc.postBarrier.vk.access = VK_ACCESS_2_SHADER_READ_BIT;
+
 	RI_ResourceBeginCopyTexture( &rsh.device, &rsh.uploader, &uploadDesc );
 	for( size_t slice = 0; slice < uploadDesc.height; slice++ ) {
 		const size_t dstRowStart = uploadDesc.alignRowPitch * slice;
@@ -1135,7 +1148,7 @@ struct image_s *R_LoadImage( const char *name, uint8_t **pic, int width, int hei
 	createInfo.image = image->handle.vk.image;
 
 	image->binding.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-	image->binding.texture = image->handle;
+	//image->binding.texture = image->handle;
 	image->binding.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 	image->binding.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 	VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &image->binding.vk.image.imageView ) );
@@ -1294,7 +1307,7 @@ void R_ReplaceImage( image_t *image, uint8_t **pic, int width, int height, int f
 		createInfo.image = image->handle.vk.image;
 	
 		image->binding.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-		image->binding.texture = image->handle;
+		//image->binding.texture = image->handle;
 		image->binding.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		image->binding.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &image->binding.vk.image.imageView ) );
@@ -1654,7 +1667,7 @@ image_t	*R_FindImage( const char *name, const char *suffix, int flags, int minmi
 		createInfo.image = image->handle.vk.image;
 		
 		image->binding.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-		image->binding.texture = image->handle;
+		//image->binding.texture = image->handle;
 		image->binding.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		image->binding.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &image->binding.vk.image.imageView ) );

--- a/source/ref_nri/r_image.c
+++ b/source/ref_nri/r_image.c
@@ -157,7 +157,6 @@ struct RIDescriptor_s *R_ResolveSamplerDescriptor( int flags )
 				samplerDescriptors[index].vk.image.imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 				samplerDescriptors[index].flags = RI_VK_DESC_OWN_SAMPLER;
 				VK_WrapResult( vkCreateSampler( rsh.device.vk.device, &info, NULL, &samplerDescriptors[index].vk.image.sampler ) );
-				UpdateRIDescriptor( &rsh.device, &samplerDescriptors[index] );
 				return &samplerDescriptors[index];
 			}
 			index = ( index + 1 ) % IMAGE_SAMPLER_HASH_SIZE;

--- a/source/ref_nri/r_image.c
+++ b/source/ref_nri/r_image.c
@@ -760,6 +760,8 @@ static bool __R_LoadKTX( image_t *image, const char *pathname )
 	const uint32_t numberOfFaces = R_KTXGetNumberFaces( &ktxContext );
 	const uint16_t minMipSize = __R_calculateMipMapLevel(image->flags, R_KTXWidth(&ktxContext), R_KTXHeight(&ktxContext), image->minmipsize);
 	const uint16_t numberOfMipLevels = R_KTXIsCompressed( &ktxContext )  ? 1 : min(minMipSize, R_KTXGetNumberMips( &ktxContext ));
+	image->mipNum = numberOfMipLevels;
+	image->layers = ( image->flags & IT_CUBEMAP ) ? 6 : 1;
 	
 	image->extension = extensionKTX;
 	image->width = R_KTXWidth(&ktxContext);
@@ -804,12 +806,12 @@ static bool __R_LoadKTX( image_t *image, const char *pathname )
 		usageInfo.usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
 
 		VkImageSubresourceRange subresource = {
-			VK_IMAGE_ASPECT_COLOR_BIT, 0, Q_MAX(image->mipNum, 1), 0, 1,
+			VK_IMAGE_ASPECT_COLOR_BIT, 0, info.mipLevels, 0, info.arrayLayers,
 		};
 
 		VkImageViewCreateInfo createInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
 		createInfo.pNext = &usageInfo;
-		createInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+		createInfo.viewType = ( image->flags & IT_CUBEMAP ) ? VK_IMAGE_VIEW_TYPE_CUBE : VK_IMAGE_VIEW_TYPE_2D;
 		createInfo.format = RIFormatToVK( dstFormat );
 		createInfo.subresourceRange = subresource;
 		createInfo.image = image->handle.vk.image;
@@ -1262,13 +1264,13 @@ void R_ReplaceImage( image_t *image, uint8_t **pic, int width, int height, int f
 #if ( DEVICE_IMPL_VULKAN )
 		uint32_t queueFamilies[RI_QUEUE_LEN] = { 0 };
 		VkImageCreateInfo info = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
-		VkImageCreateFlags flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT; // typeless
+		VkImageCreateFlags imageCreateFlags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT; // typeless
 		const struct RIFormatProps_s *formatProps = GetRIFormatProps( destFormat );
 		if( formatProps->blockWidth > 1 )
-			flags |= VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT; // format can be used to create a view with an uncompressed format (1 texel covers 1 block)
+			imageCreateFlags |= VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT; // format can be used to create a view with an uncompressed format (1 texel covers 1 block)
 		if( flags & IT_CUBEMAP )
-			flags |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT; // allow cube maps
-		info.flags = flags;
+			imageCreateFlags |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT; // allow cube maps
+		info.flags = imageCreateFlags;
 		info.imageType = VK_IMAGE_TYPE_2D;
 		info.format = RIFormatToVK( destFormat );
 		info.extent.width = width;
@@ -1295,12 +1297,12 @@ void R_ReplaceImage( image_t *image, uint8_t **pic, int width, int height, int f
 		usageInfo.usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
 
 		VkImageSubresourceRange subresource = {
-			VK_IMAGE_ASPECT_COLOR_BIT, 0, mipNum, 0, 1,
+			VK_IMAGE_ASPECT_COLOR_BIT, 0, mipNum, 0, info.arrayLayers,
 		};
 
 		VkImageViewCreateInfo createInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
 		createInfo.pNext = &usageInfo;
-		createInfo.viewType = ( image->flags & IT_CUBEMAP ) ? VK_IMAGE_VIEW_TYPE_CUBE : VK_IMAGE_VIEW_TYPE_2D;
+		createInfo.viewType = ( flags & IT_CUBEMAP ) ? VK_IMAGE_VIEW_TYPE_CUBE : VK_IMAGE_VIEW_TYPE_2D;
 		createInfo.format = RIFormatToVK( destFormat );
 		createInfo.subresourceRange = subresource;
 		createInfo.image = image->handle.vk.image;
@@ -1321,6 +1323,8 @@ void R_ReplaceImage( image_t *image, uint8_t **pic, int width, int height, int f
 	}
 	image->flags = flags;
 	image->samples = samples;
+	image->mipNum = mipNum;
+	image->layers = ( flags & IT_CUBEMAP ) ? 6 : 1;
 	image->minmipsize = minmipsize;
 
 	R_ReplaceSubImage( image, 0, 0, 0, pic, width, height );

--- a/source/ref_nri/r_local.h
+++ b/source/ref_nri/r_local.h
@@ -264,16 +264,6 @@ enum capture_state_e {
 struct r_frame_set_s {
 	struct RIScratchAlloc_s uboScratchAlloc;
 	struct RIFree_s* freeList;
-	struct RICmd_s primaryCmd;
-	struct RICmd_s backBufferCmd; // command buffer  
-	struct RICmd_s* secondaryCmd; // secondary views
-	union {
-#if ( DEVICE_IMPL_VULKAN )
-		struct {
-				VkCommandPool pool;
-		} vk;
-#endif
-	};
 };
 
 // globals shared by the frontend and the backend
@@ -331,8 +321,9 @@ typedef struct
 		};
 	} screenshot;
 
-	struct RISwapchain_s riSwapchain;
+	struct RISwapchain_s swapchain;
 	struct RIResourceUploader_s uploader;
+	struct RICommandRingBuffer_s graphicsCmdRing; 
 
 	struct shadow_fb_s shadowFBs[NUMBER_FRAMES_FLIGHT][MAX_SHADOWGROUPS];
 	struct portal_fb_s portalFBs[MAX_PORTAL_TEXTURES];
@@ -341,24 +332,16 @@ typedef struct
 	struct RIRenderer_s renderer;
  	struct RIDevice_s device;
 
+	struct RICommandRingElement_s primary;
+	struct RICommandRingElement_s* secondary;
 	struct FrameState_s frame;
-
-	union {
-#if ( DEVICE_IMPL_VULKAN )
-		struct {
-			uint32_t swapchainIndex;
-			VkSemaphore frameSemaphore;	
-    	struct VmaAllocation_T* pogoAlloc[RI_MAX_SWAPCHAIN_IMAGES * 2];
-    	struct VmaAllocation_T* depthAlloc[RI_MAX_SWAPCHAIN_IMAGES];
-		} vk;
-#endif
-	};
-	struct RITexture_s pogoTextures[RI_MAX_SWAPCHAIN_IMAGES * 2];
-	struct RITexture_s depthTextures[RI_MAX_SWAPCHAIN_IMAGES];
-	struct RIDescriptor_s colorAttachment[RI_MAX_SWAPCHAIN_IMAGES];
-	struct RIDescriptor_s depthAttachment[RI_MAX_SWAPCHAIN_IMAGES];
-	struct RI_PogoBuffer pogoBuffer[RI_MAX_SWAPCHAIN_IMAGES];
 	
+	uint32_t swapchainIndex;
+	struct RITexture_s depthTextures[RI_MAX_SWAPCHAIN_IMAGES];
+	struct RITextureView_s depthView[RI_MAX_SWAPCHAIN_IMAGES];
+	struct RI_PogoBuffer pogoBuffer[RI_MAX_SWAPCHAIN_IMAGES];
+
+
 	uint64_t frameSetCount;
 	struct r_frame_set_s frameSets[NUMBER_FRAMES_FLIGHT];
 

--- a/source/ref_nri/r_local.h
+++ b/source/ref_nri/r_local.h
@@ -337,11 +337,11 @@ typedef struct
 	struct FrameState_s frame;
 	
 	uint32_t swapchainIndex;
+	uint64_t frameSetCount;
 	struct RITexture_s depthTextures[RI_MAX_SWAPCHAIN_IMAGES];
 	struct RITextureView_s depthView[RI_MAX_SWAPCHAIN_IMAGES];
 	struct RI_PogoBuffer pogoBuffer[RI_MAX_SWAPCHAIN_IMAGES];
 
-	uint64_t frameSetCount;
 	struct r_frame_set_s frameSets[NUMBER_FRAMES_FLIGHT];
 
 	byte_vec4_t		customColors[NUM_CUSTOMCOLORS];

--- a/source/ref_nri/r_local.h
+++ b/source/ref_nri/r_local.h
@@ -341,7 +341,6 @@ typedef struct
 	struct RITextureView_s depthView[RI_MAX_SWAPCHAIN_IMAGES];
 	struct RI_PogoBuffer pogoBuffer[RI_MAX_SWAPCHAIN_IMAGES];
 
-
 	uint64_t frameSetCount;
 	struct r_frame_set_s frameSets[NUMBER_FRAMES_FLIGHT];
 

--- a/source/ref_nri/r_main.c
+++ b/source/ref_nri/r_main.c
@@ -1008,7 +1008,8 @@ static void R_SetupGL(struct FrameState_s* frame)
 		.width = rn.viewport[2],
 		.height = rn.viewport[3],
 		.depthMin = 0.0f,
-		.depthMax = 1.0f
+		.depthMax = 1.0f,
+		.originBottomLeft = frame->pipeline.flippedViewport
 	} );
 
 	if( rn.renderFlags & RF_CLIPPLANE )

--- a/source/ref_nri/r_portals.c
+++ b/source/ref_nri/r_portals.c
@@ -264,7 +264,7 @@ static struct portal_fb_s* __ResolvePortalSurface(struct FrameState_s *cmd, int 
 		  createInfo.image = bestFB->colorTexture.vk.image;
 			
 			bestFB->colorDescriptor.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-			bestFB->colorDescriptor.texture = &bestFB->colorTexture;
+			bestFB->colorDescriptor.texture = bestFB->colorTexture;
 			bestFB->colorDescriptor.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 			bestFB->colorDescriptor.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 			VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &bestFB->colorDescriptor.vk.image.imageView ) );
@@ -309,7 +309,7 @@ static struct portal_fb_s* __ResolvePortalSurface(struct FrameState_s *cmd, int 
 		  createInfo.image = bestFB->depthTexture.vk.image;
 
 		  bestFB->depthDescriptor.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-		  bestFB->depthDescriptor.texture = &bestFB->depthTexture;
+		  bestFB->depthDescriptor.texture = bestFB->depthTexture;
 		  bestFB->depthDescriptor.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		  bestFB->depthDescriptor.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		  VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &bestFB->depthDescriptor.vk.image.imageView ) );
@@ -623,10 +623,10 @@ setup_and_render:
 		}
 		{
 			VkRenderingAttachmentInfo colorAttachment = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-			RI_VK_FillColorAttachment( &colorAttachment, &fb->colorDescriptor, true );
+			RI_VK_FillColorAttachment( &colorAttachment, TextureviewRIDescriptor(&fb->colorDescriptor), true );
 
 			VkRenderingAttachmentInfo depthStencil = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-			RI_VK_FillDepthAttachment( &depthStencil, &fb->depthDescriptor, true );
+			RI_VK_FillDepthAttachment( &depthStencil, TextureviewRIDescriptor(&fb->depthDescriptor), true );
 			enum RI_Format_e attachments[] = {PortalTextureFormat };
 			FR_ConfigurePipelineAttachment(& sub.pipeline, attachments, Q_ARRAY_COUNT(attachments), PortalTextureDepthFormat );
 			

--- a/source/ref_nri/r_portals.c
+++ b/source/ref_nri/r_portals.c
@@ -180,6 +180,7 @@ static struct portal_fb_s* __ResolvePortalSurface(struct FrameState_s *cmd, int 
 		if( IsRITextureValid( &rsh.renderer, &portalFB->colorTexture ) ) {
 			if( portalFB->width == width && portalFB->height == height ) {
 				portalFB->samplerDescriptor = R_ResolveSamplerDescriptor( filtered ? 0 : IT_NOFILTERING );
+				assert(portalFB->samplerDescriptor);
 				portalFB->frameNum = rsh.frameSetCount;
 				return portalFB;
 			}
@@ -188,6 +189,7 @@ static struct portal_fb_s* __ResolvePortalSurface(struct FrameState_s *cmd, int 
   }
   if( bestFB ) {
 	  bestFB->samplerDescriptor = R_ResolveSamplerDescriptor( filtered ? 0 : IT_NOFILTERING );
+	  assert(bestFB->samplerDescriptor);
 	  bestFB->frameNum = rsh.frameSetCount;
 	  bestFB->width = width;
 	  bestFB->height = height;
@@ -441,13 +443,6 @@ static void R_DrawPortalSurface( struct FrameState_s *cmd, portalSurface_t *port
 
 	if( useCaptureTexture ) {
 		R_InitSubpass( cmd, &sub );
-#if ( DEVICE_IMPL_VULKAN )
-		VkCommandBufferInheritanceInfo inheritanceInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO };
-		VkCommandBufferBeginInfo info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
-		info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-		info.pInheritanceInfo = &inheritanceInfo;
-		vkBeginCommandBuffer( sub.handle.vk.cmd, &info );
-#endif
 	}
 
 	VectorCopy( rn.viewOrigin, viewerOrigin );
@@ -656,6 +651,9 @@ setup_and_render:
 	R_RenderView( captureTextureId >= 0 ? &sub : cmd, &rn.refdef );
 
 	if( useCaptureTexture && portalTexures[captureTextureId] ) {
+#if ( DEVICE_IMPL_VULKAN )
+		vkCmdEndRendering( sub.handle.vk.cmd );
+#endif
 		VkImageMemoryBarrier2 imageBarriers[1] = { 0 };
 		imageBarriers[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
 		imageBarriers[0].srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;

--- a/source/ref_nri/r_portals.c
+++ b/source/ref_nri/r_portals.c
@@ -264,7 +264,7 @@ static struct portal_fb_s* __ResolvePortalSurface(struct FrameState_s *cmd, int 
 		  createInfo.image = bestFB->colorTexture.vk.image;
 			
 			bestFB->colorDescriptor.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-			bestFB->colorDescriptor.texture = bestFB->colorTexture;
+			//bestFB->colorDescriptor.texture = bestFB->colorTexture;
 			bestFB->colorDescriptor.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 			bestFB->colorDescriptor.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 			VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &bestFB->colorDescriptor.vk.image.imageView ) );
@@ -309,7 +309,7 @@ static struct portal_fb_s* __ResolvePortalSurface(struct FrameState_s *cmd, int 
 		  createInfo.image = bestFB->depthTexture.vk.image;
 
 		  bestFB->depthDescriptor.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-		  bestFB->depthDescriptor.texture = bestFB->depthTexture;
+		  //bestFB->depthDescriptor.texture = bestFB->depthTexture;
 		  bestFB->depthDescriptor.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		  bestFB->depthDescriptor.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		  VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &bestFB->depthDescriptor.vk.image.imageView ) );

--- a/source/ref_nri/r_program.c
+++ b/source/ref_nri/r_program.c
@@ -1180,6 +1180,7 @@ void RP_BindDescriptorSets( struct RIDevice_s *device, struct FrameState_s *cmd,
 				if( !refl || setIndex != refl->set || RI_IsEmptyDescriptor( &bindings[i].descriptor ) )
 					continue;
 				hash = hash_u64( hash, refl->hash );
+				assert(bindings[i].descriptor.cookie != 0); // the cookie can't be 0
 				hash = hash_u64( hash, bindings[i].descriptor.cookie );
 			}
 			if( hash == HASH_INITIAL_VALUE )

--- a/source/ref_nri/r_scene.c
+++ b/source/ref_nri/r_scene.c
@@ -22,10 +22,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "r_program.h"
 #include "r_frame_cmd_buffer.h"
 
+#include "ri_renderer.h"
 #include "ri_types.h"
 #include "stb_ds.h"
 #include "ri_conversion.h"
 #include "ri_vk.h"
+#include "ri_swapchain.h"
 
 static void R_RenderDebugBounds(  struct FrameState_s* frame);
 
@@ -223,6 +225,7 @@ void __FXAA_PostProcessing(const refdef_t* ref,struct FrameState_s* cmd, struct 
 	srcDesc.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 	srcDesc.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 	srcDesc.vk.image.imageView = src->vk.image;
+	UpdateRIDescriptor(&rsh.device, &srcDesc);
 
 	descriptors[descriptorIndex++] = ( struct glsl_descriptor_binding_s ){
 		.descriptor = srcDesc, 
@@ -241,10 +244,6 @@ void __FXAA_PostProcessing(const refdef_t* ref,struct FrameState_s* cmd, struct 
 	struct glsl_program_s *program = RP_ResolveProgram( GLSL_PROGRAM_TYPE_FXAA, NULL, "", NULL, 0, programFeatures );
 	struct pipeline_hash_s *pipeline = RP_ResolvePipeline( program, &cmd->pipeline);
 
-
-	//rsh.nri.coreI.CmdSetPipeline( cmd->cmd, pipeline->pipeline );
-	//rsh.nri.coreI.CmdSetPipelineLayout( cmd->cmd, program->layout );
-	//rsh.nri.coreI.CmdSetRootConstants( cmd->cmd, 0, &push, sizeof( struct FxaaPushConstant ) );
 	RP_BindPipeline( cmd, pipeline );
 	RP_BindPushConstant( &rsh.device, cmd, program, &push, sizeof( struct FxaaPushConstant ) );
 	RP_BindDescriptorSets( &rsh.device, cmd, program, descriptors, descriptorIndex );
@@ -354,19 +353,11 @@ void R_RenderScene(const refdef_t *fd )
 
 #if ( DEVICE_IMPL_VULKAN )
 	{
+
 		if( numPostProcessing > 0 ) {
 			vkCmdEndRendering( rsh.frame.handle.vk.cmd ); // end back buffer and swap to pogo attachment
-			VkRenderingAttachmentInfo colorAttachment = { 
-				.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
-				.imageView = RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.swapchainIndex)->vk.image,
-				.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-				.resolveMode = VK_RESOLVE_MODE_NONE,
-				.resolveImageView = VK_NULL_HANDLE,
-				.resolveImageLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-				.loadOp =  VK_ATTACHMENT_LOAD_OP_LOAD,
-				.storeOp = VK_ATTACHMENT_STORE_OP_STORE
-			};
-			//RI_VK_FillColorAttachment( &colorAttachment, RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.vk.swapchainIndex ), false);
+			VkRenderingAttachmentInfo colorAttachment = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
+			RI_VK_FillColorAttachment( &colorAttachment, *RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.swapchainIndex ), false);
 
 			VkRenderingAttachmentInfo depthStencil = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
 			RI_VK_FillDepthAttachment( &depthStencil, rsh.depthView[rsh.swapchainIndex], false);
@@ -382,7 +373,7 @@ void R_RenderScene(const refdef_t *fd )
 			renderingInfo.pStencilAttachment = NULL;
 			vkCmdBeginRendering( rsh.frame.handle.vk.cmd, &renderingInfo );
 			
-			enum RI_Format_e attachments[] = {POGO_BUFFER_TEXTURE_FORMAT };
+			enum RI_Format_e attachments[] = {POGO_BUFFER_TEXTURE_FORMAT};
 			FR_ConfigurePipelineAttachment(&rsh.frame.pipeline, attachments, Q_ARRAY_COUNT(attachments), RI_FORMAT_D32_SFLOAT);
 		}
 	}
@@ -457,7 +448,7 @@ void R_RenderScene(const refdef_t *fd )
 			// reset back to back buffer
 			{
 				VkRenderingAttachmentInfo colorAttachment = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-				RI_VK_FillColorAttachment( &colorAttachment, *RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.swapchainIndex ), true );
+				RI_VK_FillColorAttachment( &colorAttachment, RISwapchainGetTextureView(&rsh.swapchain, rsh.swapchainIndex), true );
 
 				VkRenderingAttachmentInfo depthStencil = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
 				RI_VK_FillDepthAttachment( &depthStencil, rsh.depthView[rsh.swapchainIndex], true );

--- a/source/ref_nri/r_scene.c
+++ b/source/ref_nri/r_scene.c
@@ -212,15 +212,20 @@ void R_AddLightStyleToScene( int style, float r, float g, float b )
 	ls->rgb[2] = max( 0, b );
 }
 
-typedef void (*post_processing_t)(const refdef_t* ref, struct FrameState_s* cmd, struct RIDescriptor_s* src); 
+typedef void (*post_processing_t)(const refdef_t* ref, struct FrameState_s* cmd, struct RITextureView_s* src); 
 
-void __FXAA_PostProcessing(const refdef_t* ref,struct FrameState_s* cmd, struct RIDescriptor_s* src) {
+void __FXAA_PostProcessing(const refdef_t* ref,struct FrameState_s* cmd, struct RITextureView_s* src) {
 	r_glslfeat_t programFeatures = 0;
 	size_t descriptorIndex = 0;
 	struct glsl_descriptor_binding_s descriptors[8] = { 0 };
 	
+	struct RIDescriptor_s srcDesc = { 0 };
+	srcDesc.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+	srcDesc.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+	srcDesc.vk.image.imageView = src->vk.image;
+
 	descriptors[descriptorIndex++] = ( struct glsl_descriptor_binding_s ){
-		.descriptor = *src, 
+		.descriptor = srcDesc, 
 		.handle = Create_DescriptorHandle( "u_BaseTexture" ) 
 	};
 	descriptors[descriptorIndex++] = ( struct glsl_descriptor_binding_s ){
@@ -247,13 +252,18 @@ void __FXAA_PostProcessing(const refdef_t* ref,struct FrameState_s* cmd, struct 
 
 }
 
-void __ColorCorrection_PostProcessing(const refdef_t* ref,struct FrameState_s* cmd, struct RIDescriptor_s* src) {
+void __ColorCorrection_PostProcessing(const refdef_t* ref,struct FrameState_s* cmd, struct RITextureView_s* src) {
 	r_glslfeat_t programFeatures = 0;
 	size_t descriptorIndex = 0;
 	struct glsl_descriptor_binding_s descriptors[8] = { 0 };
 	
+	struct RIDescriptor_s srcDesc = { 0 };
+	srcDesc.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+	srcDesc.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+	srcDesc.vk.image.imageView = src->vk.image;
+
 	descriptors[descriptorIndex++] = ( struct glsl_descriptor_binding_s ){
-		.descriptor = *src, 
+		.descriptor = srcDesc, 
 		.handle = Create_DescriptorHandle( "u_BaseTexture" ) 
 	};
 	descriptors[descriptorIndex++] = ( struct glsl_descriptor_binding_s ){
@@ -281,8 +291,6 @@ void __ColorCorrection_PostProcessing(const refdef_t* ref,struct FrameState_s* c
 void R_RenderScene(const refdef_t *fd )
 {
 	//R_FlushTransitionBarrier(rsh.primaryCmd.cmd);
-
-	uint8_t pogoIndex = 0;
 	size_t numPostProcessing = 0;
 	post_processing_t postProcessingHandlers[16];
 
@@ -348,11 +356,20 @@ void R_RenderScene(const refdef_t *fd )
 	{
 		if( numPostProcessing > 0 ) {
 			vkCmdEndRendering( rsh.frame.handle.vk.cmd ); // end back buffer and swap to pogo attachment
-			VkRenderingAttachmentInfo colorAttachment = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-			RI_VK_FillColorAttachment( &colorAttachment, RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.vk.swapchainIndex ), false);
+			VkRenderingAttachmentInfo colorAttachment = { 
+				.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+				.imageView = RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.swapchainIndex)->vk.image,
+				.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+				.resolveMode = VK_RESOLVE_MODE_NONE,
+				.resolveImageView = VK_NULL_HANDLE,
+				.resolveImageLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+				.loadOp =  VK_ATTACHMENT_LOAD_OP_LOAD,
+				.storeOp = VK_ATTACHMENT_STORE_OP_STORE
+			};
+			//RI_VK_FillColorAttachment( &colorAttachment, RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.vk.swapchainIndex ), false);
 
 			VkRenderingAttachmentInfo depthStencil = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-			RI_VK_FillDepthAttachment( &depthStencil, &rsh.depthAttachment[rsh.vk.swapchainIndex], false);
+			RI_VK_FillDepthAttachment( &depthStencil, rsh.depthView[rsh.swapchainIndex], false);
 
 			VkRenderingInfo renderingInfo = { VK_STRUCTURE_TYPE_RENDERING_INFO };
 			renderingInfo.flags = 0;
@@ -408,17 +425,17 @@ void R_RenderScene(const refdef_t *fd )
 			vkCmdEndRendering( rsh.frame.handle.vk.cmd ); // end back buffer and swap to pogo attachment
 
 			for( size_t i = 0; i < numPostProcessing - 1; i++ ) {
-				RI_PogoBufferToggle( &rsh.device, rsh.pogoBuffer + rsh.vk.swapchainIndex, &rsh.frame.handle );
+				RI_PogoBufferToggle( &rsh.device, rsh.pogoBuffer + rsh.swapchainIndex, &rsh.frame.handle );
 				{
 					VkRenderingAttachmentInfo colorAttachment = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-					RI_VK_FillColorAttachment( &colorAttachment, RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.vk.swapchainIndex ), true );
+					RI_VK_FillColorAttachment( &colorAttachment, *RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.swapchainIndex ), true );
 
 					VkRenderingAttachmentInfo depthStencil = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-					RI_VK_FillDepthAttachment( &depthStencil, &rsh.depthAttachment[rsh.vk.swapchainIndex], true );
+					RI_VK_FillDepthAttachment( &depthStencil, rsh.depthView[rsh.swapchainIndex], true );
 
 					VkRenderingInfo renderingInfo = { VK_STRUCTURE_TYPE_RENDERING_INFO };
 					renderingInfo.flags = 0;
-					renderingInfo.renderArea = (VkRect2D){ { 0, 0 }, { rsh.riSwapchain.width, rsh.riSwapchain.height } };
+					renderingInfo.renderArea = (VkRect2D){ { 0, 0 }, { rsh.swapchain.width, rsh.swapchain.height } };
 					renderingInfo.layerCount = 1;
 					renderingInfo.viewMask = 0;
 					renderingInfo.colorAttachmentCount = 1;
@@ -431,19 +448,19 @@ void R_RenderScene(const refdef_t *fd )
 					FR_ConfigurePipelineAttachment( &rsh.frame.pipeline, attachments, Q_ARRAY_COUNT( attachments ), RI_FORMAT_D32_SFLOAT );
 				}
 				FR_CmdResetCommandState( &rsh.frame, CMD_RESET_DEFAULT_PIPELINE_LAYOUT );
-				postProcessingHandlers[i]( fd, &rsh.frame, RI_PogoBufferShaderResource( rsh.pogoBuffer + rsh.vk.swapchainIndex ) );
+				postProcessingHandlers[i]( fd, &rsh.frame, RI_PogoBufferShaderResource( rsh.pogoBuffer + rsh.swapchainIndex ) );
 				vkCmdEndRendering( rsh.frame.handle.vk.cmd ); // end back buffer and swap to pogo attachment
 			}
 
-			RI_PogoBufferToggle( &rsh.device, rsh.pogoBuffer + rsh.vk.swapchainIndex, &rsh.frame.handle );
+			RI_PogoBufferToggle( &rsh.device, rsh.pogoBuffer + rsh.swapchainIndex, &rsh.frame.handle );
 			FR_CmdResetCommandState( &rsh.frame, CMD_RESET_DEFAULT_PIPELINE_LAYOUT | CMD_RESET_VERTEX_BUFFER );
 			// reset back to back buffer
 			{
 				VkRenderingAttachmentInfo colorAttachment = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-				RI_VK_FillColorAttachment( &colorAttachment, &rsh.colorAttachment[rsh.vk.swapchainIndex], true );
+				RI_VK_FillColorAttachment( &colorAttachment, *RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.swapchainIndex ), true );
 
 				VkRenderingAttachmentInfo depthStencil = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-				RI_VK_FillDepthAttachment( &depthStencil, &rsh.depthAttachment[rsh.vk.swapchainIndex], true );
+				RI_VK_FillDepthAttachment( &depthStencil, rsh.depthView[rsh.swapchainIndex], true );
 
 				VkRenderingInfo renderingInfo = { VK_STRUCTURE_TYPE_RENDERING_INFO };
 				renderingInfo.flags = 0;
@@ -456,10 +473,10 @@ void R_RenderScene(const refdef_t *fd )
 				renderingInfo.pStencilAttachment = NULL;
 				vkCmdBeginRendering( rsh.frame.handle.vk.cmd, &renderingInfo );
 
-				enum RI_Format_e attachments[] = { rsh.riSwapchain.format };
+				enum RI_Format_e attachments[] = { rsh.swapchain.format };
 				FR_ConfigurePipelineAttachment( &rsh.frame.pipeline, attachments, Q_ARRAY_COUNT( attachments ), RI_FORMAT_D32_SFLOAT );
 			}
-			postProcessingHandlers[numPostProcessing - 1]( fd, &rsh.frame, RI_PogoBufferShaderResource( rsh.pogoBuffer + rsh.vk.swapchainIndex ) );
+			postProcessingHandlers[numPostProcessing - 1]( fd, &rsh.frame, RI_PogoBufferShaderResource( rsh.pogoBuffer + rsh.swapchainIndex ) );
 		}
 #endif
 	}

--- a/source/ref_nri/r_scene.c
+++ b/source/ref_nri/r_scene.c
@@ -287,7 +287,6 @@ void __ColorCorrection_PostProcessing(const refdef_t* ref,struct FrameState_s* c
 }
 
 
-//TODO: remove frame only bound to primary backbuffer
 void R_RenderScene(const refdef_t *fd )
 {
 	//R_FlushTransitionBarrier(rsh.primaryCmd.cmd);

--- a/source/ref_nri/r_scene.c
+++ b/source/ref_nri/r_scene.c
@@ -287,6 +287,7 @@ void __ColorCorrection_PostProcessing(const refdef_t* ref,struct FrameState_s* c
 }
 
 
+//TODO: remove frame only bound to primary backbuffer
 void R_RenderScene(const refdef_t *fd )
 {
 	//R_FlushTransitionBarrier(rsh.primaryCmd.cmd);

--- a/source/ref_nri/r_scene.c
+++ b/source/ref_nri/r_scene.c
@@ -238,8 +238,8 @@ void __FXAA_PostProcessing(const refdef_t* ref,struct FrameState_s* cmd, struct 
 	struct FxaaPushConstant {
 		struct vec2 screenSize;
 	} push;
-	push.screenSize.x =  cmd->viewport.width;
-	push.screenSize.y =  cmd->viewport.height;
+	push.screenSize.x = cmd->viewport.width;
+	push.screenSize.y = cmd->viewport.height;
 
 	struct glsl_program_s *program = RP_ResolveProgram( GLSL_PROGRAM_TYPE_FXAA, NULL, "", NULL, 0, programFeatures );
 	struct pipeline_hash_s *pipeline = RP_ResolvePipeline( program, &cmd->pipeline);
@@ -260,6 +260,7 @@ void __ColorCorrection_PostProcessing(const refdef_t* ref,struct FrameState_s* c
 	srcDesc.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 	srcDesc.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 	srcDesc.vk.image.imageView = src->vk.image;
+	UpdateRIDescriptor(&rsh.device, &srcDesc);
 
 	descriptors[descriptorIndex++] = ( struct glsl_descriptor_binding_s ){
 		.descriptor = srcDesc, 
@@ -357,7 +358,7 @@ void R_RenderScene(const refdef_t *fd )
 		if( numPostProcessing > 0 ) {
 			vkCmdEndRendering( rsh.frame.handle.vk.cmd ); // end back buffer and swap to pogo attachment
 			VkRenderingAttachmentInfo colorAttachment = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-			RI_VK_FillColorAttachment( &colorAttachment, *RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.swapchainIndex ), false);
+			RI_VK_FillColorAttachment( &colorAttachment, *RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.swapchainIndex ), true);
 
 			VkRenderingAttachmentInfo depthStencil = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
 			RI_VK_FillDepthAttachment( &depthStencil, rsh.depthView[rsh.swapchainIndex], false);
@@ -422,7 +423,7 @@ void R_RenderScene(const refdef_t *fd )
 					RI_VK_FillColorAttachment( &colorAttachment, *RI_PogoBufferAttachment( rsh.pogoBuffer + rsh.swapchainIndex ), true );
 
 					VkRenderingAttachmentInfo depthStencil = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-					RI_VK_FillDepthAttachment( &depthStencil, rsh.depthView[rsh.swapchainIndex], true );
+					RI_VK_FillDepthAttachment( &depthStencil, rsh.depthView[rsh.swapchainIndex], false );
 
 					VkRenderingInfo renderingInfo = { VK_STRUCTURE_TYPE_RENDERING_INFO };
 					renderingInfo.flags = 0;
@@ -448,10 +449,10 @@ void R_RenderScene(const refdef_t *fd )
 			// reset back to back buffer
 			{
 				VkRenderingAttachmentInfo colorAttachment = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-				RI_VK_FillColorAttachment( &colorAttachment, RISwapchainGetTextureView(&rsh.swapchain, rsh.swapchainIndex), true );
+				RI_VK_FillColorAttachment( &colorAttachment, RISwapchainGetTextureView(&rsh.swapchain, rsh.swapchainIndex), false );
 
 				VkRenderingAttachmentInfo depthStencil = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-				RI_VK_FillDepthAttachment( &depthStencil, rsh.depthView[rsh.swapchainIndex], true );
+				RI_VK_FillDepthAttachment( &depthStencil, rsh.depthView[rsh.swapchainIndex], false );
 
 				VkRenderingInfo renderingInfo = { VK_STRUCTURE_TYPE_RENDERING_INFO };
 				renderingInfo.flags = 0;

--- a/source/ref_nri/r_shadow.c
+++ b/source/ref_nri/r_shadow.c
@@ -421,7 +421,7 @@ static struct shadow_fb_s *__ResolveShadowSurface(size_t i, int width, int heigh
 		bestFB->width = width;
 		bestFB->height = height;
 		bestFB->descriptor.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-		bestFB->descriptor.texture = bestFB->texture;
+		//bestFB->descriptor.texture = bestFB->texture;
 		bestFB->descriptor.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		bestFB->descriptor.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &bestFB->descriptor.vk.image.imageView ) );

--- a/source/ref_nri/r_shadow.c
+++ b/source/ref_nri/r_shadow.c
@@ -421,7 +421,7 @@ static struct shadow_fb_s *__ResolveShadowSurface(size_t i, int width, int heigh
 		bestFB->width = width;
 		bestFB->height = height;
 		bestFB->descriptor.flags |= RI_VK_DESC_OWN_IMAGE_VIEW;
-		bestFB->descriptor.texture = &bestFB->texture;
+		bestFB->descriptor.texture = bestFB->texture;
 		bestFB->descriptor.vk.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		bestFB->descriptor.vk.image.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		VK_WrapResult( vkCreateImageView( rsh.device.vk.device, &createInfo, NULL, &bestFB->descriptor.vk.image.imageView ) );
@@ -462,13 +462,7 @@ void R_DrawShadowmaps(struct FrameState_s* cmd)
 		return;
 	}
 	R_InitSubpass( cmd, &sub );
-#if ( DEVICE_IMPL_VULKAN )
-	VkCommandBufferInheritanceInfo inheritanceInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO };
-	VkCommandBufferBeginInfo info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
-	info.pInheritanceInfo = &inheritanceInfo;
-	info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-	vkBeginCommandBuffer( sub.handle.vk.cmd, &info );
-#endif
+	BeginRICmd(&rsh.device, &sub.handle);
 
 	lodScale = rn.lod_dist_scale_for_fov;
 	VectorCopy( rn.lodOrigin, lodOrigin );
@@ -565,7 +559,7 @@ void R_DrawShadowmaps(struct FrameState_s* cmd)
 		}
 
 		VkRenderingAttachmentInfo depthStencil = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
-		RI_VK_FillDepthAttachment( &depthStencil, &fb->descriptor, true );
+		RI_VK_FillDepthAttachment( &depthStencil, TextureviewRIDescriptor(&fb->descriptor), true );
 		VkRenderingInfo renderingInfo = { VK_STRUCTURE_TYPE_RENDERING_INFO };
 		renderingInfo.flags = 0;
 		renderingInfo.renderArea.extent.width = fb->width;
@@ -607,7 +601,7 @@ void R_DrawShadowmaps(struct FrameState_s* cmd)
 
 		rsc.renderedShadowBits |= group->bit;
 	}
-	vkEndCommandBuffer( sub.handle.vk.cmd );
+	EndRICmd(&rsh.device, &sub.handle);
 
 	R_PopRefInst( &sub);
 }

--- a/source/ref_nri/r_vbo.c
+++ b/source/ref_nri/r_vbo.c
@@ -308,6 +308,12 @@ void R_UploadVBOVertexRawData( mesh_vbo_t *vbo, int vertsOffset, int numVerts, c
 		.target = vbo->vertexBuffer,
 		.size = numVerts * vbo->vertexSize,
 		.offset = vertsOffset * vbo->vertexSize,
+#if ( DEVICE_IMPL_VULKAN )
+		.vk = {
+			.post_stage = VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT, 
+			.post_access = VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT,         		
+		}
+#endif
 	};
 
 	RI_ResourceBeginCopyBuffer( &rsh.device, &rsh.uploader, &uploadDesc );
@@ -1313,6 +1319,10 @@ void R_UploadVBOElemData( mesh_vbo_t *vbo, int vertsOffset, int elemsOffset, con
 		.target = vbo->indexBuffer,
 		.size = mesh->numElems * sizeof( elem_t ),
 		.offset = elemsOffset * sizeof( elem_t ),
+#if ( DEVICE_IMPL_VULKAN )
+		.vk.post_stage = VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT,
+		.vk.post_access = VK_ACCESS_2_INDEX_READ_BIT,
+#endif
 	};
 
 	RI_ResourceBeginCopyBuffer( &rsh.device, &rsh.uploader, &uploadDesc );
@@ -1350,6 +1360,10 @@ vattribmask_t R_UploadVBOInstancesData( mesh_vbo_t *vbo, int instOffset, int num
 			.target = vbo->instanceBuffer,
 			.size = numInstances * sizeof( instancePoint_t ),
 			.offset = instOffset * sizeof( instancePoint_t ),
+#if ( DEVICE_IMPL_VULKAN )
+			.vk.post_stage = VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT,
+			.vk.post_access = VK_ACCESS_2_UNIFORM_READ_BIT,
+#endif
 		};
 
 		RI_ResourceBeginCopyBuffer( &rsh.device, &rsh.uploader, &uploadDesc );

--- a/source/ref_nri/r_vbo.c
+++ b/source/ref_nri/r_vbo.c
@@ -310,13 +310,8 @@ void R_UploadVBOVertexRawData( mesh_vbo_t *vbo, int vertsOffset, int numVerts, c
 		.offset = vertsOffset * vbo->vertexSize,
 	};
 
-#if ( DEVICE_IMPL_VULKAN )
-		uploadDesc.postBarrier.vk.stage = VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT;
-		uploadDesc.postBarrier.vk.access = VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT;
-#endif
-
 	RI_ResourceBeginCopyBuffer( &rsh.device, &rsh.uploader, &uploadDesc );
-	memcpy( uploadDesc.data, data, uploadDesc.size);
+	memcpy( uploadDesc.mapped.data, data, uploadDesc.size );
 	RI_ResourceEndCopyBuffer( &rsh.device, &rsh.uploader, &uploadDesc );
 }
 
@@ -1319,17 +1314,9 @@ void R_UploadVBOElemData( mesh_vbo_t *vbo, int vertsOffset, int elemsOffset, con
 		.size = mesh->numElems * sizeof( elem_t ),
 		.offset = elemsOffset * sizeof( elem_t ),
 	};
-	const uint64_t test= VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT;
-#if ( DEVICE_IMPL_VULKAN )
-	{
-		uploadDesc.postBarrier.vk.stage = VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT;
-		uploadDesc.postBarrier.vk.access = VK_ACCESS_2_INDEX_READ_BIT;
-	}
-#endif
-assert(test == uploadDesc.postBarrier.vk.stage);
 
-	RI_ResourceBeginCopyBuffer(&rsh.device, &rsh.uploader, &uploadDesc );
-	elem_t *dest = (elem_t *)uploadDesc.data;
+	RI_ResourceBeginCopyBuffer( &rsh.device, &rsh.uploader, &uploadDesc );
+	elem_t *dest = (elem_t *)uploadDesc.mapped.data;
 	for( size_t i = 0; i < mesh->numElems; i++ ) {
 		dest[i] = vertsOffset + mesh->elems[i];
 	}
@@ -1365,14 +1352,8 @@ vattribmask_t R_UploadVBOInstancesData( mesh_vbo_t *vbo, int instOffset, int num
 			.offset = instOffset * sizeof( instancePoint_t ),
 		};
 
-#if ( DEVICE_IMPL_VULKAN )
-	{
-		uploadDesc.postBarrier.vk.stage = VK_SHADER_STAGE_VERTEX_BIT;
-		uploadDesc.postBarrier.vk.access = VK_ACCESS_2_UNIFORM_READ_BIT;
-	}
-#endif
 		RI_ResourceBeginCopyBuffer( &rsh.device, &rsh.uploader, &uploadDesc );
-		instancePoint_t *dest = (instancePoint_t *)uploadDesc.data;
+		instancePoint_t *dest = (instancePoint_t *)uploadDesc.mapped.data;
 		for( size_t i = 0; i < numInstances; i++ ) {
 			memcpy( dest[i], instances[i], sizeof( instancePoint_t ) );
 		}

--- a/source/ref_nri/ri_pogoBuffer.c
+++ b/source/ref_nri/ri_pogoBuffer.c
@@ -1,7 +1,8 @@
 #include "ri_pogoBuffer.h"
-#include "r_local.h"
+#include "ri_vk.h"
 
-VkImageMemoryBarrier2 VK_RI_PogoShaderMemoryBarrier2(VkImage image,bool initial) {
+#if ( DEVICE_IMPL_VULKAN )
+VkImageMemoryBarrier2 VK_RI_PogoShaderMemoryBarrier2(VkImage image, bool initial) {
 	VkImageMemoryBarrier2 imageBarriers = { 0 };
 	imageBarriers.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
 	imageBarriers.srcStageMask = initial ? VK_PIPELINE_STAGE_2_NONE : VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -19,7 +20,7 @@ VkImageMemoryBarrier2 VK_RI_PogoShaderMemoryBarrier2(VkImage image,bool initial)
 	return imageBarriers;
 }
 
-VkImageMemoryBarrier2 VK_RI_PogoAttachmentMemoryBarrier2(VkImage image,bool initial) {
+VkImageMemoryBarrier2 VK_RI_PogoAttachmentMemoryBarrier2(VkImage image, bool initial) {
 	VkImageMemoryBarrier2 imageBarriers = { 0 };
 	imageBarriers.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
 	imageBarriers.srcStageMask = initial ? VK_PIPELINE_STAGE_2_NONE : VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
@@ -36,16 +37,73 @@ VkImageMemoryBarrier2 VK_RI_PogoAttachmentMemoryBarrier2(VkImage image,bool init
 	};
 	return imageBarriers;
 }
+#endif
+
+void RI_PogoBufferInit( struct RIDevice_s *device, struct RI_PogoBuffer *pogo, uint32_t width, uint32_t height, uint32_t format )
+{
+	pogo->attachmentIndex = 0;
+#if ( DEVICE_IMPL_VULKAN )
+	uint32_t queueFamilies[RI_QUEUE_LEN] = { 0 };
+
+	VmaAllocationCreateInfo mem_reqs = { 0 };
+	mem_reqs.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+
+	VkImageCreateInfo info = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
+	info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT;
+	info.imageType = VK_IMAGE_TYPE_2D;
+	info.extent.width = width;
+	info.extent.height = height;
+	info.extent.depth = 1;
+	info.mipLevels = 1;
+	info.arrayLayers = 1;
+	info.samples = 1;
+	info.tiling = VK_IMAGE_TILING_OPTIMAL;
+	info.pQueueFamilyIndices = queueFamilies;
+	VK_ConfigureImageQueueFamilies( &info, device->queues, RI_QUEUE_LEN, queueFamilies, RI_QUEUE_LEN );
+	info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+	info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+	info.format = RIFormatToVK( format );
+
+	for( size_t p = 0; p < 2; p++ ) {
+		VK_WrapResult( vmaCreateImage( device->vk.vmaAllocator, &info, &mem_reqs, &pogo->vk.textures[p].vk.image, &pogo->vk.textures[p].vk.allocation, NULL ) );
+
+		VkImageViewUsageCreateInfo usageInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO };
+		VkImageViewCreateInfo createInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
+		createInfo.pNext = &usageInfo;
+		createInfo.subresourceRange = (VkImageSubresourceRange){
+			VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1,
+		};
+		usageInfo.usage = ( VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT );
+		createInfo.image = pogo->vk.textures[p].vk.image;
+		createInfo.format = RIFormatToVK( format );
+		createInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+
+		VK_WrapResult( vkCreateImageView( device->vk.device, &createInfo, NULL, &pogo->vk.views[p].vk.image ) );
+	}
+#endif
+}
+
+void RI_PogoBufferDestroy( struct RIDevice_s *device, struct RI_PogoBuffer *pogo )
+{
+#if ( DEVICE_IMPL_VULKAN )
+	for( size_t p = 0; p < 2; p++ ) {
+		vkDestroyImageView( device->vk.device, pogo->vk.views[p].vk.image, NULL );
+		vmaDestroyImage( device->vk.vmaAllocator, pogo->vk.textures[p].vk.image, pogo->vk.textures[p].vk.allocation );
+	}
+#endif
+}
 
 void RI_PogoBufferToggle( struct RIDevice_s *device, struct RI_PogoBuffer *pogo, struct RICmd_s *handle )
 {
+#if ( DEVICE_IMPL_VULKAN )
 	VkImageMemoryBarrier2 imageBarriers[2] = { 0 };
-	imageBarriers[0] = VK_RI_PogoShaderMemoryBarrier2(pogo->pogoAttachment[pogo->attachmentIndex].texture->vk.image, false );
+	imageBarriers[0] = VK_RI_PogoShaderMemoryBarrier2( pogo->vk.textures[pogo->attachmentIndex].vk.image, false );
 	pogo->attachmentIndex = ((pogo->attachmentIndex + 1) % 2);
-	imageBarriers[1] = VK_RI_PogoAttachmentMemoryBarrier2( pogo->pogoAttachment[pogo->attachmentIndex].texture->vk.image, false );
+	imageBarriers[1] = VK_RI_PogoAttachmentMemoryBarrier2( pogo->vk.textures[pogo->attachmentIndex].vk.image, false );
 
 	VkDependencyInfo dependencyInfo = { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
 	dependencyInfo.imageMemoryBarrierCount = 2;
 	dependencyInfo.pImageMemoryBarriers = imageBarriers;
 	vkCmdPipelineBarrier2( handle->vk.cmd, &dependencyInfo );
+#endif
 }

--- a/source/ref_nri/ri_pogoBuffer.h
+++ b/source/ref_nri/ri_pogoBuffer.h
@@ -6,24 +6,34 @@
 struct FrameState_s;
 
 struct RI_PogoBuffer {
-	struct RIDescriptor_s pogoAttachment[2];
 	uint16_t attachmentIndex;
+	union {
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			struct RITexture_s textures[2];
+			struct RITextureView_s views[2];
+		} vk;
+#endif
+	};
 };
 
-VkImageMemoryBarrier2 VK_RI_PogoShaderMemoryBarrier2( VkImage image, bool initial );
-VkImageMemoryBarrier2 VK_RI_PogoAttachmentMemoryBarrier2( VkImage image, bool initial );
-
+void RI_PogoBufferInit( struct RIDevice_s *device, struct RI_PogoBuffer *pogo, uint32_t width, uint32_t height, uint32_t format );
+void RI_PogoBufferDestroy( struct RIDevice_s *device, struct RI_PogoBuffer *pogo );
 void RI_PogoBufferToggle( struct RIDevice_s *device, struct RI_PogoBuffer *pogo, struct RICmd_s *handle );
 
-static inline struct RIDescriptor_s *RI_PogoBufferAttachment( struct RI_PogoBuffer *pogo )
+#if ( DEVICE_IMPL_VULKAN )
+static VkImageMemoryBarrier2 VK_RI_PogoShaderMemoryBarrier2( VkImage image, bool initial );
+static VkImageMemoryBarrier2 VK_RI_PogoAttachmentMemoryBarrier2( VkImage image, bool initial );
+#endif
+
+static inline struct RITextureView_s *RI_PogoBufferAttachment( struct RI_PogoBuffer *pogo )
 {
-	return pogo->pogoAttachment + pogo->attachmentIndex;
+	return &pogo->vk.views[pogo->attachmentIndex];
 }
 
-static inline struct RIDescriptor_s *RI_PogoBufferShaderResource( struct RI_PogoBuffer *pogo )
+static inline struct RITextureView_s *RI_PogoBufferShaderResource( struct RI_PogoBuffer *pogo )
 {
-	return pogo->pogoAttachment + ( ( pogo->attachmentIndex + 1 ) % 2 );
+	return &pogo->vk.views[( pogo->attachmentIndex + 1 ) % 2];
 }
 
 #endif
-

--- a/source/ref_nri/ri_pogoBuffer.h
+++ b/source/ref_nri/ri_pogoBuffer.h
@@ -22,8 +22,8 @@ void RI_PogoBufferDestroy( struct RIDevice_s *device, struct RI_PogoBuffer *pogo
 void RI_PogoBufferToggle( struct RIDevice_s *device, struct RI_PogoBuffer *pogo, struct RICmd_s *handle );
 
 #if ( DEVICE_IMPL_VULKAN )
-static VkImageMemoryBarrier2 VK_RI_PogoShaderMemoryBarrier2( VkImage image, bool initial );
-static VkImageMemoryBarrier2 VK_RI_PogoAttachmentMemoryBarrier2( VkImage image, bool initial );
+VkImageMemoryBarrier2 VK_RI_PogoShaderMemoryBarrier2( VkImage image, bool initial );
+VkImageMemoryBarrier2 VK_RI_PogoAttachmentMemoryBarrier2( VkImage image, bool initial );
 #endif
 
 static inline struct RITextureView_s *RI_PogoBufferAttachment( struct RI_PogoBuffer *pogo )

--- a/source/ref_nri/ri_renderer.c
+++ b/source/ref_nri/ri_renderer.c
@@ -1,8 +1,8 @@
 #include "ri_renderer.h"
 
+#include "../qcommon/qcommon.h"
 #include "stb_ds.h"
 #include <qstr.h>
-#include "../qcommon/qcommon.h"
 
 #include "ri_conversion.h"
 #include "ri_gpu_preset.h"
@@ -142,10 +142,10 @@ VkBool32 VKAPI_PTR __VK_DebugUtilsMessenger( VkDebugUtilsMessageSeverityFlagBits
 {
 	switch( messageSeverity ) {
 		case VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT:
-			//assert(callbackData->messageIdNumber ==0xc1c74a9c );
+			// assert(callbackData->messageIdNumber ==0xc1c74a9c );
 			Com_Printf( "VK ERROR: %s", callbackData->pMessage );
-		  if( callbackData->messageIdNumber != 0xcc9c32be )
-		  	assert( false );
+			if( callbackData->messageIdNumber != 0xcc9c32be )
+				assert( false );
 			break;
 		case VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT:
 			Com_Printf( "VK WARNING: %s", callbackData->pMessage );
@@ -180,7 +180,7 @@ inline static bool __VK_isExtensionSupported( const char *targetExt, VkExtension
 static bool __VK_SupportExtension( VkExtensionProperties *properties, size_t len, struct QStrSpan extension )
 {
 	for( size_t i = 0; i < len; i++ ) {
-		if( qStrCompare( qCToStrRef( (properties + i)->extensionName ), extension ) == 0 ) {
+		if( qStrCompare( qCToStrRef( ( properties + i )->extensionName ), extension ) == 0 ) {
 			return true;
 		}
 	}
@@ -200,11 +200,11 @@ int EnumerateRIAdapters( struct RIRenderer_s *renderer, struct RIPhysicalAdapter
 
 		if( adapters ) {
 			VkPhysicalDeviceGroupProperties *physicalDeviceGroupProperties = calloc( deviceGroupNum, sizeof( VkPhysicalDeviceGroupProperties ) );
-			for(size_t i = 0; i < deviceGroupNum; i++) {
+			for( size_t i = 0; i < deviceGroupNum; i++ ) {
 				physicalDeviceGroupProperties[i].sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES;
 			}
-			if( !VK_WrapResult(vkEnumeratePhysicalDeviceGroups( renderer->vk.instance, &deviceGroupNum, physicalDeviceGroupProperties ))) {
-				free(physicalDeviceGroupProperties);
+			if( !VK_WrapResult( vkEnumeratePhysicalDeviceGroups( renderer->vk.instance, &deviceGroupNum, physicalDeviceGroupProperties ) ) ) {
+				free( physicalDeviceGroupProperties );
 				return RI_FAIL;
 			}
 			assert( ( *numAdapters ) >= deviceGroupNum );
@@ -250,15 +250,14 @@ int EnumerateRIAdapters( struct RIRenderer_s *renderer, struct RIPhysicalAdapter
 				// Fill desc
 				physicalAdapter->luid = *(uint64_t *)&deviceIDProperties.deviceLUID[0];
 				physicalAdapter->deviceId = properties.properties.deviceID;
-				memcpy(physicalAdapter->name, properties.properties.deviceName, sizeof(properties.properties.deviceName));
-				assert(sizeof(physicalAdapter->name) >= sizeof(properties.properties.deviceName));
+				memcpy( physicalAdapter->name, properties.properties.deviceName, sizeof( properties.properties.deviceName ) );
+				assert( sizeof( physicalAdapter->name ) >= sizeof( properties.properties.deviceName ) );
 				physicalAdapter->vendor = VendorFromID( properties.properties.vendorID );
 				physicalAdapter->vk.apiVersion = properties.properties.apiVersion;
 				physicalAdapter->presetLevel = RI_GPU_PRESET_NONE;
 				// selected preset
-				for(size_t i = 0; i < Q_ARRAY_COUNT(gpuPCPresets); i++) {
-					if(gpuPCPresets[i].vendorId == properties.properties.vendorID && 
-						 gpuPCPresets[i].modelId == properties.properties.deviceID) {
+				for( size_t i = 0; i < Q_ARRAY_COUNT( gpuPCPresets ); i++ ) {
+					if( gpuPCPresets[i].vendorId == properties.properties.vendorID && gpuPCPresets[i].modelId == properties.properties.deviceID ) {
 						physicalAdapter->presetLevel = gpuPCPresets[i].preset;
 						break;
 					}
@@ -316,7 +315,7 @@ int EnumerateRIAdapters( struct RIRenderer_s *renderer, struct RIPhysicalAdapter
 				physicalAdapter->textureArrayLayerMaxNum = limits->maxImageArrayLayers;
 				physicalAdapter->typedBufferMaxDim = limits->maxTexelBufferElements;
 
-				for(uint32_t i = 0; i < memoryProperties.memoryHeapCount; i++) {
+				for( uint32_t i = 0; i < memoryProperties.memoryHeapCount; i++ ) {
 					if( ( memoryProperties.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT ) != 0 && physicalAdapter->type != RI_ADAPTER_TYPE_INTEGRATED_GPU )
 						physicalAdapter->videoMemorySize += memoryProperties.memoryHeaps[i].size;
 					else
@@ -506,7 +505,8 @@ int EnumerateRIAdapters( struct RIRenderer_s *renderer, struct RIPhysicalAdapter
 	return RI_SUCCESS;
 }
 
-static inline VkDeviceQueueCreateInfo* __VK_findQueueCreateInfo(VkDeviceQueueCreateInfo* queues, size_t numQueues, uint32_t queueIndex) {
+static inline VkDeviceQueueCreateInfo *__VK_findQueueCreateInfo( VkDeviceQueueCreateInfo *queues, size_t numQueues, uint32_t queueIndex )
+{
 	for( size_t i = 0; i < numQueues; i++ ) {
 		if( queues[i].queueFamilyIndex == queueIndex ) {
 			return queues + i;
@@ -517,13 +517,13 @@ static inline VkDeviceQueueCreateInfo* __VK_findQueueCreateInfo(VkDeviceQueueCre
 
 int InitRIDevice( struct RIRenderer_s *renderer, struct RIDeviceDesc_s *init, struct RIDevice_s *device )
 {
-	assert(device);
+	assert( device );
 	assert( init->physicalAdapter );
-	memset(device, 0, sizeof(struct RIDevice_s));
+	memset( device, 0, sizeof( struct RIDevice_s ) );
 
 	enum RIResult_e riResult = RI_SUCCESS;
 	struct RIPhysicalAdapter_s *physicalAdapter = init->physicalAdapter;
-	
+
 	device->renderer = renderer;
 	device->physicalAdapter = *init->physicalAdapter;
 
@@ -535,16 +535,16 @@ int InitRIDevice( struct RIRenderer_s *renderer, struct RIDeviceDesc_s *init, st
 		vkEnumerateDeviceExtensionProperties( physicalAdapter->vk.physicalDevice, NULL, &extensionNum, NULL );
 		VkExtensionProperties *extensionProperties = malloc( extensionNum * sizeof( VkExtensionProperties ) );
 		vkEnumerateDeviceExtensionProperties( physicalAdapter->vk.physicalDevice, NULL, &extensionNum, extensionProperties );
-		
+
 		for( size_t idx = 0; idx < Q_ARRAY_COUNT( DefaultDeviceExtension ); idx++ ) {
 			if( __VK_SupportExtension( extensionProperties, extensionNum, qCToStrRef( DefaultDeviceExtension[idx] ) ) ) {
-				Com_Printf("Enabled Extension: %s", extensionProperties[idx].extensionName);
+				Com_Printf( "Enabled Extension: %s", extensionProperties[idx].extensionName );
 				arrpush( enabledExtensionNames, DefaultDeviceExtension[idx] );
 			}
 		}
-		
-		for(size_t i = 0; i < extensionNum; i++) {
-			Com_Printf( "VK Extension %s - %lu", extensionProperties[i].extensionName, extensionProperties[i].specVersion);
+
+		for( size_t i = 0; i < extensionNum; i++ ) {
+			Com_Printf( "VK Extension %s - %lu", extensionProperties[i].extensionName, extensionProperties[i].specVersion );
 		}
 
 		uint32_t familyNum = 0;
@@ -552,11 +552,11 @@ int InitRIDevice( struct RIRenderer_s *renderer, struct RIDeviceDesc_s *init, st
 
 		VkQueueFamilyProperties *queueFamilyProps = malloc( ( familyNum * sizeof( VkQueueFamilyProperties ) ) );
 		vkGetPhysicalDeviceQueueFamilyProperties( init->physicalAdapter->vk.physicalDevice, &familyNum, queueFamilyProps );
-		
+
 		VkDeviceQueueCreateInfo deviceQueueCreateInfo[8] = { 0 };
 		VkDeviceCreateInfo deviceCreateInfo = { VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
 		deviceCreateInfo.pQueueCreateInfos = deviceQueueCreateInfo;
-		const float priorities[] = {1.0f, 0.9f, 0.8f, 0.7f, 0.6f, 0.5f};
+		const float priorities[] = { 1.0f, 0.9f, 0.8f, 0.7f, 0.6f, 0.5f };
 
 		{
 			struct QStr str = { 0 };
@@ -565,25 +565,25 @@ int InitRIDevice( struct RIRenderer_s *renderer, struct RIDeviceDesc_s *init, st
 			for( size_t i = 0; i < familyNum; i++ ) {
 				qStrSetLen( &str, 0 );
 				numFeatures = 0;
-				if(queueFamilyProps[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) 
-					queueFeatures[numFeatures++] = qCToStrRef("VK_QUEUE_GRAPHICS_BIT"); 
-				if(queueFamilyProps[i].queueFlags & VK_QUEUE_COMPUTE_BIT ) 
-					queueFeatures[numFeatures++] = qCToStrRef("VK_QUEUE_COMPUTE_BIT"); 
-				if(queueFamilyProps[i].queueFlags & VK_QUEUE_TRANSFER_BIT) 
-					queueFeatures[numFeatures++] = qCToStrRef("VK_QUEUE_TRANSFER_BIT"); 
-				if(queueFamilyProps[i].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT) 
-					queueFeatures[numFeatures++] = qCToStrRef("VK_QUEUE_SPARSE_BINDING_BIT"); 
-				if(queueFamilyProps[i].queueFlags & VK_QUEUE_PROTECTED_BIT) 
-					queueFeatures[numFeatures++] = qCToStrRef("VK_QUEUE_PROTECTED_BIT"); 
-				if(queueFamilyProps[i].queueFlags & VK_QUEUE_VIDEO_DECODE_BIT_KHR) 
-					queueFeatures[numFeatures++] = qCToStrRef("VK_QUEUE_VIDEO_DECODE_BIT_KHR"); 
-				if(queueFamilyProps[i].queueFlags & VK_QUEUE_VIDEO_ENCODE_BIT_KHR ) 
-					queueFeatures[numFeatures++] = qCToStrRef("VK_QUEUE_VIDEO_ENCODE_BIT_KHR"); 
-				if(queueFamilyProps[i].queueFlags & VK_QUEUE_OPTICAL_FLOW_BIT_NV ) 
-					queueFeatures[numFeatures++] = qCToStrRef("VK_QUEUE_OPTICAL_FLOW_BIT_NV"); 
-				qstrcatprintf(&str, "VK Queue - %lu: ", i);
-				qstrcatjoin(&str, queueFeatures, numFeatures, qCToStrRef(","));
-				Com_Printf("%.*s", str.len, str.buf);
+				if( queueFamilyProps[i].queueFlags & VK_QUEUE_GRAPHICS_BIT )
+					queueFeatures[numFeatures++] = qCToStrRef( "VK_QUEUE_GRAPHICS_BIT" );
+				if( queueFamilyProps[i].queueFlags & VK_QUEUE_COMPUTE_BIT )
+					queueFeatures[numFeatures++] = qCToStrRef( "VK_QUEUE_COMPUTE_BIT" );
+				if( queueFamilyProps[i].queueFlags & VK_QUEUE_TRANSFER_BIT )
+					queueFeatures[numFeatures++] = qCToStrRef( "VK_QUEUE_TRANSFER_BIT" );
+				if( queueFamilyProps[i].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT )
+					queueFeatures[numFeatures++] = qCToStrRef( "VK_QUEUE_SPARSE_BINDING_BIT" );
+				if( queueFamilyProps[i].queueFlags & VK_QUEUE_PROTECTED_BIT )
+					queueFeatures[numFeatures++] = qCToStrRef( "VK_QUEUE_PROTECTED_BIT" );
+				if( queueFamilyProps[i].queueFlags & VK_QUEUE_VIDEO_DECODE_BIT_KHR )
+					queueFeatures[numFeatures++] = qCToStrRef( "VK_QUEUE_VIDEO_DECODE_BIT_KHR" );
+				if( queueFamilyProps[i].queueFlags & VK_QUEUE_VIDEO_ENCODE_BIT_KHR )
+					queueFeatures[numFeatures++] = qCToStrRef( "VK_QUEUE_VIDEO_ENCODE_BIT_KHR" );
+				if( queueFamilyProps[i].queueFlags & VK_QUEUE_OPTICAL_FLOW_BIT_NV )
+					queueFeatures[numFeatures++] = qCToStrRef( "VK_QUEUE_OPTICAL_FLOW_BIT_NV" );
+				qstrcatprintf( &str, "VK Queue - %lu: ", i );
+				qstrcatjoin( &str, queueFeatures, numFeatures, qCToStrRef( "," ) );
+				Com_Printf( "%.*s", str.len, str.buf );
 			}
 			qStrFree( &str );
 		}
@@ -597,7 +597,7 @@ int InitRIDevice( struct RIRenderer_s *renderer, struct RIDeviceDesc_s *init, st
 			{ VK_QUEUE_TRANSFER_BIT, RI_QUEUE_COPY },
 		};
 		for( uint32_t configureIdx = 0; configureIdx < Q_ARRAY_COUNT( configureQueue ); configureIdx++ ) {
-			//bool found = false;
+			// bool found = false;
 			const uint32_t requiredBits = configureQueue[configureIdx].requiredBits;
 
 			uint32_t minQueueFlag = UINT32_MAX;
@@ -608,7 +608,7 @@ int InitRIDevice( struct RIRenderer_s *renderer, struct RIDeviceDesc_s *init, st
 					bestQueueFamilyIdx = familyIdx;
 					break;
 				}
-				VkDeviceQueueCreateInfo* createInfo = __VK_findQueueCreateInfo(deviceQueueCreateInfo, deviceCreateInfo.queueCreateInfoCount, familyIdx);
+				VkDeviceQueueCreateInfo *createInfo = __VK_findQueueCreateInfo( deviceQueueCreateInfo, deviceCreateInfo.queueCreateInfoCount, familyIdx );
 				if( queueFamilyProps[familyIdx].queueCount == 0 ) {
 					continue;
 				}
@@ -630,20 +630,20 @@ int InitRIDevice( struct RIRenderer_s *renderer, struct RIDeviceDesc_s *init, st
 				}
 			}
 
-			VkDeviceQueueCreateInfo *createInfo = __VK_findQueueCreateInfo( deviceQueueCreateInfo, deviceCreateInfo.queueCreateInfoCount, bestQueueFamilyIdx);
-			if(createInfo == NULL)
+			VkDeviceQueueCreateInfo *createInfo = __VK_findQueueCreateInfo( deviceQueueCreateInfo, deviceCreateInfo.queueCreateInfoCount, bestQueueFamilyIdx );
+			if( createInfo == NULL )
 				createInfo = &deviceQueueCreateInfo[deviceCreateInfo.queueCreateInfoCount++];
 			createInfo->queueFamilyIndex = bestQueueFamilyIdx;
 			createInfo->pQueuePriorities = priorities;
 			createInfo->sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
 
 			struct RIQueue_s *queue = &device->queues[configureQueue[configureIdx].queueType];
-			if( createInfo->queueCount >= queueFamilyProps[createInfo->queueFamilyIndex].queueCount) {
+			if( createInfo->queueCount >= queueFamilyProps[createInfo->queueFamilyIndex].queueCount ) {
 				struct RIQueue_s *dupQueue = NULL;
 				minQueueFlag = UINT32_MAX;
 				for( size_t i = 0; i < Q_ARRAY_COUNT( device->queues ); i++ ) {
-					const uint32_t matchingQueueFlags = ( device->queues[i].vk.queueFlags & requiredBits  );
-					if( matchingQueueFlags && ( ( device->queues[i].vk.queueFlags & ~requiredBits  ) == 0 ) ) {
+					const uint32_t matchingQueueFlags = ( device->queues[i].vk.queueFlags & requiredBits );
+					if( matchingQueueFlags && ( ( device->queues[i].vk.queueFlags & ~requiredBits ) == 0 ) ) {
 						dupQueue = &device->queues[i];
 						break;
 					}
@@ -761,7 +761,7 @@ int InitRIDevice( struct RIRenderer_s *renderer, struct RIDeviceDesc_s *init, st
 			createInfo.device = device->vk.device;
 			createInfo.instance = device->renderer->vk.instance;
 			createInfo.pVulkanFunctions = &vulkanFunctions;
-			createInfo.vulkanApiVersion = VK_API_VERSION_1_3 ;
+			createInfo.vulkanApiVersion = VK_API_VERSION_1_3;
 
 			if( device->physicalAdapter.vk.isBufferDeviceAddressSupported ) {
 				createInfo.flags |= VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
@@ -789,9 +789,9 @@ int InitRIDevice( struct RIRenderer_s *renderer, struct RIDeviceDesc_s *init, st
 
 int InitRIRenderer( const struct RIBackendInit_s *init, struct RIRenderer_s *renderer )
 {
-	memset(renderer, 0, sizeof(struct RIRenderer_s));
+	memset( renderer, 0, sizeof( struct RIRenderer_s ) );
 	renderer->api = init->api;
-#if(DEVICE_IMPL_VULKAN)
+#if ( DEVICE_IMPL_VULKAN )
 	{
 		volkInitialize();
 
@@ -802,9 +802,9 @@ int InitRIRenderer( const struct RIBackendInit_s *init, struct RIRenderer_s *ren
 		appInfo.applicationVersion = VK_MAKE_VERSION( 1, 0, 0 );
 		appInfo.pEngineName = "qfusion";
 		appInfo.engineVersion = VK_MAKE_VERSION( 1, 0, 0 );
-    appInfo.apiVersion = VK_API_VERSION_1_3;
+		appInfo.apiVersion = VK_API_VERSION_1_3;
 
-    renderer->vk.apiVersion = appInfo.apiVersion;
+		renderer->vk.apiVersion = appInfo.apiVersion;
 
 		const VkValidationFeatureEnableEXT enabledValidationFeatures[] = { VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT };
 
@@ -884,8 +884,8 @@ int InitRIRenderer( const struct RIBackendInit_s *init, struct RIRenderer_s *ren
 		if( !VK_WrapResult( result ) ) {
 			return RI_FAIL;
 		}
-		volkLoadInstance(renderer->vk.instance);
-		if( init->vk.enableValidationLayer && vkCreateDebugUtilsMessengerEXT) {
+		volkLoadInstance( renderer->vk.instance );
+		if( init->vk.enableValidationLayer && vkCreateDebugUtilsMessengerEXT ) {
 			VkDebugUtilsMessengerCreateInfoEXT createInfo = { VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT };
 			createInfo.pUserData = renderer;
 			createInfo.pfnUserCallback = __VK_DebugUtilsMessenger;
@@ -912,13 +912,13 @@ void UpdateRIDescriptor( struct RIDevice_s *dev, struct RIDescriptor_s *desc )
 			case VK_DESCRIPTOR_TYPE_SAMPLER:
 				// test some assumptions
 				assert( desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLER ||
-						( desc->texture && ( desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE || desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ) ) );
+						( desc->texture.vk.image && ( desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE || desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ) ) );
 				desc->cookie = hash_data( hash_u64( HASH_INITIAL_VALUE, desc->vk.type ), &desc->vk.image, sizeof( desc->vk.image ) );
 				break;
 			case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
 			case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-				assert( desc->buffer );
-				desc->vk.buffer.buffer = desc->buffer->vk.buffer;
+				assert( desc->buffer.vk.buffer );
+				desc->vk.buffer.buffer = desc->buffer.vk.buffer;
 				desc->cookie = hash_data( hash_u64( HASH_INITIAL_VALUE, desc->vk.type ), &desc->vk.buffer, sizeof( desc->vk.buffer ) );
 				break;
 			default:
@@ -928,6 +928,20 @@ void UpdateRIDescriptor( struct RIDevice_s *dev, struct RIDescriptor_s *desc )
 	}
 #endif
 }
+
+struct RITextureView_s TextureviewRIDescriptor(struct RIDescriptor_s* desc) {
+struct RITextureView_s res = {};
+#if ( DEVICE_IMPL_VULKAN )
+	if(desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLER ||
+		desc->vk.type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE || 
+		desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE  
+			) {
+		res.vk.image = desc->vk.image.imageView; 
+	}	
+
+#endif
+return res;
+} 
 
 void FreeRIDescriptor( struct RIDevice_s *dev, struct RIDescriptor_s *desc )
 {
@@ -952,27 +966,28 @@ void FreeRIDescriptor( struct RIDevice_s *dev, struct RIDescriptor_s *desc )
 	memset( desc, 0, sizeof( struct RIDescriptor_s ) );
 }
 
-void FreeRIFree(struct RIDevice_s* dev,struct RIFree_s* mem) {
-assert(free);
-	switch(mem->type) {
+void FreeRIFree( struct RIDevice_s *dev, struct RIFree_s *mem )
+{
+	assert( free );
+	switch( mem->type ) {
 #if ( DEVICE_IMPL_VULKAN )
 		case RI_FREE_VK_IMAGE:
-			vkDestroyImage( dev->vk.device, mem->vkImage, NULL);
+			vkDestroyImage( dev->vk.device, mem->vkImage, NULL );
 			break;
 		case RI_FREE_VK_IMAGEVIEW:
-			vkDestroyImageView(dev->vk.device, mem->vkImageView, NULL);
+			vkDestroyImageView( dev->vk.device, mem->vkImageView, NULL );
 			break;
 		case RI_FREE_VK_SAMPLER:
-			vkDestroySampler(dev->vk.device, mem->vkSampler, NULL);
+			vkDestroySampler( dev->vk.device, mem->vkSampler, NULL );
 			break;
 		case RI_FREE_VK_VMA_AllOC:
-			vmaFreeMemory(dev->vk.vmaAllocator, mem->vmaAlloc);
+			vmaFreeMemory( dev->vk.vmaAllocator, mem->vmaAlloc );
 			break;
 		case RI_FREE_VK_BUFFER:
-			vkDestroyBuffer(dev->vk.device, mem->vkBuffer, NULL);
+			vkDestroyBuffer( dev->vk.device, mem->vkBuffer, NULL );
 			break;
 		case RI_FREE_VK_BUFFER_VIEW:
-			vkDestroyBufferView(dev->vk.device, mem->vkBufferView, NULL);
+			vkDestroyBufferView( dev->vk.device, mem->vkBufferView, NULL );
 			break;
 #endif
 		default:
@@ -986,28 +1001,101 @@ void FreeRITexture( struct RIDevice_s *dev, struct RITexture_s *tex )
 #if ( DEVICE_IMPL_VULKAN )
 	{
 		if( tex->vk.image ) {
-			vkDestroyImage( dev->vk.device, tex->vk.image, NULL );
+			if( tex->vk.allocation ) {
+				vmaDestroyImage( dev->vk.vmaAllocator, tex->vk.image, tex->vk.allocation );
+				tex->vk.allocation = NULL;
+			} else {
+				vkDestroyImage( dev->vk.device, tex->vk.image, NULL );
+			}
 			tex->vk.image = NULL;
 		}
 	}
 #endif
 }
 
-void FreeRICmd(struct RIDevice_s* dev, struct RICmd_s* cmd) {
-	assert(cmd->vk.pool);
-	assert(cmd->vk.cmd);
+void InitRIPool( struct RIDevice_s *dev, struct RIPool_s *pool, struct RIQueue_s *queue )
+{
 #if ( DEVICE_IMPL_VULKAN )
 	{
-		if( cmd->vk.cmd) {
-			vkFreeCommandBuffers( dev->vk.device, cmd->vk.pool, 1, &cmd->vk.cmd );
-		}
-		cmd->vk.cmd = VK_NULL_HANDLE;
-		cmd->vk.pool = VK_NULL_HANDLE;
+		VkCommandPoolCreateInfo cmdPoolCreateInfo = { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO };
+		cmdPoolCreateInfo.queueFamilyIndex = queue->vk.queueFamilyIdx;
+		cmdPoolCreateInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+		VK_WrapResult( vkCreateCommandPool( dev->vk.device, &cmdPoolCreateInfo, NULL, &pool->vk.pool ) );
+		return;
 	}
 #endif
-
+	assert( false );
 }
 
+void FreeRIPool( struct RIDevice_s *dev, struct RIPool_s *pool )
+{
+#if ( DEVICE_IMPL_VULKAN )
+	{
+		vkDestroyCommandPool( dev->vk.device, pool->vk.pool, NULL );
+		return;
+	}
+#endif
+	assert( false );
+}
+
+void ResetRIPool( struct RIDevice_s *dev, struct RIPool_s *pool )
+{
+#if ( DEVICE_IMPL_VULKAN )
+	{
+		VK_WrapResult( vkResetCommandPool( dev->vk.device, pool->vk.pool, 0 ) );
+	}
+#endif
+}
+
+void InitRICmd( struct RIDevice_s *dev, struct RIPool_s *pool, struct RICmd_s *cmd )
+{
+#if ( DEVICE_IMPL_VULKAN )
+	{
+		struct VkCommandBufferAllocateInfo command_allocate_info = {
+			.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, 
+			.commandPool = pool->vk.pool, 
+			.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY, 
+			.commandBufferCount = 1 
+		};
+		VK_WrapResult( vkAllocateCommandBuffers( dev->vk.device, &command_allocate_info, &cmd->vk.cmd ) );
+		return;
+	}
+#endif
+}
+
+void BeginRICmd( struct RIDevice_s *dev, struct RICmd_s *cmd )
+{
+#if ( DEVICE_IMPL_VULKAN )
+	{
+		VkCommandBufferBeginInfo info = { .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT };
+		VK_WrapResult( vkBeginCommandBuffer( cmd->vk.cmd, &info ) );
+		return;
+	}
+#endif
+}
+
+void EndRICmd( struct RIDevice_s *dev, struct RICmd_s *cmd )
+{
+#if ( DEVICE_IMPL_VULKAN )
+	{
+		VK_WrapResult( vkEndCommandBuffer( cmd->vk.cmd ) );
+		return;
+	}
+#endif
+}
+
+void FreeRICmd( struct RIDevice_s *dev, struct RICmd_s *cmd, struct RIPool_s *pool )
+{
+	assert( cmd->vk.cmd );
+#if ( DEVICE_IMPL_VULKAN )
+	{
+		if( cmd->vk.cmd ) {
+			vkFreeCommandBuffers( dev->vk.device, pool->vk.pool, 1, &cmd->vk.cmd );
+		}
+		cmd->vk.cmd = VK_NULL_HANDLE;
+	}
+#endif
+}
 
 void ShutdownRIRenderer( struct RIRenderer_s *renderer )
 {
@@ -1019,17 +1107,19 @@ void ShutdownRIRenderer( struct RIRenderer_s *renderer )
 #endif
 }
 
-void WaitRIQueueIdle( struct RIDevice_s *device, struct RIQueue_s *queue ) {
+void WaitRIQueueIdle( struct RIDevice_s *device, struct RIQueue_s *queue )
+{
 #if ( DEVICE_IMPL_VULKAN )
 	VK_WrapResult( vkQueueWaitIdle( queue->vk.queue ) );
 #endif
 }
 
-int FreeRIDevice( struct RIDevice_s *dev ) {
+int FreeRIDevice( struct RIDevice_s *dev )
+{
 #if ( DEVICE_IMPL_VULKAN )
 	assert( dev );
-	assert(dev->vk.vmaAllocator );
-	assert(dev->vk.device );
+	assert( dev->vk.vmaAllocator );
+	assert( dev->vk.device );
 
 	if( dev->vk.vmaAllocator )
 		vmaDestroyAllocator( dev->vk.vmaAllocator );
@@ -1037,5 +1127,90 @@ int FreeRIDevice( struct RIDevice_s *dev ) {
 
 	dev->vk.device = NULL;
 	dev->vk.vmaAllocator = NULL;
+#endif
+	return RI_SUCCESS;
+}
+
+void InitRICommandRingBuffer( struct RIDevice_s *dev, struct RIQueue_s *queue, struct RICommandRingBuffer_s *ring, bool syncPrimitives )
+{
+	memset( ring, 0, sizeof( struct RICommandRingBuffer_s ) );
+	ring->poolCount = RI_COMMAND_RING_POOL_COUNT;
+	ring->cmdPerPool = RI_COMMAND_RING_CMD_PER_POOL;
+	ring->syncPrimitive = syncPrimitives;
+
+	ring->poolIndex = ring->poolCount - 1; // Start so first advance goes to 0
+	ring->cmdIndex = 0;
+	ring->fenceIndex = 0;
+
+	for( uint32_t poolIndex = 0; poolIndex < ring->poolCount; poolIndex++ ) {
+		InitRIPool( dev, &ring->pools[poolIndex], queue );
+		for( uint32_t cmdIndex = 0; cmdIndex < ring->cmdPerPool; cmdIndex++ ) {
+			InitRICmd( dev, &ring->pools[poolIndex], &ring->cmds[poolIndex][cmdIndex] );
+#if ( DEVICE_IMPL_VULKAN )
+			if( syncPrimitives ) {
+				VkSemaphoreCreateInfo semaphoreCreateInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
+				VK_WrapResult( vkCreateSemaphore( dev->vk.device, &semaphoreCreateInfo, NULL, &ring->vk.semaphores[poolIndex][cmdIndex] ) );
+
+				VkFenceCreateInfo fenceCreateInfo = { VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, NULL, VK_FENCE_CREATE_SIGNALED_BIT };
+				VK_WrapResult( vkCreateFence( dev->vk.device, &fenceCreateInfo, NULL, &ring->vk.fences[poolIndex][cmdIndex] ) );
+			}
+#endif
+		}
+	}
+}
+
+void FreeRICommandRingBuffer( struct RIDevice_s *dev, struct RICommandRingBuffer_s *ring )
+{
+	for( uint32_t poolIndex = 0; poolIndex < ring->poolCount; poolIndex++ ) {
+		for( uint32_t cmdIndex = 0; cmdIndex < ring->cmdPerPool; cmdIndex++ ) {
+			FreeRICmd( dev, &ring->cmds[poolIndex][cmdIndex], &ring->pools[poolIndex] );
+#if ( DEVICE_IMPL_VULKAN )
+			if( ring->syncPrimitive ) {
+				vkDestroySemaphore( dev->vk.device, ring->vk.semaphores[poolIndex][cmdIndex], NULL );
+				vkDestroyFence( dev->vk.device, ring->vk.fences[poolIndex][cmdIndex], NULL );
+			}
+#endif
+		}
+		FreeRIPool( dev, &ring->pools[poolIndex] );
+	}
+}
+
+void AdvanceRICommandRingBuffer( struct RICommandRingBuffer_s *ring )
+{
+	ring->poolIndex = ( ring->poolIndex + 1 ) % ring->poolCount;
+	ring->cmdIndex = 0;
+	ring->fenceIndex = 0;
+}
+
+struct RICommandRingElement_s GetRICommandRingElement( struct RIDevice_s *dev, struct RICommandRingBuffer_s *ring, uint32_t numCmds )
+{
+	struct RICommandRingElement_s result;
+	memset( &result, 0, sizeof( struct RICommandRingElement_s ) );
+
+	assert( numCmds <= ring->cmdPerPool );
+	assert( numCmds + ring->cmdIndex <= ring->cmdPerPool );
+
+	result.cmds = &ring->cmds[ring->poolIndex][ring->cmdIndex];
+	result.numCmds = numCmds;
+	result.pool = &ring->pools[ring->poolIndex];
+#if ( DEVICE_IMPL_VULKAN )
+	if( ring->syncPrimitive ) {
+		result.vk.semaphore = ring->vk.semaphores[ring->poolIndex][ring->fenceIndex];
+		result.vk.fence = ring->vk.fences[ring->poolIndex][ring->fenceIndex];
+	}
+#endif
+
+	ring->fenceIndex += 1;
+	ring->cmdIndex += numCmds;
+
+	return result;
+}
+
+void WaitRICommandRingElement( struct RIDevice_s *dev, struct RICommandRingElement_s *element )
+{
+#if ( DEVICE_IMPL_VULKAN )
+	if( element->vk.fence ) {
+		VK_WrapResult( vkWaitForFences( dev->vk.device, 1, &element->vk.fence, VK_TRUE, UINT64_MAX ) );
+	}
 #endif
 }

--- a/source/ref_nri/ri_renderer.c
+++ b/source/ref_nri/ri_renderer.c
@@ -144,8 +144,8 @@ VkBool32 VKAPI_PTR __VK_DebugUtilsMessenger( VkDebugUtilsMessageSeverityFlagBits
 		case VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT:
 			// assert(callbackData->messageIdNumber ==0xc1c74a9c );
 			Com_Printf( "VK ERROR: %s", callbackData->pMessage );
-			if( callbackData->messageIdNumber != 0xcc9c32be )
-				assert( false );
+			//if( callbackData->messageIdNumber != 0xcc9c32be )
+			//	assert( false );
 			break;
 		case VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT:
 			Com_Printf( "VK WARNING: %s", callbackData->pMessage );
@@ -911,14 +911,14 @@ void UpdateRIDescriptor( struct RIDevice_s *dev, struct RIDescriptor_s *desc )
 			case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
 			case VK_DESCRIPTOR_TYPE_SAMPLER:
 				// test some assumptions
-				assert( desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLER ||
-						( desc->texture.vk.image && ( desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE || desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ) ) );
+			 // assert( desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLER ||
+			 // 		( desc->texture.vk.image && ( desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE || desc->vk.type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ) ) );
 				desc->cookie = hash_data( hash_u64( HASH_INITIAL_VALUE, desc->vk.type ), &desc->vk.image, sizeof( desc->vk.image ) );
 				break;
 			case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
 			case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-				assert( desc->buffer.vk.buffer );
-				desc->vk.buffer.buffer = desc->buffer.vk.buffer;
+			//	assert( desc->buffer.vk.buffer );
+				//desc->vk.buffer.buffer = desc->buffer.vk.buffer;
 				desc->cookie = hash_data( hash_u64( HASH_INITIAL_VALUE, desc->vk.type ), &desc->vk.buffer, sizeof( desc->vk.buffer ) );
 				break;
 			default:
@@ -1012,6 +1012,20 @@ void FreeRITexture( struct RIDevice_s *dev, struct RITexture_s *tex )
 	}
 #endif
 }
+
+void FreeRITextureView( struct RIDevice_s *dev, struct RITextureView_s *view )
+{
+#if ( DEVICE_IMPL_VULKAN )
+	{
+		if( view->vk.image ) {
+			vkDestroyImageView( dev->vk.device, view->vk.image, NULL );
+			view->vk.image = VK_NULL_HANDLE;
+		}
+	}
+#endif
+	memset( view, 0, sizeof( struct RITextureView_s ) );
+}
+
 
 void InitRIPool( struct RIDevice_s *dev, struct RIPool_s *pool, struct RIQueue_s *queue )
 {
@@ -1138,7 +1152,7 @@ void InitRICommandRingBuffer( struct RIDevice_s *dev, struct RIQueue_s *queue, s
 	ring->cmdPerPool = RI_COMMAND_RING_CMD_PER_POOL;
 	ring->syncPrimitive = syncPrimitives;
 
-	ring->poolIndex = ring->poolCount - 1; // Start so first advance goes to 0
+	ring->poolIndex = 0;
 	ring->cmdIndex = 0;
 	ring->fenceIndex = 0;
 

--- a/source/ref_nri/ri_renderer.h
+++ b/source/ref_nri/ri_renderer.h
@@ -29,6 +29,7 @@ static inline bool RI_IsEmptyDescriptor( struct RIDescriptor_s *desc )
 
 // RITexture
 void FreeRITexture( struct RIDevice_s *dev, struct RITexture_s *tex );
+void FreeRITextureView( struct RIDevice_s *dev, struct RITextureView_s *view );
 
 // RICmd
 void FreeRICmd( struct RIDevice_s *dev, struct RICmd_s *cmd, struct RIPool_s *pool );

--- a/source/ref_nri/ri_renderer.h
+++ b/source/ref_nri/ri_renderer.h
@@ -3,20 +3,6 @@
 
 #include "ri_types.h"
 
-static inline uint32_t RIGetQueueFlags(struct RIRenderer_s* renderer,const struct RIQueue_s* queue) {
-#if ( DEVICE_IMPL_VULKAN )
-  return (queue->vk.queueFlags & VK_QUEUE_GRAPHICS_BIT ? RI_QUEUE_GRAPHICS_BIT : 0) |
-    (queue->vk.queueFlags  & VK_QUEUE_COMPUTE_BIT ? RI_QUEUE_COMPUTE_BIT  : 0) |
-    (queue->vk.queueFlags & VK_QUEUE_TRANSFER_BIT ? RI_QUEUE_TRANSFER_BIT  : 0) | 
-    (queue->vk.queueFlags & VK_QUEUE_SPARSE_BINDING_BIT ? RI_QUEUE_SPARSE_BINDING_BIT  : 0) |  
-    (queue->vk.queueFlags & VK_QUEUE_VIDEO_DECODE_BIT_KHR ? RI_QUEUE_VIDEO_DECODE_BIT : 0) |
-    (queue->vk.queueFlags & VK_QUEUE_VIDEO_ENCODE_BIT_KHR ? RI_QUEUE_VIDEO_ENCODE_BIT  : 0) |
-    (queue->vk.queueFlags & VK_QUEUE_PROTECTED_BIT ? RI_QUEUE_PROTECTED_BIT  : 0) |
-    (queue->vk.queueFlags & VK_QUEUE_OPTICAL_FLOW_BIT_NV ? RI_QUEUE_OPTICAL_FLOW_BIT_NV : 0);
-#endif
-  return 0;
-}
-
 struct RIDeviceDesc_s {
 	struct RIPhysicalAdapter_s *physicalAdapter;
 };
@@ -34,21 +20,36 @@ void FreeRIFree( struct RIDevice_s *dev, struct RIFree_s *mem );
 // RIDescriptor
 void UpdateRIDescriptor( struct RIDevice_s *dev, struct RIDescriptor_s *desc ); // after configure an RIDescriptor call update to configure it
 void FreeRIDescriptor( struct RIDevice_s *dev, struct RIDescriptor_s *desc );
-static inline bool RI_IsEmptyDescriptor( struct RIDescriptor_s *desc ) { return desc->cookie == 0; }
+struct RITextureView_s TextureviewRIDescriptor(struct RIDescriptor_s* desc); 
+static inline bool RI_IsEmptyDescriptor( struct RIDescriptor_s *desc )
+{
+	return desc->cookie == 0;
+}
+
 
 // RITexture
 void FreeRITexture( struct RIDevice_s *dev, struct RITexture_s *tex );
 
 // RICmd
-void FreeRICmd( struct RIDevice_s *dev, struct RICmd_s *cmd);
+void FreeRICmd( struct RIDevice_s *dev, struct RICmd_s *cmd, struct RIPool_s *pool );
+void BeginRICmd( struct RIDevice_s *dev, struct RICmd_s *cmd );
+void EndRICmd( struct RIDevice_s *dev, struct RICmd_s *cmd );
+void InitRICmd( struct RIDevice_s *dev, struct RIPool_s * pool, struct RICmd_s *cmd  );
 
+void InitRIPool( struct RIDevice_s *dev, struct RIPool_s *pool, struct RIQueue_s *queue );
+void ResetRIPool( struct RIDevice_s *dev, struct RIPool_s *pool );
+void FreeRIPool( struct RIDevice_s *dev, struct RIPool_s *pool );
+
+// RICommandRingBuffer
+void InitRICommandRingBuffer( struct RIDevice_s *dev, struct RIQueue_s *queue, struct RICommandRingBuffer_s *ring, bool syncPrimitives );
+void FreeRICommandRingBuffer( struct RIDevice_s *dev, struct RICommandRingBuffer_s *ring );
+void AdvanceRICommandRingBuffer( struct RICommandRingBuffer_s *ring );
+struct RICommandRingElement_s GetRICommandRingElement( struct RIDevice_s *dev, struct RICommandRingBuffer_s *ring, uint32_t numCmds );
+void WaitRICommandRingElement( struct RIDevice_s *dev, struct RICommandRingElement_s *element );
 #if DEVICE_IMPL_VULKAN
 void VK_ConfigureBufferQueueFamilies( VkBufferCreateInfo *info, struct RIQueue_s *queues, size_t numQueues, uint32_t *queueFamiliesIdx, size_t reservedLen );
 void VK_ConfigureImageQueueFamilies( VkImageCreateInfo *info, struct RIQueue_s *queues, size_t numQueues, uint32_t *queueFamiliesIdx, size_t reservedLen );
 void vk_fillQueueFamilies( struct RIDevice_s *dev, uint32_t *queueFamilies, uint32_t *queueFamiliesIdx, size_t reservedLen );
 #endif
 
-
-
 #endif
-

--- a/source/ref_nri/ri_resource_upload.c
+++ b/source/ref_nri/ri_resource_upload.c
@@ -270,7 +270,43 @@ void RI_ResourceEndCopyBuffer( struct RIDevice_s *device, struct RIResourceUploa
 	region.size = trans->size;
 
 	VkCommandBuffer cmd = __AcquireCmd( device, &res->upload_resource );
+
+	if( trans->vk.current_stage != VK_PIPELINE_STAGE_2_COPY_BIT || trans->vk.current_access != VK_ACCESS_2_TRANSFER_WRITE_BIT ) {
+		VkBufferMemoryBarrier2 pre_barrier = { VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2 };
+		pre_barrier.srcStageMask = trans->vk.current_stage;
+		pre_barrier.srcAccessMask = trans->vk.current_access;
+		pre_barrier.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+		pre_barrier.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+		pre_barrier.buffer = trans->target.vk.buffer;
+		pre_barrier.offset = 0;
+		pre_barrier.size = VK_WHOLE_SIZE;
+
+		VkDependencyInfo pre_dependency_info = { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
+		pre_dependency_info.bufferMemoryBarrierCount = 1;
+		pre_dependency_info.pBufferMemoryBarriers = &pre_barrier;
+		vkCmdPipelineBarrier2( cmd, &pre_dependency_info );
+	}
+
 	vkCmdCopyBuffer( cmd, trans->mapped.buffer, trans->target.vk.buffer, 1, &region );
+
+	if( trans->vk.post_stage != VK_PIPELINE_STAGE_2_COPY_BIT || trans->vk.post_access != VK_ACCESS_2_TRANSFER_WRITE_BIT ) {
+		// Only issue post-barrier if the post state is actually specified (non-zero stage)
+		if( trans->vk.post_stage != 0 ) {
+			VkBufferMemoryBarrier2 post_barrier = { VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2 };
+			post_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+			post_barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+			post_barrier.dstStageMask = trans->vk.post_stage;
+			post_barrier.dstAccessMask = trans->vk.post_access;
+			post_barrier.buffer = trans->target.vk.buffer;
+			post_barrier.offset = 0;
+			post_barrier.size = VK_WHOLE_SIZE;
+
+			VkDependencyInfo post_dependency_info = { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
+			post_dependency_info.bufferMemoryBarrierCount = 1;
+			post_dependency_info.pBufferMemoryBarriers = &post_barrier;
+			vkCmdPipelineBarrier2( cmd, &post_dependency_info );
+		}
+	}
 #endif
 }
 

--- a/source/ref_nri/ri_resource_upload.c
+++ b/source/ref_nri/ri_resource_upload.c
@@ -1,402 +1,421 @@
 #include "ri_resource_upload.h"
-#include "ri_types.h"
 #include "qtypes.h"
-
-#include <stb_ds.h>
 #include "ri_format.h"
 #include "ri_renderer.h"
+#include "ri_types.h"
 
-static void __BeginNewCommandSet( struct RIDevice_s *device, struct RIResourceUploader_s *res )
+#include <stb_ds.h>
+
+/*
+ * __AcquireCmd
+ *
+ * Mirrors acquire_cmd() in resource_loader.zig.
+ * If the group is not yet recording, waits for the fence of the active set,
+ * resets the staging offset, frees temporary buffers, resets the pool, and
+ * begins the command buffer.  Returns the active VkCommandBuffer.
+ */
+static VkCommandBuffer __AcquireCmd( struct RIDevice_s *device, struct RITransferCommandGroup_s *group )
 {
-	res->remaningSpace += res->reservedSpacePerSet[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS];
-	res->reservedSpacePerSet[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS] = 0;
 #if ( DEVICE_IMPL_VULKAN )
-	{
-		if( res->syncIndex >= RI_RESOURCE_NUM_COMMAND_SETS ) {
-			for( size_t i = 0; i < arrlen( res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].temporary ); i++ ) {
-				vkDestroyBuffer( device->vk.device, res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].temporary[i].buffer, NULL );
-				vmaFreeMemory( device->vk.vmaAllocator, res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].temporary[i].alloc );
-			}
-			arrsetlen( res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].temporary, 0 );
+	if( !group->is_recording ) {
+		/* wait for GPU to finish using this set */
+		VkFence fence = group->vk.fences[group->active_set];
+		if( vkGetFenceStatus( device->vk.device, fence ) == VK_NOT_READY ) {
+			VK_WrapResult( vkWaitForFences( device->vk.device, 1, &fence, VK_TRUE, UINT64_MAX ) );
 		}
 
-		{
-			VkCommandBufferBeginInfo info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
-			info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-			VK_WrapResult( vkBeginCommandBuffer( res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].cmd, &info ));
+		/* free overflow temporary buffers from the previous use of this set */
+		group->staging_buffer_offset = 0;
+		for( size_t j = 0; j < (size_t)arrlen( group->temporary_buffers ); j++ ) {
+			vkDestroyBuffer( device->vk.device, group->temporary_buffers[j].vk.buffer, NULL );
+			vmaFreeMemory( device->vk.vmaAllocator, group->temporary_buffers[j].vk.allocation );
 		}
+		arrsetlen( group->temporary_buffers, 0 );
+
+		ResetRIPool( device, &group->cmd_pool[group->active_set] );
+		BeginRICmd( device, &group->cmd[group->active_set] );
+
+		group->is_recording = true;
 	}
+	return group->cmd[group->active_set].vk.cmd;
+#else
+	return VK_NULL_HANDLE;
 #endif
 }
 
-void RI_InitResourceUploader( struct RIDevice_s *device, struct RIResourceUploader_s *resource )
+/*
+ * __InitTransferCommandGroup
+ *
+ * Mirrors init_resource_copy_queue() in resource_loader.zig.
+ * Allocates RI_RESOURCE_MAX_SETS command pools, command buffers, host-mapped
+ * staging buffers, binary fences (starting signalled), and binary semaphores.
+ */
+static void __InitTransferCommandGroup( struct RIDevice_s *device, struct RITransferCommandGroup_s *group, struct RIQueue_s *queue )
 {
-	assert(resource->copyQueue == NULL);
-#if ( DEVICE_IMPL_VULKAN )
-	{
-		resource->copyQueue = &device->queues[RI_QUEUE_COPY];
-		{
-			VkSemaphoreTypeCreateInfo semaphoreTypeCreateInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO };
-			semaphoreTypeCreateInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-			VkSemaphoreCreateInfo semaphoreCreateInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
-			semaphoreCreateInfo.pNext = &semaphoreTypeCreateInfo;
-			VK_WrapResult( vkCreateSemaphore( device->vk.device, &semaphoreCreateInfo, NULL, &resource->vk.uploadSem ) );
-		}
-		for( size_t i = 0; i < RI_RESOURCE_NUM_COMMAND_SETS; i++ ) {
-			VkCommandPoolCreateInfo cmdPoolCreateInfo = { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO };
-			cmdPoolCreateInfo.queueFamilyIndex = resource->copyQueue->vk.queueFamilyIdx;
-			cmdPoolCreateInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-			VK_WrapResult( vkCreateCommandPool( device->vk.device, &cmdPoolCreateInfo, NULL, &resource->vk.cmdSets[i].cmdPool ) );
+	memset( group, 0, sizeof( *group ) );
+	group->queue = queue;
+	group->active_set = 0;
+	group->is_recording = false;
 
-			VkCommandBufferAllocateInfo cmdAllocInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO };
-			cmdAllocInfo.commandPool = resource->vk.cmdSets[i].cmdPool;
-			cmdAllocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-			cmdAllocInfo.commandBufferCount = 1;
-			VK_WrapResult( vkAllocateCommandBuffers( device->vk.device, &cmdAllocInfo, &resource->vk.cmdSets[i].cmd ) );
-		}
+#if ( DEVICE_IMPL_VULKAN )
+	for( size_t i = 0; i < RI_RESOURCE_MAX_SETS; i++ ) {
+		/* command pool + command buffer */
 		{
-			VmaAllocationInfo allocationInfo = { 0 };
+			VkCommandPoolCreateInfo info = { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO };
+			info.queueFamilyIndex = queue->vk.queueFamilyIdx;
+			info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+			group->cmd_pool[i].vk.queue = queue->vk.queue;
+			VK_WrapResult( vkCreateCommandPool( device->vk.device, &info, NULL, &group->cmd_pool[i].vk.pool ) );
+
+			VkCommandBufferAllocateInfo allocInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO };
+			allocInfo.commandPool = group->cmd_pool[i].vk.pool;
+			allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+			allocInfo.commandBufferCount = 1;
+			VK_WrapResult( vkAllocateCommandBuffers( device->vk.device, &allocInfo, &group->cmd[i].vk.cmd ) );
+		}
+
+		/* host-visible, persistently-mapped staging buffer */
+		{
 			VmaAllocationCreateInfo allocInfo = { 0 };
 			allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
 			allocInfo.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
-			uint32_t queueFamilies[RI_QUEUE_LEN] = { 0 };
-			VkBufferCreateInfo stageBufferCreateInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
-			VK_ConfigureBufferQueueFamilies( &stageBufferCreateInfo, device->queues, RI_QUEUE_LEN, queueFamilies, RI_QUEUE_LEN );
-			stageBufferCreateInfo.pNext = NULL;
-			stageBufferCreateInfo.flags = 0;
-			stageBufferCreateInfo.size = RI_RESOURCE_STAGE_SIZE;
-			stageBufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-			VK_WrapResult(vmaCreateBuffer(device->vk.vmaAllocator, &stageBufferCreateInfo, &allocInfo, &resource->vk.stageBuffer, &resource->vk.stageAlloc, &allocationInfo));
-			resource->vk.pMappedData = allocationInfo.pMappedData;
 
+			VkBufferCreateInfo bufInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
+			bufInfo.size = RI_RESOURCE_STAGE_BUFFER_SIZE;
+			bufInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+			bufInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+
+			VmaAllocationInfo vmaInfo = { 0 };
+			VK_WrapResult( vmaCreateBuffer( device->vk.vmaAllocator, &bufInfo, &allocInfo, &group->staging_buffer[i].vk.buffer, &group->staging_buffer[i].vk.allocation, &vmaInfo ) );
+			/* store mapped pointer alongside the buffer index for __AllocateFromStageBuffer */
+			/* we stash it in a local per-group array; extend the union if needed */
+			/* for now use vmaInfo.pMappedData at acquire time via vmaGetAllocationInfo */
+			(void)vmaInfo; /* mapped data retrieved via vmaGetAllocationInfo at runtime */
+		}
+
+		/* binary fence – start signalled so first acquire doesn't wait */
+		{
+			VkFenceCreateInfo info = { VK_STRUCTURE_TYPE_FENCE_CREATE_INFO };
+			info.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+			VK_WrapResult( vkCreateFence( device->vk.device, &info, NULL, &group->vk.fences[i] ) );
+		}
+
+		/* binary semaphore */
+		{
+			VkSemaphoreCreateInfo info = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
+			VK_WrapResult( vkCreateSemaphore( device->vk.device, &info, NULL, &group->vk.semaphores[i] ) );
 		}
 	}
+	group->temporary_buffers = NULL; /* stb_ds array, starts empty */
 #endif
-	__BeginNewCommandSet( device, resource );
 }
 
-void RI_FreeResourceUploader( struct RIDevice_s *device, struct RIResourceUploader_s *resource )
+/*
+ * __FreeTransferCommandGroup
+ *
+ * Mirrors deinit_command_group() in resource_loader.zig.
+ */
+static void __FreeTransferCommandGroup( struct RIDevice_s *device, struct RITransferCommandGroup_s *group )
 {
-	arrfree( resource->postImageBarriers );
-	arrfree( resource->postBufferBarriers );
 #if ( DEVICE_IMPL_VULKAN )
-	vkDestroyBuffer( device->vk.device, resource->vk.stageBuffer, NULL );
-	vmaFreeMemory( device->vk.vmaAllocator, resource->vk.stageAlloc );
+	/* free any remaining overflow temporary buffers */
+	for( size_t j = 0; j < (size_t)arrlen( group->temporary_buffers ); j++ ) {
+		vkDestroyBuffer( device->vk.device, group->temporary_buffers[j].vk.buffer, NULL );
+		vmaFreeMemory( device->vk.vmaAllocator, group->temporary_buffers[j].vk.allocation );
+	}
+	arrfree( group->temporary_buffers );
 
-	vkDestroySemaphore( device->vk.device, resource->vk.uploadSem, NULL );
-	for( size_t i = 0; i < RI_RESOURCE_NUM_COMMAND_SETS; i++ ) {
-		for( size_t ti = 0; ti < arrlen( resource->vk.cmdSets[i].temporary ); ti++ ) {
-			vkDestroyBuffer( device->vk.device, resource->vk.cmdSets[i].temporary[ti].buffer, NULL );
-			vmaFreeMemory( device->vk.vmaAllocator, resource->vk.cmdSets[i].temporary[ti].alloc );
-		}
-		arrfree( resource->vk.cmdSets[i].temporary );
-		vkFreeCommandBuffers( device->vk.device, resource->vk.cmdSets[i].cmdPool, 1, &resource->vk.cmdSets[i].cmd );
-		vkDestroyCommandPool( device->vk.device, resource->vk.cmdSets[i].cmdPool, NULL );
+	for( size_t i = 0; i < RI_RESOURCE_MAX_SETS; i++ ) {
+		vkFreeCommandBuffers( device->vk.device, group->cmd_pool[i].vk.pool, 1, &group->cmd[i].vk.cmd );
+		vkDestroyCommandPool( device->vk.device, group->cmd_pool[i].vk.pool, NULL );
+
+		vmaDestroyBuffer( device->vk.vmaAllocator, group->staging_buffer[i].vk.buffer, group->staging_buffer[i].vk.allocation );
+
+		vkDestroyFence( device->vk.device, group->vk.fences[i], NULL );
+		vkDestroySemaphore( device->vk.device, group->vk.semaphores[i], NULL );
 	}
 #endif
-	memset( resource, 0, sizeof( struct RIResourceUploader_s ) );
 }
 
-static bool __R_AllocFromStageBuffer( struct RIDevice_s *dev, struct RIResourceUploader_s *res, size_t reqSize, struct RIResourceReq *req )
+/*
+ * __AllocateFromStageBuffer
+ *
+ * Mirrors allocate_from_stage_buffer() in resource_loader.zig.
+ * Tries to sub-allocate 'size' bytes (aligned to 'alignment') from the
+ * active set's per-set staging buffer.  Returns true on success.
+ */
+static bool __AllocateFromStageBuffer( struct RIDevice_s *device, struct RITransferCommandGroup_s *group, size_t size, size_t alignment, struct RIMappedMemoryRange *out )
 {
-	size_t allocSize = Q_ALIGN_TO( reqSize, 4 ); // we round up to multiples of uint32_t
-	if( allocSize > res->remaningSpace ) {
-		// we are out of avaliable space from staging
+#if ( DEVICE_IMPL_VULKAN )
+	const size_t alignedSize = Q_ALIGN_TO( size, alignment );
+	const size_t alignedOffset = Q_ALIGN_TO( group->staging_buffer_offset, alignment );
+
+	if( alignedOffset >= RI_RESOURCE_STAGE_BUFFER_SIZE )
 		return false;
-	}
+	if( alignedSize > RI_RESOURCE_STAGE_BUFFER_SIZE - alignedOffset )
+		return false;
 
-	// we are past the end of the buffer
-	if( res->tailOffset + allocSize > RI_RESOURCE_STAGE_SIZE ) {
-		const size_t remainingSpace = ( RI_RESOURCE_STAGE_SIZE - res->tailOffset ); // remaining space at the end of the buffer this unusable
-		if( allocSize > res->remaningSpace - remainingSpace ) {
-			return false;
-		}
+	const size_t set = group->active_set;
+	VmaAllocationInfo vmaInfo = { 0 };
+	vmaGetAllocationInfo( device->vk.vmaAllocator, group->staging_buffer[set].vk.allocation, &vmaInfo );
 
-		res->remaningSpace -= remainingSpace;
-		res->reservedSpacePerSet[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS] += remainingSpace; // give the remaning space to the requesting set
-		res->tailOffset = 0;
-	}
+	out->offset = alignedOffset;
+	out->size = alignedSize;
+	out->data = (uint8_t *)vmaInfo.pMappedData + alignedOffset;
+	out->buffer = group->staging_buffer[set].vk.buffer;
+	out->alloc = NULL; /* belongs to the persistent staging buffer */
 
-#if ( DEVICE_IMPL_VULKAN )
-	{
-		req->vk.alloc = res->vk.stageAlloc;
-		req->cpuMapping = res->vk.pMappedData;
-		req->byteOffset = res->tailOffset;
-		req->vk.buffer = res->vk.stageBuffer;
-	}
-#endif
-
-	res->reservedSpacePerSet[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS] += allocSize;
-
-	res->tailOffset += allocSize;
-	res->remaningSpace -= allocSize;
+	group->staging_buffer_offset = alignedOffset + alignedSize;
 	return true;
-}
-
-static bool __ResolveStageBuffer( struct RIDevice_s *dev, struct RIResourceUploader_s *res, size_t reqSize, struct RIResourceReq *req )
-{
-	if( __R_AllocFromStageBuffer( dev, res, reqSize, req ) ) {
-		return true;
-	}
-#if ( DEVICE_IMPL_VULKAN )
-	{
-		uint32_t queueFamilies[RI_QUEUE_LEN] = { 0 };
-		struct RI_VK_TempBuffers tempBuffer;
-		VkBufferCreateInfo stageBufferCreateInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
-		VK_ConfigureBufferQueueFamilies( &stageBufferCreateInfo, dev->queues, RI_QUEUE_LEN, queueFamilies, RI_QUEUE_LEN );
-		stageBufferCreateInfo.size = reqSize;
-		stageBufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-
-		VmaAllocationInfo allocationInfo = { 0 };
-		VmaAllocationCreateInfo allocInfo = { 0 };
-		allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
-		allocInfo.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT ;
-	
-		VK_WrapResult(vmaCreateBuffer(dev->vk.vmaAllocator, &stageBufferCreateInfo, &allocInfo, &tempBuffer.buffer, &tempBuffer.alloc, &allocationInfo));
-
-		req->vk.alloc = tempBuffer.alloc;
-		req->vk.buffer = tempBuffer.buffer;
-		req->cpuMapping = allocationInfo.pMappedData;
-		req->byteOffset = 0;
-
-		arrpush( res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].temporary, tempBuffer );
-	}
-#endif
-	return true;
-}
-
-
-void RI_ResourceBeginCopyBuffer( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIResourceBufferTransaction_s *trans ) {
-	__ResolveStageBuffer(device, res, trans->size, &trans->req);
-	trans->data = (uint8_t *)trans->req.cpuMapping + trans->req.byteOffset;
-}
-
-static inline bool __ResourceInTransitionBuffer( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIBuffer_s target )
-{
-	for( size_t i = 0; i < arrlen( res->postBufferBarriers ); i++ ) {
-		if( res->postBufferBarriers[i].buffer == target.vk.buffer ) {
-			return true;
-		}
-	}
+#else
 	return false;
-}
-
-void RI_ResourceEndCopyBuffer( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIResourceBufferTransaction_s *trans ) {
-#if ( DEVICE_IMPL_VULKAN )
-	{
-		if( !__ResourceInTransitionBuffer(device, res, trans->target)) {
-			VkBufferMemoryBarrier2 bufferBarriers[1] = { 0 };
-			bufferBarriers[0].sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2;
-			bufferBarriers[0].srcStageMask = trans->srcBarrier.vk.stage;
-			bufferBarriers[0].srcAccessMask = trans->srcBarrier.vk.access; // VK_ACCESS_2_NONE;
-			bufferBarriers[0].dstStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
-			bufferBarriers[0].dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
-			bufferBarriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED; // TODO: VK_SHARING_MODE_EXCLUSIVE could be used instead of VK_SHARING_MODE_CONCURRENT with queue ownership transfers
-			bufferBarriers[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-			bufferBarriers[0].buffer = trans->target.vk.buffer;
-			bufferBarriers[0].offset = 0;
-			bufferBarriers[0].size = VK_WHOLE_SIZE;
-
-			VkDependencyInfo dependencyInfo = { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
-			dependencyInfo.bufferMemoryBarrierCount = Q_ARRAY_COUNT( bufferBarriers );
-			dependencyInfo.pBufferMemoryBarriers = bufferBarriers;
-			vkCmdPipelineBarrier2( res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].cmd, &dependencyInfo );
-
-			struct RIResourcePostBufferBarrier_s postTransition = { 0 };
-			postTransition.buffer = trans->target.vk.buffer;
-			postTransition.postBarrier = trans->postBarrier;
-			arrpush( res->postBufferBarriers, postTransition );
-		}
-
-		VkBufferCopy copyBuffer = { 0 };
-		copyBuffer.size = trans->size;
-		copyBuffer.dstOffset = trans->offset;
-		copyBuffer.srcOffset = trans->req.byteOffset;
-		vkCmdCopyBuffer( res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].cmd, trans->req.vk.buffer, trans->target.vk.buffer, 1, &copyBuffer );
-	
-
-	}
 #endif
 }
 
-void RI_InsertTransitionBarriers( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RICmd_s *cmd )
+/*
+ * __AllocateTemporaryBuffer
+ *
+ * Mirrors allocate_temporary_buffer() in resource_loader.zig.
+ * Creates a brand-new host-mapped VMA buffer for uploads that exceed the
+ * staging buffer.  The buffer is registered in group->temporary_buffers
+ * and will be destroyed when the set is reused.
+ */
+static void __AllocateTemporaryBuffer( struct RIDevice_s *device, struct RITransferCommandGroup_s *group, size_t size, struct RIMappedMemoryRange *out )
 {
 #if ( DEVICE_IMPL_VULKAN )
-	{
-		size_t postBufferIdx = 0;
-		size_t numBufferBarriers = 0;
-		VkBufferMemoryBarrier2 bufferBarriers[32] = { 0 };
-		
-		size_t postImageIdx = 0;
-		size_t numImageBarriers = 0;
-		VkImageMemoryBarrier2 imageBarriers[32] = { 0 };
+	VmaAllocationCreateInfo allocInfo = { 0 };
+	allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+	allocInfo.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
 
-		while( true ) {
-			while( postBufferIdx < arrlen( res->postBufferBarriers ) && numBufferBarriers < Q_ARRAY_COUNT( bufferBarriers ) ) {
-				VkBufferMemoryBarrier2 *barrier = &bufferBarriers[numBufferBarriers++];
-				struct RIResourcePostBufferBarrier_s *post = &res->postBufferBarriers[postBufferIdx++];
-				memset( barrier, 0, sizeof( VkBufferMemoryBarrier2 ) );
-				barrier->sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2;
-				barrier->srcStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
-				barrier->srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
-				barrier->dstStageMask = post->postBarrier.vk.stage;
-				barrier->dstAccessMask = post->postBarrier.vk.access;
-				barrier->srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-				barrier->dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-				barrier->buffer = post->buffer;
-				barrier->offset = 0;
-				barrier->size = VK_WHOLE_SIZE;
-			}
+	VkBufferCreateInfo bufInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
+	bufInfo.size = size;
+	bufInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	bufInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
-			while( postImageIdx < arrlen( res->postImageBarriers ) && numImageBarriers < Q_ARRAY_COUNT( imageBarriers ) ) {
-				VkImageMemoryBarrier2 *barrier = &imageBarriers[numImageBarriers++];
-				struct RIResourcePostImageBarrier_s *post = &res->postImageBarriers[postImageIdx++];
-				memset( barrier, 0, sizeof( VkImageMemoryBarrier2 ) );
-				barrier->sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
-				barrier->srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
-				barrier->srcStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
-				barrier->oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-				barrier->dstStageMask = post->postBarrier.vk.stage;
-				barrier->dstAccessMask = post->postBarrier.vk.access;
-				barrier->newLayout = post->postBarrier.vk.layout;
-				barrier->subresourceRange = (VkImageSubresourceRange){
-					VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS,
-				};
-				barrier->srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-				barrier->dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-				barrier->image = post->image;
-			}
-			if( numBufferBarriers == 0 && numImageBarriers == 0 ) {
-				break;
-			}
-			VkDependencyInfo dependencyInfo = { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
-			dependencyInfo.bufferMemoryBarrierCount = numBufferBarriers;
-			dependencyInfo.pBufferMemoryBarriers = bufferBarriers;
-			dependencyInfo.imageMemoryBarrierCount = numImageBarriers;
-			dependencyInfo.pImageMemoryBarriers = imageBarriers;
-			vkCmdPipelineBarrier2(  cmd->vk.cmd, &dependencyInfo );
-			numBufferBarriers = 0;
-			numImageBarriers = 0; 
-		}
-	}
+	struct RIBuffer_s tmp = { 0 };
+	VmaAllocationInfo vmaInfo = { 0 };
+	VK_WrapResult( vmaCreateBuffer( device->vk.vmaAllocator, &bufInfo, &allocInfo, &tmp.vk.buffer, &tmp.vk.allocation, &vmaInfo ) );
+
+	arrpush( group->temporary_buffers, tmp );
+
+	out->offset = 0;
+	out->size = size;
+	out->data = vmaInfo.pMappedData;
+	out->buffer = tmp.vk.buffer;
+	out->alloc = tmp.vk.allocation;
 #endif
 }
 
-void RI_ResourceSubmit( struct RIDevice_s *device, struct RIResourceUploader_s *res )
+/*
+ * __ResolveStageMemory
+ *
+ * Try the staging buffer first; fall back to a temporary buffer.
+ */
+static void __ResolveStageMemory( struct RIDevice_s *device, struct RITransferCommandGroup_s *group, size_t size, struct RIMappedMemoryRange *out )
 {
-	if(arrlen(res->postImageBarriers) == 0 && arrlen(res->postBufferBarriers) == 0) {
-		return;	
-	}
-	arrsetlen( res->postImageBarriers, 0 );
-	arrsetlen( res->postBufferBarriers, 0 );
-
-#if ( DEVICE_IMPL_VULKAN )
-	{
-		vkEndCommandBuffer( res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].cmd );
-
-		VkSemaphoreSubmitInfo signalSem = { VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO };
-		signalSem.stageMask = VK_PIPELINE_STAGE_2_NONE;
-		signalSem.value = 1 + res->syncIndex;
-		signalSem.semaphore = res->vk.uploadSem;
-
-		VkCommandBufferSubmitInfo cmdSubmitInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO };
-		cmdSubmitInfo.commandBuffer = res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].cmd;
-
-		VkSubmitInfo2 submitInfo = { VK_STRUCTURE_TYPE_SUBMIT_INFO_2 };
-		submitInfo.pSignalSemaphoreInfos = &signalSem;
-		submitInfo.signalSemaphoreInfoCount = 1;
-		submitInfo.pCommandBufferInfos = &cmdSubmitInfo;
-		submitInfo.commandBufferInfoCount = 1;
-
-		VK_WrapResult( vkQueueSubmit2( res->copyQueue->vk.queue, 1, &submitInfo, VK_NULL_HANDLE ) );
-	}
-#endif
-	res->syncIndex++;
-	if( res->syncIndex >= RI_RESOURCE_NUM_COMMAND_SETS ) {
-		uint64_t waitValue = 1 + res->syncIndex - RI_RESOURCE_NUM_COMMAND_SETS;
-		VkSemaphoreWaitInfo semaphoreWaitInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO };
-		semaphoreWaitInfo.semaphoreCount = 1;
-		semaphoreWaitInfo.pSemaphores = &res->vk.uploadSem;
-		semaphoreWaitInfo.pValues = &waitValue;
-		VK_WrapResult( vkWaitSemaphores( device->vk.device, &semaphoreWaitInfo, 5000 * 1000000ull) );
-		VK_WrapResult( vkResetCommandPool( device->vk.device, res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].cmdPool, 0 ) );
-	}
-	__BeginNewCommandSet( device, res );
+	if( !__AllocateFromStageBuffer( device, group, size, 4, out ) )
+		__AllocateTemporaryBuffer( device, group, size, out );
 }
+
+/* =======================================================================
+ * Public API
+ * ======================================================================= */
+
+void RI_InitResourceUploader( struct RIDevice_s *device, struct RIResourceUploader_s *res )
+{
+	assert( res );
+	memset( res, 0, sizeof( *res ) );
+
+	/* Upload group on the graphics queue (matches Zig: upload_resource) */
+	__InitTransferCommandGroup( device, &res->upload_resource, &device->queues[RI_QUEUE_GRAPHICS] );
+
+	/* Copy group on the dedicated transfer/copy queue (matches Zig: copy_resource).
+	 * Fall back to graphics queue if the copy queue is unavailable. */
+	struct RIQueue_s *copyQueue = &device->queues[RI_QUEUE_COPY];
+#if ( DEVICE_IMPL_VULKAN )
+	if( copyQueue->vk.queue == VK_NULL_HANDLE )
+		copyQueue = &device->queues[RI_QUEUE_GRAPHICS];
+#endif
+	__InitTransferCommandGroup( device, &res->copy_resource, copyQueue );
+}
+
+void RI_FreeResourceUploader( struct RIDevice_s *device, struct RIResourceUploader_s *res )
+{
+	assert( res );
+	__FreeTransferCommandGroup( device, &res->upload_resource );
+	__FreeTransferCommandGroup( device, &res->copy_resource );
+	memset( res, 0, sizeof( *res ) );
+}
+
+/* -----------------------------------------------------------------------
+ * Buffer copy
+ * ----------------------------------------------------------------------- */
+
+void RI_ResourceBeginCopyBuffer( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIResourceBufferTransaction_s *trans )
+{
+	__AcquireCmd( device, &res->upload_resource );
+	__ResolveStageMemory( device, &res->upload_resource, trans->size, &trans->mapped );
+}
+
+void RI_ResourceEndCopyBuffer( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIResourceBufferTransaction_s *trans )
+{
+#if ( DEVICE_IMPL_VULKAN )
+	VkBufferCopy region = { 0 };
+	region.srcOffset = trans->mapped.offset;
+	region.dstOffset = trans->offset;
+	region.size = trans->size;
+
+	VkCommandBuffer cmd = __AcquireCmd( device, &res->upload_resource );
+	vkCmdCopyBuffer( cmd, trans->mapped.buffer, trans->target.vk.buffer, 1, &region );
+#endif
+}
+
+/* -----------------------------------------------------------------------
+ * Texture copy
+ * ----------------------------------------------------------------------- */
 
 void RI_ResourceBeginCopyTexture( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIResourceTextureTransaction_s *trans )
 {
 	const uint64_t alignedRowPitch = Q_ALIGN_TO( trans->rowPitch, device->physicalAdapter.uploadBufferTextureRowAlignment );
-	const uint64_t alignedSlicePitch = Q_ALIGN_TO( trans->sliceNum * alignedRowPitch, device->physicalAdapter.uploadBufferTextureSliceAlignment );
-	trans->alignRowPitch = alignedRowPitch;
-	trans->alignSlicePitch = alignedSlicePitch;
-	__ResolveStageBuffer(device, res, alignedSlicePitch, &trans->req);
-	trans->data = (uint8_t *)trans->req.cpuMapping + trans->req.byteOffset;
+	const uint64_t alignedSlicePitch = Q_ALIGN_TO( (uint64_t)trans->sliceNum * alignedRowPitch, device->physicalAdapter.uploadBufferTextureSliceAlignment );
+
+	trans->alignRowPitch = (uint32_t)alignedRowPitch;
+	trans->alignSlicePitch = (uint32_t)alignedSlicePitch;
+
+	__AcquireCmd( device, &res->upload_resource );
+	__ResolveStageMemory( device, &res->upload_resource, alignedSlicePitch, &trans->mapped );
 }
 
 void RI_ResourceEndCopyTexture( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIResourceTextureTransaction_s *trans )
 {
-
 #if ( DEVICE_IMPL_VULKAN )
-	{
-		bool foundInTransition = false;
-		for(size_t i = 0; i < arrlen(res->postImageBarriers); i++) {
-			if(res->postImageBarriers[i].image == trans->target.vk.image) {
-				foundInTransition = true;
-				break;
-			}
-		}
-		if( !foundInTransition ) {
-			VkImageMemoryBarrier2 imageBarriers[1] = { 0 };
-			imageBarriers[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
-			imageBarriers[0].srcAccessMask = trans->srcBarrier.vk.access; // VK_ACCESS_2_NONE;
-			imageBarriers[0].srcStageMask = trans->srcBarrier.vk.stage;
-			imageBarriers[0].oldLayout = trans->srcBarrier.vk.layout;	  // VK_IMAGE_LAYOUT_UNDEFINED;
-			imageBarriers[0].dstStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
-			imageBarriers[0].dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
-			imageBarriers[0].newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-			imageBarriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-			imageBarriers[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-			imageBarriers[0].image = trans->target.vk.image;
-			imageBarriers[0].subresourceRange = (VkImageSubresourceRange){
-				VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS,
-			};
-			VkDependencyInfo dependencyInfo = { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
-			dependencyInfo.imageMemoryBarrierCount = Q_ARRAY_COUNT( imageBarriers );
-			dependencyInfo.pImageMemoryBarriers = imageBarriers;
-			vkCmdPipelineBarrier2( res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].cmd, &dependencyInfo );
+	const struct RIFormatProps_s *formatProps = GetRIFormatProps( trans->format );
 
-			struct RIResourcePostImageBarrier_s postTransition = { 0 };
-			postTransition.image = trans->target.vk.image;
-			postTransition.postBarrier = trans->postBarrier;
-			arrpush(res->postImageBarriers, postTransition);
-		}
-		{
-			const struct RIFormatProps_s *formatProps = GetRIFormatProps( trans->format );
+	const uint32_t rowBlockNum = trans->rowPitch / formatProps->stride;
+	const uint32_t bufferRowLength = rowBlockNum * formatProps->blockWidth;
+	const uint32_t sliceRowNum = trans->alignSlicePitch / trans->rowPitch;
+	const uint32_t bufferImageHeight = sliceRowNum * formatProps->blockWidth;
 
-			const uint32_t rowBlockNum = trans->rowPitch / formatProps->stride;
-			const uint32_t bufferRowLength = rowBlockNum * formatProps->blockWidth;
+	VkBufferImageCopy region = { 0 };
+	region.bufferOffset = trans->mapped.offset;
+	region.bufferRowLength = bufferRowLength;
+	region.bufferImageHeight = bufferImageHeight;
+	region.imageOffset.x = trans->x;
+	region.imageOffset.y = trans->y;
+	region.imageOffset.z = trans->z;
+	region.imageExtent.width = trans->width;
+	region.imageExtent.height = trans->height;
+	region.imageExtent.depth = trans->depth;
+	region.imageSubresource.mipLevel = trans->mipOffset;
+	region.imageSubresource.baseArrayLayer = trans->arrayOffset;
+	region.imageSubresource.layerCount = 1;
+	region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-			const uint32_t sliceRowNum = trans->alignSlicePitch / trans->rowPitch;
-			const uint32_t bufferImageHeight = sliceRowNum * formatProps->blockWidth;
-
-			VkBufferImageCopy copyReq = { 0 };
-			copyReq.bufferOffset = trans->req.byteOffset;
-			copyReq.bufferRowLength = bufferRowLength;
-			copyReq.bufferImageHeight = bufferImageHeight;
-			copyReq.imageOffset.x = trans->x;
-			copyReq.imageOffset.y = trans->y;
-			copyReq.imageOffset.z = trans->z;
-			copyReq.imageExtent.width = trans->width;
-			copyReq.imageExtent.height = trans->height;
-			copyReq.imageExtent.depth = trans->depth;
-			copyReq.imageSubresource.mipLevel = trans->mipOffset;
-			copyReq.imageSubresource.baseArrayLayer = trans->arrayOffset;
-			copyReq.imageSubresource.layerCount = 1;
-			copyReq.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			//assert( res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS < Q_ARRAY_COUNT( res->vk.cmdSets ) );
-			vkCmdCopyBufferToImage( res->vk.cmdSets[res->syncIndex % RI_RESOURCE_NUM_COMMAND_SETS].cmd, trans->req.vk.buffer, trans->target.vk.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copyReq );
-		}
-	}
+	VkCommandBuffer cmd = __AcquireCmd( device, &res->upload_resource );
+	vkCmdCopyBufferToImage( cmd, trans->mapped.buffer, trans->target.vk.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region );
 #endif
 }
+
+/* -----------------------------------------------------------------------
+ * Submit
+ *
+ * Mirrors VKFlushResourceUpdate() in resource_loader.zig.
+ * Ends and submits the upload command buffer with a binary fence signal,
+ * then advances to the next set.  No-ops if nothing was recorded.
+ * ----------------------------------------------------------------------- */
+
+//void RI_ResourceSubmit( struct RIDevice_s *device, struct RIResourceUploader_s *res )
+//{
+//	struct RITransferCommandGroup_s *group = &res->upload_resource;
+//	if( !group->is_recording )
+//		return;
+//
+//#if ( DEVICE_IMPL_VULKAN )
+//	const size_t set = group->active_set;
+//
+//	VK_WrapResult( vkEndCommandBuffer( group->cmd[set].vk.cmd ) );
+//
+//	VkCommandBufferSubmitInfo cmdSubmit = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO };
+//	cmdSubmit.commandBuffer = group->cmd[set].vk.cmd;
+//
+//	VkSemaphoreSubmitInfo signalSem = { VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO };
+//	signalSem.semaphore = group->vk.semaphores[set];
+//	signalSem.stageMask = VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT;
+//	signalSem.value = 0; /* binary semaphore */
+//
+//	/* Fence must be in signalled state before we reset it; assert to catch bugs. */
+//	assert( vkGetFenceStatus( device->vk.device, group->vk.fences[set] ) == VK_SUCCESS );
+//	VK_WrapResult( vkResetFences( device->vk.device, 1, &group->vk.fences[set] ) );
+//
+//	VkSubmitInfo2 submitInfo = { VK_STRUCTURE_TYPE_SUBMIT_INFO_2 };
+//	submitInfo.commandBufferInfoCount = 1;
+//	submitInfo.pCommandBufferInfos = &cmdSubmit;
+//	submitInfo.signalSemaphoreInfoCount = 1;
+//	submitInfo.pSignalSemaphoreInfos = &signalSem;
+//
+//	VK_WrapResult( vkQueueSubmit2( group->queue->vk.queue, 1, &submitInfo, group->vk.fences[set] ) );
+//
+//	group->active_set = ( set + 1 ) % RI_RESOURCE_MAX_SETS;
+//	group->is_recording = false;
+//	group->staging_buffer_offset = 0;
+//#endif
+//}
+
+#if ( DEVICE_IMPL_VULKAN )
+struct RIResourceUploaderVKResult_s RI_VKFlushResourceUpdate( struct RIDevice_s *device, struct RIResourceUploader_s *res, size_t num_semaphores, VkSemaphoreSubmitInfo *wait_semaphore_info )
+{
+	struct RITransferCommandGroup_s *group = &res->upload_resource;
+	const size_t active_set = group->active_set;
+
+	/* Early-out: nothing was recorded – return the current fence/semaphore
+	 * with signaled = false so the caller knows no submit occurred. */
+	if( !group->is_recording ) {
+		return (struct RIResourceUploaderVKResult_s){
+			.vk =
+				{
+					.fence = group->vk.fences[active_set],
+					.semaphore = group->vk.semaphores[active_set],
+				},
+			.signaled = false,
+		};
+	}
+
+	VK_WrapResult( vkEndCommandBuffer( group->cmd[active_set].vk.cmd ) );
+
+	VkCommandBufferSubmitInfo cmdSubmit = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO };
+	cmdSubmit.commandBuffer = group->cmd[active_set].vk.cmd;
+	cmdSubmit.deviceMask = 0;
+
+	VkSemaphoreSubmitInfo signalSem = { VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO };
+	signalSem.semaphore = group->vk.semaphores[active_set];
+	signalSem.value = 0; /* binary semaphore */
+	signalSem.stageMask = VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT;
+	signalSem.deviceIndex = 0;
+
+	VkSubmitInfo2 submitInfo = { VK_STRUCTURE_TYPE_SUBMIT_INFO_2 };
+	submitInfo.commandBufferInfoCount = 1;
+	submitInfo.pCommandBufferInfos = &cmdSubmit;
+	submitInfo.waitSemaphoreInfoCount = (uint32_t)num_semaphores;
+	submitInfo.pWaitSemaphoreInfos = wait_semaphore_info;
+	submitInfo.signalSemaphoreInfoCount = 1;
+	submitInfo.pSignalSemaphoreInfos = &signalSem;
+
+	/* Fence must already be signalled before we reset it; assert to catch bugs. */
+	assert( vkGetFenceStatus( device->vk.device, group->vk.fences[active_set] ) == VK_SUCCESS );
+	VK_WrapResult( vkResetFences( device->vk.device, 1, &group->vk.fences[active_set] ) );
+
+	VK_WrapResult( vkQueueSubmit2( group->queue->vk.queue, 1, &submitInfo, group->vk.fences[active_set] ) );
+
+	group->active_set = ( active_set + 1 ) % RI_RESOURCE_MAX_SETS;
+	group->is_recording = false;
+
+	return (struct RIResourceUploaderVKResult_s){
+		.vk =
+			{
+				.fence = group->vk.fences[active_set],
+				.semaphore = group->vk.semaphores[active_set],
+			},
+		.signaled = true,
+	};
+}
+#endif

--- a/source/ref_nri/ri_resource_upload.c
+++ b/source/ref_nri/ri_resource_upload.c
@@ -312,7 +312,53 @@ void RI_ResourceEndCopyTexture( struct RIDevice_s *device, struct RIResourceUplo
 	region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
 	VkCommandBuffer cmd = __AcquireCmd( device, &res->upload_resource );
+
+	if( trans->vk.current_stage != VK_PIPELINE_STAGE_2_COPY_BIT || trans->vk.current_access != VK_ACCESS_2_TRANSFER_WRITE_BIT ) {
+		VkImageMemoryBarrier2 pre_barrier = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2 };
+		pre_barrier.srcStageMask = trans->vk.current_stage;
+		pre_barrier.srcAccessMask = trans->vk.current_access;
+		pre_barrier.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+		pre_barrier.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+		pre_barrier.oldLayout = trans->vk.current_layout;
+		pre_barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+		pre_barrier.image = trans->target.vk.image;
+		pre_barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		pre_barrier.subresourceRange.baseMipLevel = trans->mipOffset;
+		pre_barrier.subresourceRange.levelCount = 1;
+		pre_barrier.subresourceRange.baseArrayLayer = trans->arrayOffset;
+		pre_barrier.subresourceRange.layerCount = 1;
+
+		VkDependencyInfo pre_dependency_info = { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
+		pre_dependency_info.imageMemoryBarrierCount = 1;
+		pre_dependency_info.pImageMemoryBarriers = &pre_barrier;
+		vkCmdPipelineBarrier2( cmd, &pre_dependency_info );
+	}
+
 	vkCmdCopyBufferToImage( cmd, trans->mapped.buffer, trans->target.vk.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region );
+
+	if( trans->vk.post_stage != VK_PIPELINE_STAGE_2_COPY_BIT || trans->vk.post_access != VK_ACCESS_2_TRANSFER_WRITE_BIT ) {
+		// Only issue post-barrier if the post state is actually specified (non-zero stage)
+		if( trans->vk.post_stage != 0 ) {
+			VkImageMemoryBarrier2 post_barrier = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2 };
+			post_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+			post_barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+			post_barrier.dstStageMask = trans->vk.post_stage;
+			post_barrier.dstAccessMask = trans->vk.post_access;
+			post_barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+			post_barrier.newLayout = trans->vk.post_layout != VK_IMAGE_LAYOUT_UNDEFINED ? trans->vk.post_layout : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			post_barrier.image = trans->target.vk.image;
+			post_barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+			post_barrier.subresourceRange.baseMipLevel = trans->mipOffset;
+			post_barrier.subresourceRange.levelCount = 1;
+			post_barrier.subresourceRange.baseArrayLayer = trans->arrayOffset;
+			post_barrier.subresourceRange.layerCount = 1;
+
+			VkDependencyInfo post_dependency_info = { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
+			post_dependency_info.imageMemoryBarrierCount = 1;
+			post_dependency_info.pImageMemoryBarriers = &post_barrier;
+			vkCmdPipelineBarrier2( cmd, &post_dependency_info );
+		}
+	}
 #endif
 }
 
@@ -403,7 +449,6 @@ struct RIResourceUploaderVKResult_s RI_VKFlushResourceUpdate( struct RIDevice_s 
 	/* Fence must already be signalled before we reset it; assert to catch bugs. */
 	assert( vkGetFenceStatus( device->vk.device, group->vk.fences[active_set] ) == VK_SUCCESS );
 	VK_WrapResult( vkResetFences( device->vk.device, 1, &group->vk.fences[active_set] ) );
-
 	VK_WrapResult( vkQueueSubmit2( group->queue->vk.queue, 1, &submitInfo, group->vk.fences[active_set] ) );
 
 	group->active_set = ( active_set + 1 ) % RI_RESOURCE_MAX_SETS;

--- a/source/ref_nri/ri_resource_upload.c
+++ b/source/ref_nri/ri_resource_upload.c
@@ -26,11 +26,11 @@ static VkCommandBuffer __AcquireCmd( struct RIDevice_s *device, struct RITransfe
 
 		/* free overflow temporary buffers from the previous use of this set */
 		group->staging_buffer_offset = 0;
-		for( size_t j = 0; j < (size_t)arrlen( group->temporary_buffers ); j++ ) {
-			vkDestroyBuffer( device->vk.device, group->temporary_buffers[j].vk.buffer, NULL );
-			vmaFreeMemory( device->vk.vmaAllocator, group->temporary_buffers[j].vk.allocation );
+		for( size_t j = 0; j < (size_t)arrlen( group->temporary_buffers[group->active_set] ); j++ ) {
+			vkDestroyBuffer( device->vk.device, group->temporary_buffers[group->active_set][j].vk.buffer, NULL );
+			vmaFreeMemory( device->vk.vmaAllocator, group->temporary_buffers[group->active_set][j].vk.allocation );
 		}
-		arrsetlen( group->temporary_buffers, 0 );
+		arrsetlen( group->temporary_buffers[group->active_set], 0 );
 
 		ResetRIPool( device, &group->cmd_pool[group->active_set] );
 		BeginRICmd( device, &group->cmd[group->active_set] );
@@ -106,7 +106,9 @@ static void __InitTransferCommandGroup( struct RIDevice_s *device, struct RITran
 			VK_WrapResult( vkCreateSemaphore( device->vk.device, &info, NULL, &group->vk.semaphores[i] ) );
 		}
 	}
-	group->temporary_buffers = NULL; /* stb_ds array, starts empty */
+	for( size_t i = 0; i < RI_RESOURCE_MAX_SETS; i++ ) {
+		group->temporary_buffers[i] = NULL; /* stb_ds array, starts empty */
+	}
 #endif
 }
 
@@ -119,11 +121,13 @@ static void __FreeTransferCommandGroup( struct RIDevice_s *device, struct RITran
 {
 #if ( DEVICE_IMPL_VULKAN )
 	/* free any remaining overflow temporary buffers */
-	for( size_t j = 0; j < (size_t)arrlen( group->temporary_buffers ); j++ ) {
-		vkDestroyBuffer( device->vk.device, group->temporary_buffers[j].vk.buffer, NULL );
-		vmaFreeMemory( device->vk.vmaAllocator, group->temporary_buffers[j].vk.allocation );
+	for( size_t i = 0; i < RI_RESOURCE_MAX_SETS; i++ ) {
+		for( size_t j = 0; j < (size_t)arrlen( group->temporary_buffers[i] ); j++ ) {
+			vkDestroyBuffer( device->vk.device, group->temporary_buffers[i][j].vk.buffer, NULL );
+			vmaFreeMemory( device->vk.vmaAllocator, group->temporary_buffers[i][j].vk.allocation );
+		}
+		arrfree( group->temporary_buffers[i] );
 	}
-	arrfree( group->temporary_buffers );
 
 	for( size_t i = 0; i < RI_RESOURCE_MAX_SETS; i++ ) {
 		vkFreeCommandBuffers( device->vk.device, group->cmd_pool[i].vk.pool, 1, &group->cmd[i].vk.cmd );
@@ -196,7 +200,7 @@ static void __AllocateTemporaryBuffer( struct RIDevice_s *device, struct RITrans
 	VmaAllocationInfo vmaInfo = { 0 };
 	VK_WrapResult( vmaCreateBuffer( device->vk.vmaAllocator, &bufInfo, &allocInfo, &tmp.vk.buffer, &tmp.vk.allocation, &vmaInfo ) );
 
-	arrpush( group->temporary_buffers, tmp );
+	arrpush( group->temporary_buffers[group->active_set], tmp );
 
 	out->offset = 0;
 	out->size = size;

--- a/source/ref_nri/ri_resource_upload.h
+++ b/source/ref_nri/ri_resource_upload.h
@@ -80,6 +80,18 @@ struct RIResourceBufferTransaction_s {
 	size_t size;
 	size_t offset; /* destination offset inside 'target'          */
 
+	union {
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			VkPipelineStageFlags2 current_stage;
+			VkAccessFlags2 current_access;
+
+			VkPipelineStageFlags2 post_stage;
+			VkAccessFlags2 post_access;
+		} vk;
+#endif
+	};
+
 	/* filled by RI_ResourceBeginCopyBuffer */
 	struct RIMappedMemoryRange mapped;
 };

--- a/source/ref_nri/ri_resource_upload.h
+++ b/source/ref_nri/ri_resource_upload.h
@@ -90,6 +90,20 @@ struct RIResourceBufferTransaction_s {
 struct RIResourceTextureTransaction_s {
 	struct RITexture_s target;
 
+		union {
+#if ( DEVICE_IMPL_VULKAN )
+			struct {
+					VkPipelineStageFlags2 current_stage;
+					VkAccessFlags2 current_access;
+					VkImageLayout current_layout;
+
+					VkPipelineStageFlags2 post_stage;
+					VkAccessFlags2 post_access;
+					VkImageLayout post_layout;
+			} vk;
+#endif
+		};
+
 	/* https://github.com/microsoft/DirectXTex/wiki/Image */
 	uint32_t format; /* RI_Format_e */
 	uint32_t sliceNum;

--- a/source/ref_nri/ri_resource_upload.h
+++ b/source/ref_nri/ri_resource_upload.h
@@ -48,8 +48,8 @@ struct RITransferCommandGroup_s {
 	size_t staging_buffer_offset; /* running tail within the active set's staging buf */
 	struct RIBuffer_s staging_buffer[RI_RESOURCE_MAX_SETS];
 
-	/* temporary overflow buffers – freed when the set is reused */
-	struct RIBuffer_s *temporary_buffers; /* stb_ds array */
+	/* temporary overflow buffers – per-set, freed when the set is reused */
+	struct RIBuffer_s *temporary_buffers[RI_RESOURCE_MAX_SETS]; /* stb_ds arrays */
 
 	union {
 		struct {

--- a/source/ref_nri/ri_resource_upload.h
+++ b/source/ref_nri/ri_resource_upload.h
@@ -2,92 +2,96 @@
 #ifndef RI_RESOURCE_UPLOAD_H
 #define RI_RESOURCE_UPLOAD_H
 
-#define RI_RESOURCE_NUM_COMMAND_SETS 5 
-#define RI_RESOURCE_STAGE_SIZE (8 * MB_TO_BYTE)
+#define RI_RESOURCE_MAX_SETS 2
+#define RI_RESOURCE_STAGE_BUFFER_SIZE ( 8 * MB_TO_BYTE )
 
-#include "ri_types.h"
 #include "qtypes.h"
+#include "ri_types.h"
 
-struct RIResourceReq {
-	uint64_t byteOffset;
-	void *cpuMapping;
-	union {
+/* -----------------------------------------------------------------------
+ * Mapped memory range – the slice of staging memory a transaction gets
+ * ----------------------------------------------------------------------- */
+struct RIMappedMemoryRange {
+	size_t offset; /* byte offset from the start of the backing buffer  */
+	size_t size;
+	void *data; /* CPU-accessible pointer to the mapped slice         */
 #if ( DEVICE_IMPL_VULKAN )
-		struct {
-			VkBuffer buffer;
-    	struct VmaAllocation_T* alloc;
-		} vk;
+	VkBuffer buffer;			   /* which VkBuffer backs this range                   */
+	struct VmaAllocation_T *alloc; /* VMA allocation (NULL for stage buf)  */
 #endif
-	};
 };
 
-struct RIResourcePostImageBarrier_s {
-	VkImage image;
-	struct RIBarrierImageHandle_s postBarrier; 
-};
-
-struct RIResourcePostBufferBarrier_s {
+/* -----------------------------------------------------------------------
+ * Internal: temporary overflow buffer (freed on next acquire of same set)
+ * ----------------------------------------------------------------------- */
+struct RI_VK_TempBuffer {
+#if ( DEVICE_IMPL_VULKAN )
 	VkBuffer buffer;
-	struct RIBarrierBufferHandle_s postBarrier;
+	struct VmaAllocation_T *alloc;
+#endif
 };
 
-struct RIResourceUploader_s {
-	struct RIQueue_s *copyQueue;
-	struct RIResourcePostImageBarrier_s* postImageBarriers;
-	struct RIResourcePostBufferBarrier_s* postBufferBarriers;
-	size_t tailOffset;
-	size_t remaningSpace;
-	size_t reservedSpacePerSet[RI_RESOURCE_NUM_COMMAND_SETS];
-	uint64_t syncIndex;
+/* -----------------------------------------------------------------------
+ * Transfer command group  (mirrors TransferCommandGroup in resource_loader.zig)
+ * One group = one queue + per-set cmd pool/buffer/staging/fence/semaphore
+ * ----------------------------------------------------------------------- */
+struct RITransferCommandGroup_s {
+	struct RIQueue_s *queue;
+
+	bool is_recording;
+	size_t active_set;
+
+	struct RIPool_s cmd_pool[RI_RESOURCE_MAX_SETS];
+	struct RICmd_s cmd[RI_RESOURCE_MAX_SETS];
+
+	/* per-set staging buffer (host-visible, persistently mapped) */
+	size_t staging_buffer_offset; /* running tail within the active set's staging buf */
+	struct RIBuffer_s staging_buffer[RI_RESOURCE_MAX_SETS];
+
+	/* temporary overflow buffers – freed when the set is reused */
+	struct RIBuffer_s *temporary_buffers; /* stb_ds array */
 
 	union {
-#if ( DEVICE_IMPL_VULKAN )
 		struct {
-			struct VmaAllocation_T *stageAlloc;
-			VkBuffer stageBuffer;
-			void *pMappedData;
-			
-			VkSemaphore uploadSem;	
-			struct {
-				VkCommandPool cmdPool;
-				VkCommandBuffer cmd;
-				struct RI_VK_TempBuffers {
-					VkBuffer buffer;
-					struct VmaAllocation_T *alloc;
-				} *temporary;
-			} cmdSets[RI_RESOURCE_NUM_COMMAND_SETS];
-		} vk;
+			/* per-set binary fence (starts signalled) + binary semaphore */
+#if ( DEVICE_IMPL_VULKAN )
+			VkFence fences[RI_RESOURCE_MAX_SETS];
+			VkSemaphore semaphores[RI_RESOURCE_MAX_SETS];
 #endif
+		} vk;
 	};
 };
 
-void RI_InitResourceUploader( struct RIDevice_s *device, struct RIResourceUploader_s *resource );
-void RI_FreeResourceUploader( struct RIDevice_s *device, struct RIResourceUploader_s *resource );
+/* -----------------------------------------------------------------------
+ * Resource uploader  (two groups: upload on graphics, copy on transfer)
+ * ----------------------------------------------------------------------- */
+struct RIResourceUploader_s {
+	struct RITransferCommandGroup_s upload_resource; /* graphics queue            */
+	struct RITransferCommandGroup_s copy_resource;	 /* transfer/copy queue       */
+
+	bool is_running;
+};
+
+/* -----------------------------------------------------------------------
+ * Buffer transaction
+ * ----------------------------------------------------------------------- */
 struct RIResourceBufferTransaction_s {
 	struct RIBuffer_s target;
-
-	struct RIBarrierBufferHandle_s srcBarrier;
-	struct RIBarrierBufferHandle_s postBarrier;
-
 	size_t size;
-	size_t offset;
+	size_t offset; /* destination offset inside 'target'          */
 
-	// begin mapping
-	void *data;
-	struct RIResourceReq req;
+	/* filled by RI_ResourceBeginCopyBuffer */
+	struct RIMappedMemoryRange mapped;
 };
 
-void RI_ResourceBeginCopyBuffer( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIResourceBufferTransaction_s *trans );
-void RI_ResourceEndCopyBuffer( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIResourceBufferTransaction_s *trans );
-
+/* -----------------------------------------------------------------------
+ * Texture transaction
+ * ----------------------------------------------------------------------- */
 struct RIResourceTextureTransaction_s {
 	struct RITexture_s target;
 
-	struct RIBarrierImageHandle_s srcBarrier;
-	struct RIBarrierImageHandle_s postBarrier;
-
-	// https://github.com/microsoft/DirectXTex/wiki/Image
-	uint32_t format; // RI_Format_e 
+	/* https://github.com/microsoft/DirectXTex/wiki/Image */
+	uint32_t format; /* RI_Format_e */
 	uint32_t sliceNum;
 	uint32_t rowPitch;
 
@@ -101,21 +105,42 @@ struct RIResourceTextureTransaction_s {
 	uint32_t arrayOffset;
 	uint32_t mipOffset;
 
-	// begin mapping
-	void *data;
+	/* filled by RI_ResourceBeginCopyTexture */
 	uint32_t alignRowPitch;
 	uint32_t alignSlicePitch;
-	struct RIResourceReq req;
+	struct RIMappedMemoryRange mapped;
 };
 
-void RI_ResourceBeginCopyTexture(struct RIDevice_s* device, struct RIResourceUploader_s *res, struct RIResourceTextureTransaction_s *trans );
-void RI_ResourceEndCopyTexture(struct RIDevice_s* device, struct RIResourceUploader_s *res, struct RIResourceTextureTransaction_s *trans );
+/* -----------------------------------------------------------------------
+ * API
+ * ----------------------------------------------------------------------- */
+void RI_InitResourceUploader( struct RIDevice_s *device, struct RIResourceUploader_s *res );
+void RI_FreeResourceUploader( struct RIDevice_s *device, struct RIResourceUploader_s *res );
 
-void RI_InsertTransitionBarriers(struct RIDevice_s* device, struct RIResourceUploader_s *res, struct RICmd_s* cmd);
-void RI_ResourceSubmit(struct RIDevice_s* device, struct RIResourceUploader_s *res);
+void RI_ResourceBeginCopyBuffer( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIResourceBufferTransaction_s *trans );
+void RI_ResourceEndCopyBuffer( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIResourceBufferTransaction_s *trans );
 
-//struct RIBarrierBufferHandle_s  RI_VertexBufferBarrier( struct RIDevice_s *device );
-//struct RIBarrierBufferHandle_s  RI_IndexBufferBarrier( struct RIDevice_s *device );
-//struct RIBarrierImageHandle_s RI_SampledImageImageBarrier( struct RIDevice_s *device );
+void RI_ResourceBeginCopyTexture( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIResourceTextureTransaction_s *trans );
+void RI_ResourceEndCopyTexture( struct RIDevice_s *device, struct RIResourceUploader_s *res, struct RIResourceTextureTransaction_s *trans );
+
+/* Submit the upload group and advance to the next set. */
+//void RI_ResourceSubmit( struct RIDevice_s *device, struct RIResourceUploader_s *res );
+
+struct RIResourceUploaderVKResult_s {
+	bool signaled;
+	
+	union {
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			VkFence fence;
+			VkSemaphore semaphore;
+		} vk;
+#endif
+	};
+};
+
+#if ( DEVICE_IMPL_VULKAN )
+struct RIResourceUploaderVKResult_s RI_VKFlushResourceUpdate( struct RIDevice_s *device, struct RIResourceUploader_s *res, size_t num_semaphores, VkSemaphoreSubmitInfo *wait_semaphore_info );
+#endif
 
 #endif

--- a/source/ref_nri/ri_swapchain.c
+++ b/source/ref_nri/ri_swapchain.c
@@ -172,12 +172,10 @@ int InitRISwapchain( struct RIDevice_s *dev, struct RISwapchainDesc_s *init, str
 		vkGetSwapchainImagesKHR( dev->vk.device, swapchain->vk.swapchain, &imageNum, swapchain->vk.images );
 		swapchain->vk.imageCount = imageNum;
 
-		// Cache surface format and present mode for resize (Zig: image_format, image_colorspace, present_mode)
 		swapchain->format = VKToRIFormat( selectedSurf->format );
 		swapchain->vk.imageColorSpace = selectedSurf->colorSpace;
 		swapchain->vk.presentMode = presentMode;
 
-		// Create binary semaphores (Zig: signal_semaphores)
 		for( size_t i = 0; i < imageNum; i++ ) {
 			VkSemaphoreCreateInfo createInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
 			VkSemaphoreTypeCreateInfo timelineCreateInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO };
@@ -188,7 +186,6 @@ int InitRISwapchain( struct RIDevice_s *dev, struct RISwapchainDesc_s *init, str
 			VK_WrapResult( result );
 		}
 
-		// Create image views (Zig: for (0..images.len) |k| { dkb.createImageView(...) })
 		for( size_t i = 0; i < imageNum; i++ ) {
 			VkImageViewCreateInfo viewCreateInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
 			viewCreateInfo.image = swapchain->vk.images[i];
@@ -226,9 +223,9 @@ uint32_t RISwapchainAcquireNextTexture( struct RIDevice_s *dev, struct RISwapcha
 	return 0;
 }
 
-//void RISwapchainPresent( struct RIDevice_s *dev, struct RISwapchain_s *swapchain )
+// void RISwapchainPresent( struct RIDevice_s *dev, struct RISwapchain_s *swapchain )
 //{
-//#if ( DEVICE_IMPL_VULKAN )
+// #if ( DEVICE_IMPL_VULKAN )
 //	{
 //		VkSemaphore renderingFinishedSemaphore = swapchain->vk.renderFinished[swapchain->vk.signal_idx];
 //		{
@@ -243,19 +240,17 @@ uint32_t RISwapchainAcquireNextTexture( struct RIDevice_s *dev, struct RISwapcha
 //			VK_WrapResult( vkQueuePresentKHR( swapchain->presentQueue->vk.queue, &presentInfo ) );
 //		}
 //	}
-//#endif
-//}
+// #endif
+// }
 
 void FreeRISwapchain( struct RIDevice_s *dev, struct RISwapchain_s *swapchain )
 {
 #if ( DEVICE_IMPL_VULKAN )
 	{
-		// Zig: for (self.backend.vk.signal_semaphores) |sem| { destroySemaphore }
 		for( size_t p = 0; p < RI_MAX_SWAPCHAIN_IMAGES; p++ ) {
 			if( swapchain->vk.signaled[p] )
 				vkDestroySemaphore( dev->vk.device, swapchain->vk.signaled[p], NULL );
 		}
-		// Zig: for (self.backend.vk.views) |view| { destroyImageView }
 		for( size_t p = 0; p < RI_MAX_SWAPCHAIN_IMAGES; p++ ) {
 			if( swapchain->vk.views[p] )
 				vkDestroyImageView( dev->vk.device, swapchain->vk.views[p], NULL );
@@ -269,21 +264,20 @@ void FreeRISwapchain( struct RIDevice_s *dev, struct RISwapchain_s *swapchain )
 #endif
 }
 
-void RISwapchainPresent_vk(struct RIDevice_s* dev, struct RISwapchain_s* swapchain, uint32_t index, size_t num_wait_semaphores, VkSemaphore* wait_semaphores ) {
+void RISwapchainPresent_vk( struct RIDevice_s *dev, struct RISwapchain_s *swapchain, uint32_t index, size_t num_wait_semaphores, VkSemaphore *wait_semaphores )
+{
 #if ( DEVICE_IMPL_VULKAN )
 	{
-			VkPresentInfoKHR presentInfo = { VK_STRUCTURE_TYPE_PRESENT_INFO_KHR };
-			presentInfo.waitSemaphoreCount = num_wait_semaphores;
-			presentInfo.pWaitSemaphores = wait_semaphores;
-			presentInfo.swapchainCount = 1;
-			presentInfo.pSwapchains = &swapchain->vk.swapchain;
-			presentInfo.pImageIndices = &index;
-			VK_WrapResult( vkQueuePresentKHR( swapchain->presentQueue->vk.queue, &presentInfo ) );
+		VkPresentInfoKHR presentInfo = { VK_STRUCTURE_TYPE_PRESENT_INFO_KHR };
+		presentInfo.waitSemaphoreCount = num_wait_semaphores;
+		presentInfo.pWaitSemaphores = wait_semaphores;
+		presentInfo.swapchainCount = 1;
+		presentInfo.pSwapchains = &swapchain->vk.swapchain;
+		presentInfo.pImageIndices = &index;
+		VK_WrapResult( vkQueuePresentKHR( swapchain->presentQueue->vk.queue, &presentInfo ) );
 	}
 #endif
-
 }
-
 
 int RISwapchainResize( struct RIDevice_s *dev, struct RISwapchain_s *swapchain, uint16_t width, uint16_t height )
 {
@@ -297,7 +291,7 @@ int RISwapchainResize( struct RIDevice_s *dev, struct RISwapchain_s *swapchain, 
 		VkSwapchainCreateInfoKHR swapChainCreateInfo = { VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR };
 		swapChainCreateInfo.surface = swapchain->vk.surface;
 		swapChainCreateInfo.minImageCount = swapchain->vk.imageCount;
-		swapChainCreateInfo.imageFormat = RIFormatToVK(swapchain->format);
+		swapChainCreateInfo.imageFormat = RIFormatToVK( swapchain->format );
 		swapChainCreateInfo.imageColorSpace = swapchain->vk.imageColorSpace;
 		swapChainCreateInfo.imageExtent.width = width;
 		swapChainCreateInfo.imageExtent.height = height;
@@ -321,7 +315,7 @@ int RISwapchainResize( struct RIDevice_s *dev, struct RISwapchain_s *swapchain, 
 			if( swapchain->vk.views[i] )
 				vkDestroyImageView( dev->vk.device, swapchain->vk.views[i], NULL );
 			swapchain->vk.views[i] = VK_NULL_HANDLE;
-			//swapchain->vk.images[i] = VK_NULL_HANDLE;
+			// swapchain->vk.images[i] = VK_NULL_HANDLE;
 		}
 
 		// Zig: re-query images
@@ -336,7 +330,7 @@ int RISwapchainResize( struct RIDevice_s *dev, struct RISwapchain_s *swapchain, 
 			VkImageViewCreateInfo viewCreateInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
 			viewCreateInfo.image = swapchain->vk.images[i];
 			viewCreateInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-			viewCreateInfo.format = RIFormatToVK(swapchain->format);
+			viewCreateInfo.format = RIFormatToVK( swapchain->format );
 			viewCreateInfo.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
 			viewCreateInfo.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
 			viewCreateInfo.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
@@ -357,32 +351,40 @@ int RISwapchainResize( struct RIDevice_s *dev, struct RISwapchain_s *swapchain, 
 	return 1;
 }
 
-struct RIDescriptor_s RISwapchainDescriptor( struct RISwapchain_s *swapchain, uint32_t index )
-{
-	struct RIDescriptor_s desc = {
-		.texture = {
-			.vk = {
-				.image =  swapchain->vk.images[index],
-			}
-		},
+struct RITextureView_s RISwapchainGetTextureView(struct RISwapchain_s *swapchain, uint32_t index) {
+	struct RITextureView_s view = {
 		.vk = {
-			.image = {
-				.imageView = swapchain->vk.views[index],
-			},
+			.image = swapchain->vk.views[index]
 		}
 	};
-	return desc;
+	return view;
 }
 
-//struct RITexture_s RISwapchainGetTexture( struct RISwapchain_s *swapchain, uint32_t index )
+
+//struct RIDescriptor_s RISwapchainDescriptor( struct RISwapchain_s *swapchain, uint32_t index )
+//{
+//	struct RIDescriptor_s desc = { .texture = { .vk =
+//													{
+//														.image = swapchain->vk.images[index],
+//													} },
+//								   .vk = {
+//									   .image =
+//										   {
+//											   .imageView = swapchain->vk.views[index],
+//										   },
+//								   } };
+//	return desc;
+//}
+
+// struct RITexture_s RISwapchainGetTexture( struct RISwapchain_s *swapchain, uint32_t index )
 //{
 //	struct RITexture_s tex;
 //	memset( &tex, 0, sizeof( tex ) );
-//#if ( DEVICE_IMPL_VULKAN )
+// #if ( DEVICE_IMPL_VULKAN )
 //	tex.vk.image = swapchain->vk.images[index];
-//#endif
+// #endif
 //	return tex;
-//}
+// }
 
 uint32_t RISwapchainGetImageCount( struct RISwapchain_s *swapchain )
 {
@@ -392,11 +394,10 @@ uint32_t RISwapchainGetImageCount( struct RISwapchain_s *swapchain )
 	return 0;
 }
 
-//uint32_t RISwapchainGetFormat( struct RISwapchain_s *swapchain )
+// uint32_t RISwapchainGetFormat( struct RISwapchain_s *swapchain )
 //{
-//#if ( DEVICE_IMPL_VULKAN )
+// #if ( DEVICE_IMPL_VULKAN )
 //	return VKToRIFormat( swapchain->vk.imageFormat );
-//#endif
+// #endif
 //	return 0;
-//}
-
+// }

--- a/source/ref_nri/ri_swapchain.c
+++ b/source/ref_nri/ri_swapchain.c
@@ -307,25 +307,20 @@ int RISwapchainResize( struct RIDevice_s *dev, struct RISwapchain_s *swapchain, 
 		result = vkCreateSwapchainKHR( dev->vk.device, &swapChainCreateInfo, NULL, &swapchain->vk.swapchain );
 		VK_WrapResult( result );
 
-		// Zig: dkb.destroySwapchainKHR(device, old_swapchain, null)
 		vkDestroySwapchainKHR( dev->vk.device, oldSwapchain, NULL );
 
-		// Zig: destroy old views, zero slices
 		for( size_t i = 0; i < swapchain->vk.imageCount; i++ ) {
 			if( swapchain->vk.views[i] )
 				vkDestroyImageView( dev->vk.device, swapchain->vk.views[i], NULL );
 			swapchain->vk.views[i] = VK_NULL_HANDLE;
-			// swapchain->vk.images[i] = VK_NULL_HANDLE;
 		}
 
-		// Zig: re-query images
 		uint32_t imageNum = 0;
 		vkGetSwapchainImagesKHR( dev->vk.device, swapchain->vk.swapchain, &imageNum, NULL );
 		assert( imageNum <= RI_MAX_SWAPCHAIN_IMAGES );
 		vkGetSwapchainImagesKHR( dev->vk.device, swapchain->vk.swapchain, &imageNum, swapchain->vk.images );
 		swapchain->vk.imageCount = imageNum;
 
-		// Zig: recreate image views
 		for( size_t i = 0; i < imageNum; i++ ) {
 			VkImageViewCreateInfo viewCreateInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
 			viewCreateInfo.image = swapchain->vk.images[i];

--- a/source/ref_nri/ri_swapchain.c
+++ b/source/ref_nri/ri_swapchain.c
@@ -1,26 +1,25 @@
 #include "ri_swapchain.h"
+#include "ri_format.h"
 #include "ri_renderer.h"
 #include "ri_types.h"
-#include "ri_format.h"
-
-
+#include "ri_vk.h"
 #if ( DEVICE_IMPL_VULKAN )
 
-static uint32_t __priority_BT709_G22_16BIT(const VkSurfaceFormatKHR* surface)  {
-    return ((surface->format == VK_FORMAT_R16G16B16A16_SFLOAT) << 0) | 
-           ((surface->colorSpace == VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT) << 1);
+static uint32_t __priority_BT709_G22_16BIT( const VkSurfaceFormatKHR *surface )
+{
+	return ( ( surface->format == VK_FORMAT_R16G16B16A16_SFLOAT ) << 0 ) | ( ( surface->colorSpace == VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT ) << 1 );
 };
 
-static uint32_t __priority_BT709_G22_8BIT(const VkSurfaceFormatKHR* surface) {
-    // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSurfaceFormatsKHR.html
-    // There is always a corresponding UNORM, SRGB just need to consider UNORM
-    return ((surface->format == VK_FORMAT_R8G8B8A8_UNORM || surface->format == VK_FORMAT_B8G8R8A8_UNORM) << 0) | 
-  				 ((surface->colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) << 1);
+static uint32_t __priority_BT709_G22_8BIT( const VkSurfaceFormatKHR *surface )
+{
+	// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceSurfaceFormatsKHR.html
+	// There is always a corresponding UNORM, SRGB just need to consider UNORM
+	return ( ( surface->format == VK_FORMAT_R8G8B8A8_UNORM || surface->format == VK_FORMAT_B8G8R8A8_UNORM ) << 0 ) | ( ( surface->colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR ) << 1 );
 }
 
-static uint32_t __priority_BT709_G22_10BIT(const VkSurfaceFormatKHR* surface){
-    return ((surface->format == VK_FORMAT_A2B10G10R10_UNORM_PACK32) << 0) | 
-           ((surface->colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) << 1);
+static uint32_t __priority_BT709_G22_10BIT( const VkSurfaceFormatKHR *surface )
+{
+	return ( ( surface->format == VK_FORMAT_A2B10G10R10_UNORM_PACK32 ) << 0 ) | ( ( surface->colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR ) << 1 );
 }
 
 static uint32_t __priority_BT2020_G2084_10BIT( const VkSurfaceFormatKHR *surface )
@@ -90,11 +89,11 @@ int InitRISwapchain( struct RIDevice_s *dev, struct RISwapchainDesc_s *init, str
 #endif
 	uint32_t numSurfaceFormats = 0;
 	result = vkGetPhysicalDeviceSurfaceFormatsKHR( dev->physicalAdapter.vk.physicalDevice, swapchain->vk.surface, &numSurfaceFormats, NULL );
-	VK_WrapResult(result);
+	VK_WrapResult( result );
 	VkSurfaceFormatKHR *surfaceFormats = malloc( sizeof( VkSurfaceFormatKHR ) * numSurfaceFormats );
 	result = vkGetPhysicalDeviceSurfaceFormatsKHR( dev->physicalAdapter.vk.physicalDevice, swapchain->vk.surface, &numSurfaceFormats, surfaceFormats );
-	VK_WrapResult(result);
-	VkSurfaceFormatKHR *selectedSurf = surfaceFormats ;
+	VK_WrapResult( result );
+	VkSurfaceFormatKHR *selectedSurf = surfaceFormats;
 	{
 		uint32_t ( *priorityHandler )( const VkSurfaceFormatKHR *surface ) = __priority_BT709_G22_8BIT;
 		switch( init->format ) {
@@ -120,34 +119,30 @@ int InitRISwapchain( struct RIDevice_s *dev, struct RISwapchainDesc_s *init, str
 	}
 
 	uint32_t presentModeCount = 0;
-  result = vkGetPhysicalDeviceSurfacePresentModesKHR(dev->physicalAdapter.vk.physicalDevice, swapchain->vk.surface, &presentModeCount, NULL);
-	VK_WrapResult(result);
-	VkPresentModeKHR* supportedPresentMode = malloc(presentModeCount * sizeof(VkPresentModeKHR));
-  result = vkGetPhysicalDeviceSurfacePresentModesKHR(dev->physicalAdapter.vk.physicalDevice, swapchain->vk.surface, &presentModeCount, supportedPresentMode);
-	VK_WrapResult(result);
+	result = vkGetPhysicalDeviceSurfacePresentModesKHR( dev->physicalAdapter.vk.physicalDevice, swapchain->vk.surface, &presentModeCount, NULL );
+	VK_WrapResult( result );
+	VkPresentModeKHR *supportedPresentMode = malloc( presentModeCount * sizeof( VkPresentModeKHR ) );
+	result = vkGetPhysicalDeviceSurfacePresentModesKHR( dev->physicalAdapter.vk.physicalDevice, swapchain->vk.surface, &presentModeCount, supportedPresentMode );
+	VK_WrapResult( result );
 
-  // The VK_PRESENT_MODE_FIFO_KHR mode must always be present as per spec
-  // This mode waits for the vertical blank ("v-sync")
-  VkPresentModeKHR presentMode = VK_PRESENT_MODE_FIFO_KHR;
+	// The VK_PRESENT_MODE_FIFO_KHR mode must always be present as per spec
+	// This mode waits for the vertical blank ("v-sync")
+	VkPresentModeKHR presentMode = VK_PRESENT_MODE_FIFO_KHR;
 
-  VkPresentModeKHR preferredModeList[] = {
-      VK_PRESENT_MODE_IMMEDIATE_KHR,
-      VK_PRESENT_MODE_FIFO_RELAXED_KHR,
-      VK_PRESENT_MODE_FIFO_KHR
-  };
-  for( size_t j = 0; j < Q_ARRAY_COUNT( preferredModeList ); j++ ) {
-	  VkPresentModeKHR mode = preferredModeList[j];
-	  uint32_t i = 0;
-	  for(; i < presentModeCount; ++i ) {
-	  	if(supportedPresentMode[i] == mode) {
-	  		break;
-	  	}
-	  }
-	  if( i < presentModeCount ) {
-		  presentMode = mode;
-		  break;
-	  }
-  }
+	VkPresentModeKHR preferredModeList[] = { VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_FIFO_RELAXED_KHR, VK_PRESENT_MODE_FIFO_KHR };
+	for( size_t j = 0; j < Q_ARRAY_COUNT( preferredModeList ); j++ ) {
+		VkPresentModeKHR mode = preferredModeList[j];
+		uint32_t i = 0;
+		for( ; i < presentModeCount; ++i ) {
+			if( supportedPresentMode[i] == mode ) {
+				break;
+			}
+		}
+		if( i < presentModeCount ) {
+			presentMode = mode;
+			break;
+		}
+	}
 	{
 		VkSwapchainCreateInfoKHR swapChainCreateInfo = { VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR };
 		swapChainCreateInfo.flags = 0;
@@ -155,7 +150,7 @@ int InitRISwapchain( struct RIDevice_s *dev, struct RISwapchainDesc_s *init, str
 		swapChainCreateInfo.minImageCount = init->imageCount;
 		swapChainCreateInfo.imageFormat = selectedSurf->format;
 		swapChainCreateInfo.imageColorSpace = selectedSurf->colorSpace;
-		swapChainCreateInfo.imageExtent.width = init->width ;
+		swapChainCreateInfo.imageExtent.width = init->width;
 		swapChainCreateInfo.imageExtent.height = init->height;
 		swapChainCreateInfo.imageArrayLayers = 1;
 		swapChainCreateInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
@@ -167,102 +162,103 @@ int InitRISwapchain( struct RIDevice_s *dev, struct RISwapchainDesc_s *init, str
 		swapChainCreateInfo.presentMode = presentMode;
 		swapChainCreateInfo.clipped = VK_TRUE;
 		swapChainCreateInfo.oldSwapchain = 0;
-		result = vkCreateSwapchainKHR( dev->vk.device, &swapChainCreateInfo, NULL, &swapchain->vk.swapchain);
+		result = vkCreateSwapchainKHR( dev->vk.device, &swapChainCreateInfo, NULL, &swapchain->vk.swapchain );
 	}
 
 	{
 		uint32_t imageNum = 0;
-		vkGetSwapchainImagesKHR(dev->vk.device, swapchain->vk.swapchain, &imageNum, NULL);
-		assert(imageNum <= RI_MAX_SWAPCHAIN_IMAGES);
-		vkGetSwapchainImagesKHR(dev->vk.device, swapchain->vk.swapchain, &imageNum, swapchain->vk.images);
-		for(size_t i = 0; i < imageNum; i++) {
-			swapchain->textures[i].vk.image = swapchain->vk.images[i];
+		vkGetSwapchainImagesKHR( dev->vk.device, swapchain->vk.swapchain, &imageNum, NULL );
+		assert( imageNum <= RI_MAX_SWAPCHAIN_IMAGES );
+		vkGetSwapchainImagesKHR( dev->vk.device, swapchain->vk.swapchain, &imageNum, swapchain->vk.images );
+		swapchain->vk.imageCount = imageNum;
+
+		// Cache surface format and present mode for resize (Zig: image_format, image_colorspace, present_mode)
+		swapchain->format = VKToRIFormat( selectedSurf->format );
+		swapchain->vk.imageColorSpace = selectedSurf->colorSpace;
+		swapchain->vk.presentMode = presentMode;
+
+		// Create binary semaphores (Zig: signal_semaphores)
+		for( size_t i = 0; i < imageNum; i++ ) {
+			VkSemaphoreCreateInfo createInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
+			VkSemaphoreTypeCreateInfo timelineCreateInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO };
+			timelineCreateInfo.semaphoreType = VK_SEMAPHORE_TYPE_BINARY;
+			R_VK_ADD_STRUCT( &createInfo, &timelineCreateInfo );
+
+			result = vkCreateSemaphore( dev->vk.device, &createInfo, NULL, &swapchain->vk.signaled[i] );
+			VK_WrapResult( result );
 		}
-		swapchain->imageCount = imageNum;
-		swapchain->format = VKToRIFormat(selectedSurf->format);
 
-		for(size_t i = 0; i < RI_MAX_SWAPCHAIN_IMAGES; i++) {
-			VkSemaphoreCreateInfo createInfo = {VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
-      VkSemaphoreTypeCreateInfo timelineCreateInfo = {VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO};
-      timelineCreateInfo.semaphoreType = VK_SEMAPHORE_TYPE_BINARY;
-			R_VK_ADD_STRUCT(&createInfo, &timelineCreateInfo);
-
-			result = vkCreateSemaphore(dev->vk.device, &createInfo, NULL, &swapchain->vk.imageAcquireSem[i]);
-			VK_WrapResult(result);
-			
-			result = vkCreateSemaphore(dev->vk.device, &createInfo, NULL, &swapchain->vk.finishSem[i]);
-			VK_WrapResult(result);
+		// Create image views (Zig: for (0..images.len) |k| { dkb.createImageView(...) })
+		for( size_t i = 0; i < imageNum; i++ ) {
+			VkImageViewCreateInfo viewCreateInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
+			viewCreateInfo.image = swapchain->vk.images[i];
+			viewCreateInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+			viewCreateInfo.format = selectedSurf->format;
+			viewCreateInfo.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
+			viewCreateInfo.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
+			viewCreateInfo.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
+			viewCreateInfo.components.a = VK_COMPONENT_SWIZZLE_IDENTITY;
+			viewCreateInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+			viewCreateInfo.subresourceRange.baseMipLevel = 0;
+			viewCreateInfo.subresourceRange.levelCount = 1;
+			viewCreateInfo.subresourceRange.baseArrayLayer = 0;
+			viewCreateInfo.subresourceRange.layerCount = 1;
+			result = vkCreateImageView( dev->vk.device, &viewCreateInfo, NULL, &swapchain->vk.views[i] );
+			VK_WrapResult( result );
 		}
 	}
-	free(supportedPresentMode);
-	free(surfaceFormats);
-  return RI_SUCCESS;
+	free( supportedPresentMode );
+	free( surfaceFormats );
+	return RI_SUCCESS;
 }
 
 uint32_t RISwapchainAcquireNextTexture( struct RIDevice_s *dev, struct RISwapchain_s *swapchain )
 {
 #if ( DEVICE_IMPL_VULKAN )
 	{
-		VkSemaphore imageAcquiredSemaphore = swapchain->vk.imageAcquireSem[swapchain->vk.frameIndex];
-		VK_WrapResult( vkAcquireNextImageKHR( dev->vk.device, swapchain->vk.swapchain, 5000 * 1000000ull, imageAcquiredSemaphore, VK_NULL_HANDLE, &swapchain->vk.textureIndex ) );
-		return swapchain->vk.textureIndex;
+		uint32_t image_index;
+		swapchain->vk.signal_idx = ( swapchain->vk.signal_idx + 1 ) % swapchain->vk.imageCount;
+		VkSemaphore imageAcquiredSemaphore = swapchain->vk.signaled[swapchain->vk.signal_idx];
+		VK_WrapResult( vkAcquireNextImageKHR( dev->vk.device, swapchain->vk.swapchain, UINT64_MAX, imageAcquiredSemaphore, VK_NULL_HANDLE, &image_index ) );
+		return image_index;
 	}
 #endif
 	return 0;
 }
 
-void RISwapchainPresent(struct RIDevice_s* dev, struct RISwapchain_s* swapchain) {
-#if ( DEVICE_IMPL_VULKAN )
-	{
-		VkSemaphore imageAcquiredSemaphore = swapchain->vk.imageAcquireSem[swapchain->vk.frameIndex];
-		VkSemaphore renderingFinishedSemaphore = swapchain->vk.finishSem[swapchain->vk.frameIndex];
-		{ // Wait & Signal
-			VkSemaphoreSubmitInfo waitSemaphore = { VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO };
-			waitSemaphore.semaphore = imageAcquiredSemaphore;
-			waitSemaphore.stageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-
-			VkSemaphoreSubmitInfo signalSemaphore = { VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO };
-			signalSemaphore.semaphore = renderingFinishedSemaphore;
-			signalSemaphore.stageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-
-			VkSubmitInfo2 submitInfo = { VK_STRUCTURE_TYPE_SUBMIT_INFO_2 };
-			submitInfo.waitSemaphoreInfoCount = 1;
-			submitInfo.pWaitSemaphoreInfos = &waitSemaphore;
-			submitInfo.signalSemaphoreInfoCount = 1;
-			submitInfo.pSignalSemaphoreInfos = &signalSemaphore;
-			VK_WrapResult( vkQueueSubmit2( swapchain->presentQueue->vk.queue, 1, &submitInfo, VK_NULL_HANDLE ) );
-		}
-		{
-			VkPresentInfoKHR presentInfo = { VK_STRUCTURE_TYPE_PRESENT_INFO_KHR };
-			presentInfo.waitSemaphoreCount = 1;
-			presentInfo.pWaitSemaphores = &renderingFinishedSemaphore;
-			presentInfo.swapchainCount = 1;
-			presentInfo.pSwapchains = &swapchain->vk.swapchain;
-			presentInfo.pImageIndices = &swapchain->vk.textureIndex;
-
-			//TODO: need to add support for presentID
-			// VkPresentIdKHR presentId = { VK_STRUCTURE_TYPE_PRESENT_ID_KHR };
-			// presentId.swapchainCount = 1;
-			// presentId.pPresentIds = &swapchain->vk.presentID;
-			// if( dev->physicalAdapter.vk.isPresentIDSupported )
-			// 	presentInfo.pNext = &presentId;
-			VK_WrapResult( vkQueuePresentKHR( swapchain->presentQueue->vk.queue, &presentInfo ) );
-		}
-		swapchain->vk.presentID++;
-		swapchain->vk.frameIndex = ( swapchain->vk.frameIndex + 1 ) % RI_MAX_SWAPCHAIN_IMAGES;
-	}
-#endif
-}
+//void RISwapchainPresent( struct RIDevice_s *dev, struct RISwapchain_s *swapchain )
+//{
+//#if ( DEVICE_IMPL_VULKAN )
+//	{
+//		VkSemaphore renderingFinishedSemaphore = swapchain->vk.renderFinished[swapchain->vk.signal_idx];
+//		{
+//			VkPresentInfoKHR presentInfo = { VK_STRUCTURE_TYPE_PRESENT_INFO_KHR };
+//			presentInfo.waitSemaphoreCount = 1;
+//			presentInfo.pWaitSemaphores = &renderingFinishedSemaphore;
+//			presentInfo.swapchainCount = 1;
+//			presentInfo.pSwapchains = &swapchain->vk.swapchain;
+//			presentInfo.pImageIndices = &swapchain->vk.textureIndex;
+//
+//			// TODO: need to add support for presentID
+//			VK_WrapResult( vkQueuePresentKHR( swapchain->presentQueue->vk.queue, &presentInfo ) );
+//		}
+//	}
+//#endif
+//}
 
 void FreeRISwapchain( struct RIDevice_s *dev, struct RISwapchain_s *swapchain )
 {
 #if ( DEVICE_IMPL_VULKAN )
 	{
+		// Zig: for (self.backend.vk.signal_semaphores) |sem| { destroySemaphore }
 		for( size_t p = 0; p < RI_MAX_SWAPCHAIN_IMAGES; p++ ) {
-			if( swapchain->vk.imageAcquireSem[p] )
-				vkDestroySemaphore( dev->vk.device, swapchain->vk.imageAcquireSem[p], NULL );
-			if( swapchain->vk.finishSem[p] )
-				vkDestroySemaphore( dev->vk.device, swapchain->vk.finishSem[p], NULL );
+			if( swapchain->vk.signaled[p] )
+				vkDestroySemaphore( dev->vk.device, swapchain->vk.signaled[p], NULL );
+		}
+		// Zig: for (self.backend.vk.views) |view| { destroyImageView }
+		for( size_t p = 0; p < RI_MAX_SWAPCHAIN_IMAGES; p++ ) {
+			if( swapchain->vk.views[p] )
+				vkDestroyImageView( dev->vk.device, swapchain->vk.views[p], NULL );
 		}
 		if( swapchain->vk.swapchain )
 			vkDestroySwapchainKHR( dev->vk.device, swapchain->vk.swapchain, NULL );
@@ -272,3 +268,135 @@ void FreeRISwapchain( struct RIDevice_s *dev, struct RISwapchain_s *swapchain )
 	memset( swapchain, 0, sizeof( struct RISwapchain_s ) );
 #endif
 }
+
+void RISwapchainPresent_vk(struct RIDevice_s* dev, struct RISwapchain_s* swapchain, uint32_t index, size_t num_wait_semaphores, VkSemaphore* wait_semaphores ) {
+#if ( DEVICE_IMPL_VULKAN )
+	{
+			VkPresentInfoKHR presentInfo = { VK_STRUCTURE_TYPE_PRESENT_INFO_KHR };
+			presentInfo.waitSemaphoreCount = num_wait_semaphores;
+			presentInfo.pWaitSemaphores = wait_semaphores;
+			presentInfo.swapchainCount = 1;
+			presentInfo.pSwapchains = &swapchain->vk.swapchain;
+			presentInfo.pImageIndices = &index;
+			VK_WrapResult( vkQueuePresentKHR( swapchain->presentQueue->vk.queue, &presentInfo ) );
+	}
+#endif
+
+}
+
+
+int RISwapchainResize( struct RIDevice_s *dev, struct RISwapchain_s *swapchain, uint16_t width, uint16_t height )
+{
+	if( width == swapchain->width && height == swapchain->height )
+		return 0;
+#if ( DEVICE_IMPL_VULKAN )
+	{
+		VkResult result;
+		VkSwapchainKHR oldSwapchain = swapchain->vk.swapchain;
+
+		VkSwapchainCreateInfoKHR swapChainCreateInfo = { VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR };
+		swapChainCreateInfo.surface = swapchain->vk.surface;
+		swapChainCreateInfo.minImageCount = swapchain->vk.imageCount;
+		swapChainCreateInfo.imageFormat = RIFormatToVK(swapchain->format);
+		swapChainCreateInfo.imageColorSpace = swapchain->vk.imageColorSpace;
+		swapChainCreateInfo.imageExtent.width = width;
+		swapChainCreateInfo.imageExtent.height = height;
+		swapChainCreateInfo.imageArrayLayers = 1;
+		swapChainCreateInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+		swapChainCreateInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+		swapChainCreateInfo.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+		swapChainCreateInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+		swapChainCreateInfo.presentMode = swapchain->vk.presentMode;
+		swapChainCreateInfo.clipped = VK_TRUE;
+		swapChainCreateInfo.oldSwapchain = oldSwapchain; // Zig: swapchain_create_info.old_swapchain = old_swapchain
+
+		result = vkCreateSwapchainKHR( dev->vk.device, &swapChainCreateInfo, NULL, &swapchain->vk.swapchain );
+		VK_WrapResult( result );
+
+		// Zig: dkb.destroySwapchainKHR(device, old_swapchain, null)
+		vkDestroySwapchainKHR( dev->vk.device, oldSwapchain, NULL );
+
+		// Zig: destroy old views, zero slices
+		for( size_t i = 0; i < swapchain->vk.imageCount; i++ ) {
+			if( swapchain->vk.views[i] )
+				vkDestroyImageView( dev->vk.device, swapchain->vk.views[i], NULL );
+			swapchain->vk.views[i] = VK_NULL_HANDLE;
+			//swapchain->vk.images[i] = VK_NULL_HANDLE;
+		}
+
+		// Zig: re-query images
+		uint32_t imageNum = 0;
+		vkGetSwapchainImagesKHR( dev->vk.device, swapchain->vk.swapchain, &imageNum, NULL );
+		assert( imageNum <= RI_MAX_SWAPCHAIN_IMAGES );
+		vkGetSwapchainImagesKHR( dev->vk.device, swapchain->vk.swapchain, &imageNum, swapchain->vk.images );
+		swapchain->vk.imageCount = imageNum;
+
+		// Zig: recreate image views
+		for( size_t i = 0; i < imageNum; i++ ) {
+			VkImageViewCreateInfo viewCreateInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
+			viewCreateInfo.image = swapchain->vk.images[i];
+			viewCreateInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+			viewCreateInfo.format = RIFormatToVK(swapchain->format);
+			viewCreateInfo.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
+			viewCreateInfo.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
+			viewCreateInfo.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
+			viewCreateInfo.components.a = VK_COMPONENT_SWIZZLE_IDENTITY;
+			viewCreateInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+			viewCreateInfo.subresourceRange.baseMipLevel = 0;
+			viewCreateInfo.subresourceRange.levelCount = 1;
+			viewCreateInfo.subresourceRange.baseArrayLayer = 0;
+			viewCreateInfo.subresourceRange.layerCount = 1;
+			result = vkCreateImageView( dev->vk.device, &viewCreateInfo, NULL, &swapchain->vk.views[i] );
+			VK_WrapResult( result );
+		}
+
+		swapchain->width = width;
+		swapchain->height = height;
+	}
+#endif
+	return 1;
+}
+
+struct RIDescriptor_s RISwapchainDescriptor( struct RISwapchain_s *swapchain, uint32_t index )
+{
+	struct RIDescriptor_s desc = {
+		.texture = {
+			.vk = {
+				.image =  swapchain->vk.images[index],
+			}
+		},
+		.vk = {
+			.image = {
+				.imageView = swapchain->vk.views[index],
+			},
+		}
+	};
+	return desc;
+}
+
+//struct RITexture_s RISwapchainGetTexture( struct RISwapchain_s *swapchain, uint32_t index )
+//{
+//	struct RITexture_s tex;
+//	memset( &tex, 0, sizeof( tex ) );
+//#if ( DEVICE_IMPL_VULKAN )
+//	tex.vk.image = swapchain->vk.images[index];
+//#endif
+//	return tex;
+//}
+
+uint32_t RISwapchainGetImageCount( struct RISwapchain_s *swapchain )
+{
+#if ( DEVICE_IMPL_VULKAN )
+	return swapchain->vk.imageCount;
+#endif
+	return 0;
+}
+
+//uint32_t RISwapchainGetFormat( struct RISwapchain_s *swapchain )
+//{
+//#if ( DEVICE_IMPL_VULKAN )
+//	return VKToRIFormat( swapchain->vk.imageFormat );
+//#endif
+//	return 0;
+//}
+

--- a/source/ref_nri/ri_swapchain.h
+++ b/source/ref_nri/ri_swapchain.h
@@ -34,8 +34,8 @@ struct RISwapchainDesc_s {
 int InitRISwapchain(struct RIDevice_s* dev, struct RISwapchainDesc_s* init, struct RISwapchain_s* swapchain);
 uint32_t RISwapchainAcquireNextTexture(struct RIDevice_s* dev, struct RISwapchain_s* swapchain);
 void FreeRISwapchain(struct RIDevice_s* dev, struct RISwapchain_s* swapchain);
-struct RIDescriptor_s RISwapchainDescriptor(struct RISwapchain_s* swapchain, uint32_t index);
 uint32_t RISwapchainGetImageCount(struct RISwapchain_s *swapchain);
+struct RITextureView_s RISwapchainGetTextureView(struct RISwapchain_s* swapchain, uint32_t index); 
 
 int RISwapchainResize(struct RIDevice_s* dev, struct RISwapchain_s* swapchain, uint16_t width, uint16_t height);
 void RISwapchainPresent_vk(struct RIDevice_s* dev, struct RISwapchain_s* swapchain, uint32_t index, size_t num_wait_semaphores, VkSemaphore* wait_semaphores );

--- a/source/ref_nri/ri_swapchain.h
+++ b/source/ref_nri/ri_swapchain.h
@@ -33,12 +33,17 @@ struct RISwapchainDesc_s {
 
 int InitRISwapchain(struct RIDevice_s* dev, struct RISwapchainDesc_s* init, struct RISwapchain_s* swapchain);
 uint32_t RISwapchainAcquireNextTexture(struct RIDevice_s* dev, struct RISwapchain_s* swapchain);
-void RISwapchainPresent(struct RIDevice_s* dev, struct RISwapchain_s* swapchain);
 void FreeRISwapchain(struct RIDevice_s* dev, struct RISwapchain_s* swapchain);
+struct RIDescriptor_s RISwapchainDescriptor(struct RISwapchain_s* swapchain, uint32_t index);
+uint32_t RISwapchainGetImageCount(struct RISwapchain_s *swapchain);
+
+int RISwapchainResize(struct RIDevice_s* dev, struct RISwapchain_s* swapchain, uint16_t width, uint16_t height);
+void RISwapchainPresent_vk(struct RIDevice_s* dev, struct RISwapchain_s* swapchain, uint32_t index, size_t num_wait_semaphores, VkSemaphore* wait_semaphores );
+
 
 static inline bool IsRISwapchainValid( struct RISwapchain_s *swapchain )
 {
-	return swapchain->imageCount > 0 && swapchain->width > 0 && swapchain->height > 0;
+	return RISwapchainGetImageCount(swapchain) > 0 && swapchain->width > 0 && swapchain->height > 0;
 }
 
 #endif

--- a/source/ref_nri/ri_types.h
+++ b/source/ref_nri/ri_types.h
@@ -319,8 +319,6 @@ struct RIDescriptor_s {
 	// unique id to mark the descriptor
 	hash_t cookie;
 	uint8_t flags;
-	struct RIBuffer_s buffer;
-	struct RITexture_s texture;
 	union {
 #if ( DEVICE_IMPL_VULKAN )
 		struct {

--- a/source/ref_nri/ri_types.h
+++ b/source/ref_nri/ri_types.h
@@ -19,16 +19,18 @@
 #include "vk_mem_alloc.h"
 #endif
 
-#define R_VK_ADD_STRUCT(current, next) { \
-  void* __pNext = (void*)((current)->pNext); \
-  (current)->pNext = (next); \
-  (next)->pNext = __pNext; \
-}
+#define R_VK_ADD_STRUCT( current, next )                \
+	{                                                   \
+		void *__pNext = (void *)( ( current )->pNext ); \
+		( current )->pNext = ( next );                  \
+		( next )->pNext = __pNext;                      \
+	}
 #define VK_WrapResult( res ) __vk_WrapResult( res, __FILE__, __FUNCTION__, __LINE__ )
 
-static inline bool __vk_WrapResult(VkResult result, const char *sourceFilename, const char *functionName, int sourceLine) {
-	if(result != VK_SUCCESS) {
-		printf( "RI: VK %i, file %s:%i (%s)\n", result, sourceFilename, sourceLine, functionName);
+static inline bool __vk_WrapResult( VkResult result, const char *sourceFilename, const char *functionName, int sourceLine )
+{
+	if( result != VK_SUCCESS ) {
+		printf( "RI: VK %i, file %s:%i (%s)\n", result, sourceFilename, sourceLine, functionName );
 		return false;
 	}
 	return true;
@@ -45,14 +47,14 @@ static inline bool __vk_WrapResult(VkResult result, const char *sourceFilename, 
 #define RI_QUEUE_INVALID 0x0
 
 enum RIPresetLevel_e {
-    RI_GPU_PRESET_NONE = 0,
-    RI_GPU_PRESET_OFFICE,  // This means unsupported
-    RI_GPU_PRESET_VERYLOW, // Mostly for mobile GPU
-    RI_GPU_PRESET_LOW,
-    RI_GPU_PRESET_MEDIUM,
-    RI_GPU_PRESET_HIGH,
-    RI_GPU_PRESET_ULTRA,
-    RI_GPU_PRESET_COUNT
+	RI_GPU_PRESET_NONE = 0,
+	RI_GPU_PRESET_OFFICE,  // This means unsupported
+	RI_GPU_PRESET_VERYLOW, // Mostly for mobile GPU
+	RI_GPU_PRESET_LOW,
+	RI_GPU_PRESET_MEDIUM,
+	RI_GPU_PRESET_HIGH,
+	RI_GPU_PRESET_ULTRA,
+	RI_GPU_PRESET_COUNT
 };
 
 enum RITextureViewType_s {
@@ -86,12 +88,12 @@ enum RITextureUsageBits_e {
 
 enum RISampleCount_e
 {
-    RI_SAMPLE_COUNT_1 = 1,
-    RI_SAMPLE_COUNT_2 = 2,
-    RI_SAMPLE_COUNT_4 = 4,
-    RI_SAMPLE_COUNT_8 = 8,
-    RI_SAMPLE_COUNT_16 = 16,
-    RI_SAMPLE_COUNT_COUNT = 5,
+	RI_SAMPLE_COUNT_1 = 1,
+	RI_SAMPLE_COUNT_2 = 2,
+	RI_SAMPLE_COUNT_4 = 4,
+	RI_SAMPLE_COUNT_8 = 8,
+	RI_SAMPLE_COUNT_16 = 16,
+	RI_SAMPLE_COUNT_COUNT = 5,
 };
 
 enum RIDeviceAPI_e { 
@@ -124,12 +126,7 @@ enum RIAdapterType_e {
 	RI_ADAPTER_TYPE_DISCRETE_GPU,
 };
 
-enum RIResult_e { 
-	RI_INCOMPLETE_DEVICE = -2,
-	RI_FAIL = -1, 
-	RI_SUCCESS = 0, 
-	RI_INCOMPLETE 
-};
+enum RIResult_e { RI_INCOMPLETE_DEVICE = -2, RI_FAIL = -1, RI_SUCCESS = 0, RI_INCOMPLETE };
 
 enum RIBufferUsage_e {
 	RI_BUFFER_USAGE_NONE = 0,
@@ -160,16 +157,16 @@ enum RIVendor_e {
 };
 
 enum RITopology_e {
-    RI_TOPOLOGY_POINT_LIST,
-    RI_TOPOLOGY_LINE_LIST,
-    RI_TOPOLOGY_LINE_STRIP,
-    RI_TOPOLOGY_TRIANGLE_LIST,
-    RI_TOPOLOGY_TRIANGLE_STRIP,
-    RI_TOPOLOGY_LINE_LIST_WITH_ADJACENCY,
-    RI_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY,
-    RI_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY,
-    RI_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY,
-    RI_TOPOLOGY_PATCH_LIST
+	RI_TOPOLOGY_POINT_LIST,
+	RI_TOPOLOGY_LINE_LIST,
+	RI_TOPOLOGY_LINE_STRIP,
+	RI_TOPOLOGY_TRIANGLE_LIST,
+	RI_TOPOLOGY_TRIANGLE_STRIP,
+	RI_TOPOLOGY_LINE_LIST_WITH_ADJACENCY,
+	RI_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY,
+	RI_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY,
+	RI_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY,
+	RI_TOPOLOGY_PATCH_LIST
 };
 
 // R - fragment's depth or stencil reference
@@ -186,17 +183,9 @@ enum RICompareFunc_e {
 	RI_COMPARE_GREATER_EQUAL // R >= D
 };
 
-enum RICullMode_e {
-	RI_CULL_MODE_NONE = 0,
-	RI_CULL_MODE_FRONT = 0x1,
-	RI_CULL_MODE_BACK = 0x2,
-	RI_CULL_MODE_BOTH = RI_CULL_MODE_FRONT | RI_CULL_MODE_BACK
-};
+enum RICullMode_e { RI_CULL_MODE_NONE = 0, RI_CULL_MODE_FRONT = 0x1, RI_CULL_MODE_BACK = 0x2, RI_CULL_MODE_BOTH = RI_CULL_MODE_FRONT | RI_CULL_MODE_BACK };
 
-enum RIIndexType_e {
-	RI_INDEX_TYPE_16,
-	RI_INDEX_TYPE_32
-};
+enum RIIndexType_e { RI_INDEX_TYPE_16, RI_INDEX_TYPE_32 };
 
 enum RIColorWriteMask_e {
 	RI_COLOR_WRITE_NONE = 0,
@@ -205,58 +194,47 @@ enum RIColorWriteMask_e {
 	RI_COLOR_WRITE_B = 0x4,
 	RI_COLOR_WRITE_A = 0x8,
 
-	RI_COLOR_WRITE_RGB = 
-		RI_COLOR_WRITE_R |
-		RI_COLOR_WRITE_G |
-		RI_COLOR_WRITE_B,
-	
-	RI_COLOR_WRITE_RGBA = 
-		RI_COLOR_WRITE_R |
-		RI_COLOR_WRITE_G |
-		RI_COLOR_WRITE_B |
-		RI_COLOR_WRITE_A
+	RI_COLOR_WRITE_RGB = RI_COLOR_WRITE_R | RI_COLOR_WRITE_G | RI_COLOR_WRITE_B,
+
+	RI_COLOR_WRITE_RGBA = RI_COLOR_WRITE_R | RI_COLOR_WRITE_G | RI_COLOR_WRITE_B | RI_COLOR_WRITE_A
 };
 
 // S0 - source color 0
 // S1 - source color 1
 // D - destination color
 // C - blend constants, set by "CmdSetBlendConstants"
-enum RIBlendFactor_e {   // RGB                               ALPHA
-    RI_BLEND_ZERO,                       // 0                                 0
-    RI_BLEND_ONE,                        // 1                                 1
-    RI_BLEND_SRC_COLOR,                  // S0.r, S0.g, S0.b                  S0.a
-    RI_BLEND_ONE_MINUS_SRC_COLOR,        // 1 - S0.r, 1 - S0.g, 1 - S0.b      1 - S0.a
-    RI_BLEND_DST_COLOR,                  // D.r, D.g, D.b                     D.a
-    RI_BLEND_ONE_MINUS_DST_COLOR,        // 1 - D.r, 1 - D.g, 1 - D.b         1 - D.a
-    RI_BLEND_SRC_ALPHA,                  // S0.a                              S0.a
-    RI_BLEND_ONE_MINUS_SRC_ALPHA,        // 1 - S0.a                          1 - S0.a
-    RI_BLEND_DST_ALPHA,                  // D.a                               D.a
-    RI_BLEND_ONE_MINUS_DST_ALPHA,        // 1 - D.a                           1 - D.a
-    RI_BLEND_CONSTANT_COLOR,             // C.r, C.g, C.b                     C.a
-    RI_BLEND_ONE_MINUS_CONSTANT_COLOR,   // 1 - C.r, 1 - C.g, 1 - C.b         1 - C.a
-    RI_BLEND_CONSTANT_ALPHA,             // C.a                               C.a
-    RI_BLEND_ONE_MINUS_CONSTANT_ALPHA,   // 1 - C.a                           1 - C.a
-    RI_BLEND_SRC_ALPHA_SATURATE,         // min(S0.a, 1 - D.a)                1
-    RI_BLEND_SRC1_COLOR,                 // S1.r, S1.g, S1.b                  S1.a
-    RI_BLEND_ONE_MINUS_SRC1_COLOR,       // 1 - S1.r, 1 - S1.g, 1 - S1.b      1 - S1.a
-    RI_BLEND_SRC1_ALPHA,                 // S1.a                              S1.a
-    RI_BLEND_ONE_MINUS_SRC1_ALPHA        // 1 - S1.a                          1 - S1.a
+enum RIBlendFactor_e {				   // RGB                               ALPHA
+	RI_BLEND_ZERO,					   // 0                                 0
+	RI_BLEND_ONE,					   // 1                                 1
+	RI_BLEND_SRC_COLOR,				   // S0.r, S0.g, S0.b                  S0.a
+	RI_BLEND_ONE_MINUS_SRC_COLOR,	   // 1 - S0.r, 1 - S0.g, 1 - S0.b      1 - S0.a
+	RI_BLEND_DST_COLOR,				   // D.r, D.g, D.b                     D.a
+	RI_BLEND_ONE_MINUS_DST_COLOR,	   // 1 - D.r, 1 - D.g, 1 - D.b         1 - D.a
+	RI_BLEND_SRC_ALPHA,				   // S0.a                              S0.a
+	RI_BLEND_ONE_MINUS_SRC_ALPHA,	   // 1 - S0.a                          1 - S0.a
+	RI_BLEND_DST_ALPHA,				   // D.a                               D.a
+	RI_BLEND_ONE_MINUS_DST_ALPHA,	   // 1 - D.a                           1 - D.a
+	RI_BLEND_CONSTANT_COLOR,		   // C.r, C.g, C.b                     C.a
+	RI_BLEND_ONE_MINUS_CONSTANT_COLOR, // 1 - C.r, 1 - C.g, 1 - C.b         1 - C.a
+	RI_BLEND_CONSTANT_ALPHA,		   // C.a                               C.a
+	RI_BLEND_ONE_MINUS_CONSTANT_ALPHA, // 1 - C.a                           1 - C.a
+	RI_BLEND_SRC_ALPHA_SATURATE,	   // min(S0.a, 1 - D.a)                1
+	RI_BLEND_SRC1_COLOR,			   // S1.r, S1.g, S1.b                  S1.a
+	RI_BLEND_ONE_MINUS_SRC1_COLOR,	   // 1 - S1.r, 1 - S1.g, 1 - S1.b      1 - S1.a
+	RI_BLEND_SRC1_ALPHA,			   // S1.a                              S1.a
+	RI_BLEND_ONE_MINUS_SRC1_ALPHA	   // 1 - S1.a                          1 - S1.a
 };
 
-enum RIWindowType_e {
-	RI_WINDOW_X11,
-	RI_WINDOW_WIN32,
-	RI_WINDOW_METAL,
-	RI_WINDOW_WAYLAND
-};
+enum RIWindowType_e { RI_WINDOW_X11, RI_WINDOW_WIN32, RI_WINDOW_METAL, RI_WINDOW_WAYLAND };
 
 struct RIBuffer_s {
 	union {
-    #if(DEVICE_IMPL_VULKAN)
-    struct {
-    	VkBuffer buffer;
-    } vk;
-    #endif
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			VkBuffer buffer;
+			struct VmaAllocation_T *allocation;
+		} vk;
+#endif
 	};
 };
 
@@ -285,11 +263,22 @@ struct RIBarrierBufferHandle_s {
 
 struct RITexture_s {
 	union {
-    #if(DEVICE_IMPL_VULKAN)
-    struct {
-    	VkImage image;
-    } vk;
-    #endif
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			VkImage image;
+			struct VmaAllocation_T *allocation;
+		} vk;
+#endif
+	};
+};
+
+struct RITextureView_s {
+	union {
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			VkImageView image;
+		} vk;
+#endif
 	};
 };
 
@@ -315,14 +304,14 @@ struct RIFree_s {
 		VkBuffer vkBuffer;
 		VkSampler vkSampler;
 		VkBufferView vkBufferView;
-		struct VmaAllocation_T*  vmaAlloc;
+		struct VmaAllocation_T *vmaAlloc;
 #endif
 	};
 };
 
 enum RIDescriptorFlags_e {
 	RI_VK_DESC_BEGIN = 0,
-	RI_VK_DESC_OWN_SAMPLER = 0x1,		 // owns the backing assets VKImage, VkBuffer
+	RI_VK_DESC_OWN_SAMPLER = 0x1,	// owns the backing assets VKImage, VkBuffer
 	RI_VK_DESC_OWN_IMAGE_VIEW = 0x2 // owns the backing sampler
 };
 
@@ -330,10 +319,10 @@ struct RIDescriptor_s {
 	// unique id to mark the descriptor
 	hash_t cookie;
 	uint8_t flags;
-	struct RIBuffer_s* buffer;
-	struct RITexture_s* texture; 
+	struct RIBuffer_s buffer;
+	struct RITexture_s texture;
 	union {
-#if( DEVICE_IMPL_VULKAN )
+#if ( DEVICE_IMPL_VULKAN )
 		struct {
 			VkDescriptorType type;
 			union {
@@ -346,98 +335,147 @@ struct RIDescriptor_s {
 };
 
 struct RIRect_s {
-    int16_t x;
-    int16_t y;
-    int16_t width;
-    int16_t height;
+	int16_t x;
+	int16_t y;
+	int16_t width;
+	int16_t height;
 };
 
 struct RIViewport_s {
-    float x;
-    float y;
-    float width;
-    float height;
-    float depthMin;
-    float depthMax;
-    bool originBottomLeft; // expects "isViewportOriginBottomLeftSupported"
+	float x;
+	float y;
+	float width;
+	float height;
+	float depthMin;
+	float depthMax;
+	bool originBottomLeft; // expects "isViewportOriginBottomLeftSupported"
+};
+
+struct RIPool_s {
+	union {
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			VkQueue queue;
+			VkCommandPool pool;
+		} vk;
+#endif
+	};
 };
 
 struct RICmd_s {
 	union {
-    #if(DEVICE_IMPL_VULKAN)
-    struct {
-    	VkCommandPool pool;
-    	VkCommandBuffer cmd;  
-    } vk;
-    #endif
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			VkCommandBuffer cmd;
+		} vk;
+#endif
 	};
 };
 
+#define RI_COMMAND_RING_POOL_COUNT RI_NUMBER_FRAMES_FLIGHT
+#define RI_COMMAND_RING_CMD_PER_POOL 8
 
-struct RIQueue_s {
-  union {
-    #if(DEVICE_IMPL_VULKAN)
-      struct {
-        VkQueueFlags queueFlags;
-        uint16_t queueFamilyIdx;
-        uint16_t slotIdx;
-        VkQueue queue;
-      } vk;
-    #endif
-  };
-};
-
-struct RISwapchain_s {
-  struct RIQueue_s* presentQueue;
-	uint16_t imageCount;
-	uint16_t width;
-	uint16_t height;
-	uint32_t format; // RI_Format_e 
-	struct RITexture_s textures[RI_MAX_SWAPCHAIN_IMAGES];
+struct RICommandRingElement_s {
+	struct RICmd_s *cmds;
+	uint32_t numCmds;
+	struct RIPool_s *pool;
 	union {
 #if ( DEVICE_IMPL_VULKAN )
 		struct {
-			uint32_t frameIndex;
-			uint32_t textureIndex;
-			uint64_t presentID;
+			VkSemaphore semaphore;
+			VkFence fence;
+		} vk;
+#endif
+	};
+};
+
+struct RICommandRingBuffer_s {
+	uint32_t poolIndex;
+	uint32_t cmdIndex;
+	uint32_t fenceIndex;
+
+	uint32_t poolCount;
+	uint32_t cmdPerPool;
+	bool syncPrimitive;
+
+	struct RIPool_s pools[RI_COMMAND_RING_POOL_COUNT];
+	struct RICmd_s cmds[RI_COMMAND_RING_POOL_COUNT][RI_COMMAND_RING_CMD_PER_POOL];
+
+	union {
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			VkFence fences[RI_COMMAND_RING_POOL_COUNT][RI_COMMAND_RING_CMD_PER_POOL];
+			VkSemaphore semaphores[RI_COMMAND_RING_POOL_COUNT][RI_COMMAND_RING_CMD_PER_POOL];
+		} vk;
+#endif
+	};
+};
+
+struct RIQueue_s {
+	union {
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			VkQueueFlags queueFlags;
+			uint16_t queueFamilyIdx;
+			uint16_t slotIdx;
+			VkQueue queue;
+		} vk;
+#endif
+	};
+};
+
+struct RISwapchain_s {
+	struct RIQueue_s *presentQueue;
+	uint16_t width;
+	uint16_t height;
+	uint32_t format; // RI_Format_e
+
+	union {
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
 			VkSwapchainKHR swapchain;
 			VkSurfaceKHR surface;
+			uint32_t imageCount;
 			VkImage images[RI_MAX_SWAPCHAIN_IMAGES];
-			VkSemaphore imageAcquireSem[RI_MAX_SWAPCHAIN_IMAGES];
-			VkSemaphore finishSem[RI_MAX_SWAPCHAIN_IMAGES];
+			VkImageView views[RI_MAX_SWAPCHAIN_IMAGES];
+
+			uint32_t signal_idx;
+			VkSemaphore signaled[RI_MAX_SWAPCHAIN_IMAGES];
+
+			VkColorSpaceKHR imageColorSpace;
+			VkPresentModeKHR presentMode;
 		} vk;
 #endif
 	};
 };
 
 struct RIRenderer_s {
-  uint8_t api; // RIDeviceAPI_e  
-  union {
-    #if(DEVICE_IMPL_VULKAN)
-      struct {
-      	uint32_t apiVersion;
-        VkInstance instance;
-        VkDebugUtilsMessengerEXT debugMessageUtils;
-      } vk;
-    #endif
-  };
+	uint8_t api; // RIDeviceAPI_e
+	union {
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			uint32_t apiVersion;
+			VkInstance instance;
+			VkDebugUtilsMessengerEXT debugMessageUtils;
+		} vk;
+#endif
+	};
 };
 
-
 struct RIBackendInit_s {
-  uint8_t api; // RIDeviceAPI_e 
-  const char* applicationName;
-  union {
-    #if(DEVICE_IMPL_VULKAN)
-    struct {
-      uint32_t enableValidationLayer: 1;
-      size_t numFilterLayers;
-      const char* filterLayers[]; // filter layers for the renderer 
-    } vk;
-    #endif
-    #if(DEVICE_IMPL_MTL)
-    #endif
-  };
+	uint8_t api; // RIDeviceAPI_e
+	const char *applicationName;
+	union {
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			uint32_t enableValidationLayer : 1;
+			size_t numFilterLayers;
+			const char *filterLayers[]; // filter layers for the renderer
+		} vk;
+#endif
+#if ( DEVICE_IMPL_MTL )
+#endif
+	};
 };
 
 struct RIPhysicalAdapter_s {
@@ -446,9 +484,9 @@ struct RIPhysicalAdapter_s {
 	uint64_t videoMemorySize;
 	uint64_t systemMemorySize;
 	uint32_t deviceId;
-	uint8_t vendor; // RIVendor_e
-	uint8_t presetLevel; // RIPresetLevel_e  
-	uint8_t type; // RIAdapterType_e 
+	uint8_t vendor;		 // RIVendor_e
+	uint8_t presetLevel; // RIPresetLevel_e
+	uint8_t type;		 // RIAdapterType_e
 
 	// Viewports
 	uint32_t viewportMaxNum;
@@ -491,8 +529,8 @@ struct RIPhysicalAdapter_s {
 	uint32_t uploadBufferTextureSliceAlignment;
 	uint32_t bufferShaderResourceOffsetAlignment;
 	uint32_t constantBufferOffsetAlignment;
-	//uint32_t scratchBufferOffsetAlignment;
-	//uint32_t shaderBindingTableAlignment;
+	// uint32_t scratchBufferOffsetAlignment;
+	// uint32_t shaderBindingTableAlignment;
 
 	// Pipeline layout
 	// D3D12 only: rootConstantSize + descriptorSetNum * 4 + rootDescriptorNum * 8 <= 256 (see "FitPipelineLayoutSettingsIntoDeviceLimits")
@@ -549,20 +587,20 @@ struct RIPhysicalAdapter_s {
 	uint32_t computeShaderWorkGroupMaxDim[3];
 
 	// Ray tracing
-	//uint32_t rayTracingShaderGroupIdentifierSize;
-	//uint32_t rayTracingShaderTableMaxStride;
-	//uint32_t rayTracingShaderRecursionMaxDepth;
-	//uint32_t rayTracingGeometryObjectMaxNum;
+	// uint32_t rayTracingShaderGroupIdentifierSize;
+	// uint32_t rayTracingShaderTableMaxStride;
+	// uint32_t rayTracingShaderRecursionMaxDepth;
+	// uint32_t rayTracingGeometryObjectMaxNum;
 
 	// Mesh shaders
-	//uint32_t meshControlSharedMemoryMaxSize;
-	//uint32_t meshControlWorkGroupInvocationMaxNum;
-	//uint32_t meshControlPayloadMaxSize;
-	//uint32_t meshEvaluationOutputVerticesMaxNum;
-	//uint32_t meshEvaluationOutputPrimitiveMaxNum;
-	//uint32_t meshEvaluationOutputComponentMaxNum;
-	//uint32_t meshEvaluationSharedMemoryMaxSize;
-	//uint32_t meshEvaluationWorkGroupInvocationMaxNum;
+	// uint32_t meshControlSharedMemoryMaxSize;
+	// uint32_t meshControlWorkGroupInvocationMaxNum;
+	// uint32_t meshControlPayloadMaxSize;
+	// uint32_t meshEvaluationOutputVerticesMaxNum;
+	// uint32_t meshEvaluationOutputPrimitiveMaxNum;
+	// uint32_t meshEvaluationOutputComponentMaxNum;
+	// uint32_t meshEvaluationSharedMemoryMaxSize;
+	// uint32_t meshEvaluationWorkGroupInvocationMaxNum;
 
 	// Precision bits
 	uint32_t viewportPrecisionBits;
@@ -583,26 +621,26 @@ struct RIPhysicalAdapter_s {
 	uint32_t clipDistanceMaxNum;
 	uint32_t cullDistanceMaxNum;
 	uint32_t combinedClipAndCullDistanceMaxNum;
-	//uint8_t shadingRateAttachmentTileSize;
-	//uint8_t shaderModel; // major * 10 + minor
+	// uint8_t shadingRateAttachmentTileSize;
+	// uint8_t shaderModel; // major * 10 + minor
 
 	// Tiers (0 - unsupported)
 	// 1 - 1/2 pixel uncertainty region and does not support post-snap degenerates
 	// 2 - reduces the maximum uncertainty region to 1/256 and requires post-snap degenerates not be culled
 	// 3 - maintains a maximum 1/256 uncertainty region and adds support for inner input coverage, aka "SV_InnerCoverage"
-	//uint8_t conservativeRasterTier;
+	// uint8_t conservativeRasterTier;
 
 	// 1 - a single sample pattern can be specified to repeat for every pixel ("locationNum / sampleNum" must be 1 in "CmdSetSampleLocations")
 	// 2 - four separate sample patterns can be specified for each pixel in a 2x2 grid ("locationNum / sampleNum" can be up to 4 in "CmdSetSampleLocations")
-	//uint8_t sampleLocationsTier;
+	// uint8_t sampleLocationsTier;
 
 	// 1 - DXR 1.0: full raytracing functionality, except features below
 	// 2 - DXR 1.1: adds - ray query, "CmdDispatchRaysIndirect", "GeometryIndex()" intrinsic, additional ray flags & vertex formats
-	//uint8_t rayTracingTier;
+	// uint8_t rayTracingTier;
 
 	// 1 - shading rate can be specified only per draw
 	// 2 - adds: per primitive shading rate, per "shadingRateAttachmentTileSize" shading rate, combiners, "SV_ShadingRate" support
-	//uint8_t shadingRateTier;
+	// uint8_t shadingRateTier;
 
 	// 1 - unbound arrays with dynamic indexing
 	// 2 - D3D12 dynamic resources: https://microsoft.github.io/DirectX-Specs/d3d/HLSL_SM_6_6_DynamicResources.html
@@ -614,13 +652,13 @@ struct RIPhysicalAdapter_s {
 	uint32_t isDepthBoundsTestSupported : 1;
 	uint32_t isDrawIndirectCountSupported : 1;
 	uint32_t isIndependentFrontAndBackStencilReferenceAndMasksSupported : 1;
-	//uint32_t isLineSmoothingSupported : 1;
+	// uint32_t isLineSmoothingSupported : 1;
 	uint32_t isCopyQueueTimestampSupported : 1;
-	//uint32_t isMeshShaderPipelineStatsSupported : 1;
+	// uint32_t isMeshShaderPipelineStatsSupported : 1;
 	uint32_t isEnchancedBarrierSupported : 1; // aka - can "Layout" be ignored?
 	uint32_t isMemoryTier2Supported : 1;	  // a memory object can support resources from all 3 categories (buffers, attachments, all other textures)
 	uint32_t isDynamicDepthBiasSupported : 1;
-	//uint32_t isAdditionalShadingRatesSupported : 1;
+	// uint32_t isAdditionalShadingRatesSupported : 1;
 	uint32_t isViewportOriginBottomLeftSupported : 1;
 	uint32_t isRegionResolveSupported : 1;
 
@@ -642,56 +680,55 @@ struct RIPhysicalAdapter_s {
 	uint32_t isDrawParametersEmulationEnabled : 1;
 
 	//// Extensions (unexposed are always supported)
-	//uint32_t isSwapChainSupported : 1;	// swapchain Support
-	//uint32_t isRayTracingSupported : 1; // raytracing support
-	//uint32_t isMeshShaderSupported : 1; // meshshader support
+	// uint32_t isSwapChainSupported : 1;	// swapchain Support
+	// uint32_t isRayTracingSupported : 1; // raytracing support
+	// uint32_t isMeshShaderSupported : 1; // meshshader support
 
 	union {
 #if ( DEVICE_IMPL_VULKAN )
 		struct {
 			uint32_t apiVersion;
 			VkPhysicalDevice physicalDevice;
-			
-			uint32_t isSwapChainSupported : 1;	// swapchain Support
-			uint32_t isBufferDeviceAddressSupported: 1;
-			uint32_t isAMDDeviceCoherentMemorySupported: 1;
-			uint32_t isPresentIDSupported: 1;
-			//uint32_t YCbCrExtension : 1;
-			//uint32_t FillModeNonSolid : 1;
-			//uint32_t KHRRayQueryExtension : 1;
-			//uint32_t AMDGCNShaderExtension : 1;
-			//uint32_t AMDDrawIndirectCountExtension : 1;
-			//uint32_t AMDShaderInfoExtension : 1;
-			//uint32_t DescriptorIndexingExtension : 1;
-			//uint32_t DynamicRenderingExtension : 1;
-			//uint32_t ShaderSampledImageArrayDynamicIndexingSupported : 1;
-			//uint32_t BufferDeviceAddressSupported : 1;
-			//uint32_t DrawIndirectCountExtension : 1;
-			//uint32_t DedicatedAllocationExtension : 1;
-			//uint32_t DebugMarkerExtension : 1;
-			//uint32_t MemoryReq2Extension : 1;
-			//uint32_t FragmentShaderInterlockExtension : 1;
-			//uint32_t BufferDeviceAddressExtension : 1;
-			//uint32_t accelerationStructureExtension : 1;
-			//uint32_t rayTracingPipelineExtension : 1;
-			//uint32_t rayQueryExtension : 1;
-			//uint32_t ShaderAtomicInt64Extension : 1;
-			//uint32_t BufferDeviceAddressFeature : 1;
-			//uint32_t ShaderFloatControlsExtension : 1;
-			//uint32_t Spirv14Extension : 1;
-			//uint32_t DeferredHostOperationsExtension : 1;
-			//uint32_t DeviceFaultExtension : 1;
-			//uint32_t DeviceFaultSupported : 1;
-			//uint32_t ASTCDecodeModeExtension : 1;
-			//uint32_t DeviceMemoryReportExtension : 1;
-			//uint32_t AMDBufferMarkerExtension : 1;
-			//uint32_t AMDDeviceCoherentMemoryExtension : 1;
-			//uint32_t AMDDeviceCoherentMemorySupported : 1;
+
+			uint32_t isSwapChainSupported : 1; // swapchain Support
+			uint32_t isBufferDeviceAddressSupported : 1;
+			uint32_t isAMDDeviceCoherentMemorySupported : 1;
+			uint32_t isPresentIDSupported : 1;
+			// uint32_t YCbCrExtension : 1;
+			// uint32_t FillModeNonSolid : 1;
+			// uint32_t KHRRayQueryExtension : 1;
+			// uint32_t AMDGCNShaderExtension : 1;
+			// uint32_t AMDDrawIndirectCountExtension : 1;
+			// uint32_t AMDShaderInfoExtension : 1;
+			// uint32_t DescriptorIndexingExtension : 1;
+			// uint32_t DynamicRenderingExtension : 1;
+			// uint32_t ShaderSampledImageArrayDynamicIndexingSupported : 1;
+			// uint32_t BufferDeviceAddressSupported : 1;
+			// uint32_t DrawIndirectCountExtension : 1;
+			// uint32_t DedicatedAllocationExtension : 1;
+			// uint32_t DebugMarkerExtension : 1;
+			// uint32_t MemoryReq2Extension : 1;
+			// uint32_t FragmentShaderInterlockExtension : 1;
+			// uint32_t BufferDeviceAddressExtension : 1;
+			// uint32_t accelerationStructureExtension : 1;
+			// uint32_t rayTracingPipelineExtension : 1;
+			// uint32_t rayQueryExtension : 1;
+			// uint32_t ShaderAtomicInt64Extension : 1;
+			// uint32_t BufferDeviceAddressFeature : 1;
+			// uint32_t ShaderFloatControlsExtension : 1;
+			// uint32_t Spirv14Extension : 1;
+			// uint32_t DeferredHostOperationsExtension : 1;
+			// uint32_t DeviceFaultExtension : 1;
+			// uint32_t DeviceFaultSupported : 1;
+			// uint32_t ASTCDecodeModeExtension : 1;
+			// uint32_t DeviceMemoryReportExtension : 1;
+			// uint32_t AMDBufferMarkerExtension : 1;
+			// uint32_t AMDDeviceCoherentMemoryExtension : 1;
+			// uint32_t AMDDeviceCoherentMemorySupported : 1;
 		} vk;
 #endif
 #if ( DEVICE_IMPL_MTL )
 		struct {
-
 		} mtl;
 #endif
 	};
@@ -699,36 +736,36 @@ struct RIPhysicalAdapter_s {
 
 struct RIDevice_s {
 	struct RIPhysicalAdapter_s physicalAdapter;
-  struct RIRenderer_s* renderer;
-  struct RIQueue_s queues[RI_QUEUE_LEN];
-  union {
-    #if(DEVICE_IMPL_VULKAN)
-    struct {
-      uint32_t maintenance5Features: 1;
-      uint32_t conservaitveRasterTier: 1;
-      uint32_t swapchainMutableFormat: 1;
-      uint32_t memoryBudget: 1;
-      VkDevice device;
-      VmaAllocator vmaAllocator;
-    } vk; 
-    #endif
-    #if(DEVICE_IMPL_MTL)
-    #endif
-  };
+	struct RIRenderer_s *renderer;
+	struct RIQueue_s queues[RI_QUEUE_LEN];
+	union {
+#if ( DEVICE_IMPL_VULKAN )
+		struct {
+			uint32_t maintenance5Features : 1;
+			uint32_t conservaitveRasterTier : 1;
+			uint32_t swapchainMutableFormat : 1;
+			uint32_t memoryBudget : 1;
+			VkDevice device;
+			VmaAllocator vmaAllocator;
+		} vk;
+#endif
+#if ( DEVICE_IMPL_MTL )
+#endif
+	};
 };
 
-static inline bool IsRICmdValid( struct RIRenderer_s *renderer, struct RICmd_s *cmd )
-{
-#if ( DEVICE_IMPL_VULKAN )
-	return cmd->vk.pool && cmd->vk.cmd;
-#endif
-	return false;
-}
+// static inline bool IsRICmdValid( struct RIRenderer_s *renderer, struct RICmd_s *cmd )
+//{
+// #if ( DEVICE_IMPL_VULKAN )
+//	return cmd->vk.pool && cmd->vk.cmd;
+// #endif
+//	return false;
+// }
 
 static inline bool IsRIBufferValid( struct RIRenderer_s *renderer, const struct RIBuffer_s *handle )
 {
 #if ( DEVICE_IMPL_VULKAN )
-		return handle && handle->vk.buffer!= NULL;
+	return handle && handle->vk.buffer != NULL;
 #endif
 	return false;
 }
@@ -736,7 +773,7 @@ static inline bool IsRIBufferValid( struct RIRenderer_s *renderer, const struct 
 static inline bool IsRITextureValid( struct RIRenderer_s *renderer, const struct RITexture_s *handle )
 {
 #if ( DEVICE_IMPL_VULKAN )
-		return handle && handle->vk.image != NULL;
+	return handle && handle->vk.image != NULL;
 #endif
 	return false;
 }

--- a/source/ref_nri/ri_vk.h
+++ b/source/ref_nri/ri_vk.h
@@ -8,9 +8,9 @@
 // VkResult RI_VK_InitImageView( struct RIDevice_s *dev, VkImageViewCreateInfo *info, struct RIDescriptor_s *desc, VkDescriptorType type );
 #define RI_VK_DESCRIPTOR_IS_IMAGE( desc ) ( desc.vk.type == VK_DESCRIPTOR_TYPE_SAMPLER || desc.vk.type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE || desc.vk.type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE )
 
-static inline void RI_VK_FillColorAttachment( VkRenderingAttachmentInfo *info, struct RIDescriptor_s *desc, bool attachAndClear )
+static inline void RI_VK_FillColorAttachment( VkRenderingAttachmentInfo *info, struct RITextureView_s view, bool attachAndClear )
 {
-	info->imageView = desc->vk.image.imageView;
+	info->imageView = view.vk.image;
 	info->imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 	info->resolveMode = VK_RESOLVE_MODE_NONE;
 	info->resolveImageView = VK_NULL_HANDLE;
@@ -19,9 +19,9 @@ static inline void RI_VK_FillColorAttachment( VkRenderingAttachmentInfo *info, s
 	info->storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 }
 
-static inline void RI_VK_FillDepthAttachment( VkRenderingAttachmentInfo *info, struct RIDescriptor_s *desc, bool attachAndClear )
+static inline void RI_VK_FillDepthAttachment( VkRenderingAttachmentInfo *info, struct RITextureView_s view, bool attachAndClear )
 {
-	info->imageView = desc->vk.image.imageView;
+	info->imageView = view.vk.image;
 	info->imageLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
 	info->resolveMode = VK_RESOLVE_MODE_NONE;
 	info->resolveImageView = VK_NULL_HANDLE;


### PR DESCRIPTION
This pull request refactors and modernizes Vulkan resource and rendering management in the renderer, focusing on simplifying descriptor and command buffer handling, improving naming consistency, and updating post-processing interfaces. The changes move towards using more explicit and type-safe structures, reduce legacy Vulkan-specific code, and clean up resource access patterns.

**Vulkan Resource and Descriptor Handling Improvements:**

* Updated all assignments of `image->binding.texture` and similar fields to store the `RITexture_s` struct directly, rather than a pointer, for improved type safety and clarity. [[1]](diffhunk://#diff-bdea664f8ba0a498057e1e57a7999c304dc302db9dfd5a69822d66a0fdac29aaL819-R819) [[2]](diffhunk://#diff-bdea664f8ba0a498057e1e57a7999c304dc302db9dfd5a69822d66a0fdac29aaL1146-R1138) [[3]](diffhunk://#diff-bdea664f8ba0a498057e1e57a7999c304dc302db9dfd5a69822d66a0fdac29aaL1305-R1297) [[4]](diffhunk://#diff-bdea664f8ba0a498057e1e57a7999c304dc302db9dfd5a69822d66a0fdac29aaL1665-R1657) [[5]](diffhunk://#diff-4e135fce5e0867e9944e2ab52b7a88a1df2676bf2271194b888276bf82ba806eL267-R267) [[6]](diffhunk://#diff-4e135fce5e0867e9944e2ab52b7a88a1df2676bf2271194b888276bf82ba806eL312-R312) [[7]](diffhunk://#diff-d91d29573b8c47c84a3fafc6d6ffeac3c669ea37b9046875219e891457b2954aL424-R424)
* Refactored post-processing function signatures and implementations to use `RITextureView_s*` instead of `RIDescriptor_s*`, and ensured correct descriptor construction for shader bindings. [[1]](diffhunk://#diff-ea99f02a9f3b3dee5112cae3480b8f152daa2323c051163ad485ff3792a0f17cL215-R228) [[2]](diffhunk://#diff-ea99f02a9f3b3dee5112cae3480b8f152daa2323c051163ad485ff3792a0f17cL250-R266)
* Replaced direct buffer and descriptor accesses in rendering and post-processing with helper functions like `TextureviewRIDescriptor` and `RI_PogoBufferAttachment`, and updated attachment handling to use the new types. [[1]](diffhunk://#diff-4e135fce5e0867e9944e2ab52b7a88a1df2676bf2271194b888276bf82ba806eL626-R629) [[2]](diffhunk://#diff-ea99f02a9f3b3dee5112cae3480b8f152daa2323c051163ad485ff3792a0f17cL351-R372) [[3]](diffhunk://#diff-ea99f02a9f3b3dee5112cae3480b8f152daa2323c051163ad485ff3792a0f17cL411-R438) [[4]](diffhunk://#diff-ea99f02a9f3b3dee5112cae3480b8f152daa2323c051163ad485ff3792a0f17cL434-R463) [[5]](diffhunk://#diff-ea99f02a9f3b3dee5112cae3480b8f152daa2323c051163ad485ff3792a0f17cL459-R479) [[6]](diffhunk://#diff-d91d29573b8c47c84a3fafc6d6ffeac3c669ea37b9046875219e891457b2954aL568-R562)

**Command Buffer and Frame State Refactoring:**

* Removed legacy Vulkan command buffer and pool fields from `r_frame_set_s` and related structures, and replaced them with a more generic `RICommandRingBuffer_s` and `RICommandRingElement_s` approach for improved multi-backend support and cleaner code. [[1]](diffhunk://#diff-8d633c8f9de059b48945c6203588015fea4b6668751387dcd3288dc3fb8383bdL267-L276) [[2]](diffhunk://#diff-8d633c8f9de059b48945c6203588015fea4b6668751387dcd3288dc3fb8383bdL334-R326) [[3]](diffhunk://#diff-8d633c8f9de059b48945c6203588015fea4b6668751387dcd3288dc3fb8383bdR335-R341)
* Replaced explicit Vulkan command buffer begin/end calls with backend-agnostic `BeginRICmd` and `EndRICmd` functions. [[1]](diffhunk://#diff-d91d29573b8c47c84a3fafc6d6ffeac3c669ea37b9046875219e891457b2954aL465-R465) [[2]](diffhunk://#diff-d91d29573b8c47c84a3fafc6d6ffeac3c669ea37b9046875219e891457b2954aL610-R604)

**Resource Upload and Memory Handling:**

* Updated texture upload code to use the correct mapped data pointer (`uploadDesc.mapped.data`) instead of the previous flat pointer, ensuring proper memory mapping and alignment. [[1]](diffhunk://#diff-bdea664f8ba0a498057e1e57a7999c304dc302db9dfd5a69822d66a0fdac29aaL1007-R1017) [[2]](diffhunk://#diff-bdea664f8ba0a498057e1e57a7999c304dc302db9dfd5a69822d66a0fdac29aaL1039-R1035)

**Naming Consistency and Cleanup:**

* Renamed `riSwapchain` to `swapchain` in the renderer state for consistency, and updated all references accordingly. [[1]](diffhunk://#diff-8d633c8f9de059b48945c6203588015fea4b6668751387dcd3288dc3fb8383bdL334-R326) [[2]](diffhunk://#diff-ea99f02a9f3b3dee5112cae3480b8f152daa2323c051163ad485ff3792a0f17cL411-R438) [[3]](diffhunk://#diff-ea99f02a9f3b3dee5112cae3480b8f152daa2323c051163ad485ff3792a0f17cL459-R479)
* Removed unused or redundant fields related to swapchain and attachments, further simplifying the renderer state.

These changes collectively modernize the renderer's Vulkan integration, making the codebase more maintainable and future-proof.