### PR TITLE
feat: address minor problems with ktx loader

### DIFF
--- a/source/ref_base/r_ktx_loader.c
+++ b/source/ref_base/r_ktx_loader.c
@@ -58,27 +58,29 @@ bool R_InitKTXContext(struct ktx_context_s *cntx, uint8_t *memory, size_t size, 
 	assert( sizeof( struct __raw_ktx_header_s ) == 64 );
 	struct __raw_ktx_header_s *rawHeader = (struct __raw_ktx_header_s *)memory;
 	if( memcmp( rawHeader->identifier, "\xABKTX 11\xBB\r\n\x1A\n", 12 ) ) {
-		return KTX_ERR_INVALID_IDENTIFIER;
+		err->type = KTX_ERR_INVALID_IDENTIFIER;
+		goto error;
 	}
-  assert(cntx->pixelDepth == 0);
 
 	cntx->buffer = memory;
-	cntx->swapEndianess = ( rawHeader->endianness == 0x01020304 ) ? true : false;
-	cntx->type = cntx->swapEndianess ? LongSwap( rawHeader->type ) : rawHeader->type;
-	cntx->typeSize = cntx->swapEndianess  ? LongSwap( rawHeader->typeSize ) : rawHeader->typeSize;
-	cntx->format = cntx->swapEndianess ? LongSwap( rawHeader->format ) : rawHeader->format;
-	cntx->internalFormat = cntx->swapEndianess ? LongSwap( rawHeader->internalFormat ) : rawHeader->internalFormat;
-	cntx->baseInternalFormat = cntx->swapEndianess ? LongSwap( rawHeader->baseInternalFormat ) : rawHeader->baseInternalFormat;
-	cntx->pixelWidth = cntx->swapEndianess ? LongSwap( rawHeader->pixelWidth ) : rawHeader->pixelWidth;
-	cntx->pixelHeight = cntx->swapEndianess ? LongSwap( rawHeader->pixelHeight ) : rawHeader->pixelHeight;
-	cntx->pixelDepth = cntx->swapEndianess ? LongSwap( rawHeader->pixelDepth ) : rawHeader->pixelDepth;
-	cntx->numberOfArrayElements = cntx->swapEndianess ? LongSwap( rawHeader->numberOfArrayElements ) : rawHeader->numberOfArrayElements;
-	cntx->numberOfFaces = cntx->swapEndianess ? LongSwap( rawHeader->numberOfFaces ) : rawHeader->numberOfFaces;
-	cntx->numberOfMipmapLevels = cntx->swapEndianess ? LongSwap( rawHeader->numberOfMipmapLevels ) : rawHeader->numberOfMipmapLevels;
-	cntx->bytesOfKeyValueData = cntx->swapEndianess ? LongSwap( rawHeader->bytesOfKeyValueData ) : rawHeader->bytesOfKeyValueData;
+	cntx->swapEndianness = ( rawHeader->endianness == 0x01020304 ) ? true : false;
+	cntx->type = cntx->swapEndianness ? LongSwap( rawHeader->type ) : rawHeader->type;
+	cntx->typeSize = cntx->swapEndianness  ? LongSwap( rawHeader->typeSize ) : rawHeader->typeSize;
+	cntx->format = cntx->swapEndianness ? LongSwap( rawHeader->format ) : rawHeader->format;
+	cntx->internalFormat = cntx->swapEndianness ? LongSwap( rawHeader->internalFormat ) : rawHeader->internalFormat;
+	cntx->baseInternalFormat = cntx->swapEndianness ? LongSwap( rawHeader->baseInternalFormat ) : rawHeader->baseInternalFormat;
+	cntx->pixelWidth = cntx->swapEndianness ? LongSwap( rawHeader->pixelWidth ) : rawHeader->pixelWidth;
+	cntx->pixelHeight = cntx->swapEndianness ? LongSwap( rawHeader->pixelHeight ) : rawHeader->pixelHeight;
+	cntx->pixelDepth = cntx->swapEndianness ? LongSwap( rawHeader->pixelDepth ) : rawHeader->pixelDepth;
+	assert( cntx->pixelDepth == 0 );
+	cntx->numberOfArrayElements = cntx->swapEndianness ? LongSwap( rawHeader->numberOfArrayElements ) : rawHeader->numberOfArrayElements;
+	cntx->numberOfFaces = cntx->swapEndianness ? LongSwap( rawHeader->numberOfFaces ) : rawHeader->numberOfFaces;
+	cntx->numberOfMipmapLevels = cntx->swapEndianness ? LongSwap( rawHeader->numberOfMipmapLevels ) : rawHeader->numberOfMipmapLevels;
+	cntx->bytesOfKeyValueData = cntx->swapEndianness ? LongSwap( rawHeader->bytesOfKeyValueData ) : rawHeader->bytesOfKeyValueData;
 
   if((cntx->pixelWidth <= 0 ) || ( cntx->pixelHeight <= 0)) {
-  	return KTX_ERR_ZER_TEXTURE_SIZE;
+  	err->type = KTX_ERR_ZERO_TEXTURE_SIZE;
+  	goto error;
   }
 
 	const size_t numberOfArrayElements = max( 1, cntx->numberOfArrayElements );
@@ -101,7 +103,7 @@ bool R_InitKTXContext(struct ktx_context_s *cntx, uint8_t *memory, size_t size, 
 			default:
 				err->type = KTX_ERR_UNHANDLED_TEXTURE_TYPE;
 				err->errTextureType.type = cntx->type;
-				err->errTextureType.type = cntx->baseInternalFormat;
+				err->errTextureType.internalFormat = cntx->baseInternalFormat;
 				goto error;
 		}
 	} else {
@@ -141,7 +143,7 @@ bool R_InitKTXContext(struct ktx_context_s *cntx, uint8_t *memory, size_t size, 
 					default:
 						err->type = KTX_ERR_UNHANDLED_TEXTURE_TYPE;
 						err->errTextureType.type = cntx->type;
-						err->errTextureType.type = cntx->baseInternalFormat;
+						err->errTextureType.internalFormat = cntx->baseInternalFormat;
 						goto error;
 				}
 				break;
@@ -149,7 +151,7 @@ bool R_InitKTXContext(struct ktx_context_s *cntx, uint8_t *memory, size_t size, 
 			default:
 				err->type = KTX_ERR_UNHANDLED_TEXTURE_TYPE;
 				err->errTextureType.type = cntx->type;
-				err->errTextureType.type = cntx->baseInternalFormat;
+				err->errTextureType.internalFormat = cntx->baseInternalFormat;
 			  goto error;
 		}
 	}
@@ -161,7 +163,7 @@ bool R_InitKTXContext(struct ktx_context_s *cntx, uint8_t *memory, size_t size, 
 	size_t offset = dataOffset;
 	for( uint_fast16_t mipLevel = 0; mipLevel < numberOfMips; mipLevel++ ) {
 		size_t faceLodSize = *( (uint32_t *)&cntx->buffer[offset] );
-		faceLodSize = ( cntx->swapEndianess == true ) ? LongSwap( faceLodSize ) : faceLodSize;
+		faceLodSize = ( cntx->swapEndianness == true ) ? LongSwap( faceLodSize ) : faceLodSize;
 		faceLodSize = ALIGN( faceLodSize, 4 ); // pad buffer to multiple of 4
 		offset += sizeof( uint32_t );
 		if( faceLodSize + offset > size ) {
@@ -182,15 +184,6 @@ bool R_InitKTXContext(struct ktx_context_s *cntx, uint8_t *memory, size_t size, 
 				const int res = T_AliasTextureBuf( &img->texture, &desc, ( cntx->buffer + offset + arrByteOffset ), 0 );
 				assert(res == TEXTURE_BUF_SUCCESS);
 				arrByteOffset += img->texture.size;
-			}
-			if( faceLodSize + offset > size ) {
-				err->mipTruncated.expectedMipLevels = mipLevel;
-				cntx->numberOfMipmapLevels = ( mipLevel > 0 ) ? mipLevel - 1 : 0;
-				err->mipTruncated.mipLevels = cntx->numberOfMipmapLevels;
-				err->type = cntx->numberOfMipmapLevels == 0 ? KTX_ERR_TRUNCATED : KTX_WARN_MIPLEVEL_TRUNCATED;
-				err->mipTruncated.size = size;
-				err->mipTruncated.expected = faceLodSize + offset;
-				goto error;
 			}
 			offset += faceLodSize;
 		}

--- a/source/ref_base/r_ktx_loader.h
+++ b/source/ref_base/r_ktx_loader.h
@@ -14,7 +14,7 @@ enum ktx_context_result_type_e {
   KTX_ERR_UNHANDLED_TEXTURE_TYPE,
   KTX_ERR_TRUNCATED,
   KTX_WARN_MIPLEVEL_TRUNCATED, 
-  KTX_ERR_ZER_TEXTURE_SIZE 
+  KTX_ERR_ZERO_TEXTURE_SIZE
 };
 
 struct ktx_context_err_s {
@@ -38,7 +38,7 @@ struct ktx_context_err_s {
 };
 
 struct ktx_context_s {
-	bool swapEndianess;
+	bool swapEndianness;
 	int type;
 	int typeSize;
 	int format;

--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -1325,7 +1325,7 @@ static bool R_LoadKTX( int ctx, image_t *image, const char *pathname )
 				ri.Com_Printf( S_COLOR_YELLOW "R_LoadKTX: Truncated MipLevel size: (orignal: %lu expected: %lu) mip: (orignal: %lu expected: %lu): %s\n", err.errTruncated.size, err.errTruncated.expected,
 							   err.mipTruncated.mipLevels, err.mipTruncated.expectedMipLevels, pathname );
 				break;
-			case KTX_ERR_ZER_TEXTURE_SIZE:
+			case KTX_ERR_ZERO_TEXTURE_SIZE:
 				ri.Com_Printf( S_COLOR_RED "R_LoadKTX: Zero texture size: %s\n", pathname );
 				goto error;
 				break;

--- a/source/ref_nri/r_image.c
+++ b/source/ref_nri/r_image.c
@@ -688,7 +688,7 @@ static bool __R_LoadKTX( image_t *image, const char *pathname )
 				ri.Com_Printf( S_COLOR_YELLOW "R_LoadKTX: Truncated MipLevel size: (orignal: %lu expected: %lu) mip: (orignal: %lu expected: %lu): %s\n", err.errTruncated.size,
 							   err.errTruncated.expected, err.mipTruncated.mipLevels, err.mipTruncated.expectedMipLevels, pathname );
 				break;
-			case KTX_ERR_ZER_TEXTURE_SIZE:
+			case KTX_ERR_ZERO_TEXTURE_SIZE:
 				ri.Com_Printf( S_COLOR_RED "R_LoadKTX: Zero texture size: %s\n", pathname );
 				goto error;
 				break;

--- a/source/ref_nri/ri_segment_alloc.c
+++ b/source/ref_nri/ri_segment_alloc.c
@@ -35,7 +35,7 @@ bool RISegmentAlloc( uint32_t frameIndex, struct RISegmentAlloc_s *alloc, size_t
 		assert( alloc->head != alloc->tail ); // this shouldn't happen
 	}
 
-	assert( alloc->elementOffset < alloc->maxElements );
+	assert( alloc->elementOffset <= alloc->maxElements );
 
 	// not enough total free space
 	if( ( alloc->maxElements - alloc->elementsConsumed ) < numElements ) {


### PR DESCRIPTION
This pull request primarily addresses naming consistency, error handling improvements, and minor bug fixes in the KTX texture loader and related code. The main changes include standardizing the spelling of the `swapEndianness` field, fixing typos in error codes, correcting error assignments, and improving error handling logic.

**Naming consistency and typo fixes:**

* Renamed all instances of `swapEndianess` to `swapEndianness` in `struct ktx_context_s`, its usage, and related logic to ensure consistent naming. [[1]](diffhunk://#diff-9c7e6c4b941bec96331ce5e1a6f0f422a93472365b74a8d1af581cea2e9e24c9L61-R83) [[2]](diffhunk://#diff-fb2d577d95d3e7977187bd855f3e0075cdc51390de4e23628f04fb0aaa5dc3daL41-R41) [[3]](diffhunk://#diff-9c7e6c4b941bec96331ce5e1a6f0f422a93472365b74a8d1af581cea2e9e24c9L164-R166)
* Fixed a typo in the error code from `KTX_ERR_ZER_TEXTURE_SIZE` to `KTX_ERR_ZERO_TEXTURE_SIZE` in both the enum definition and all usages. [[1]](diffhunk://#diff-fb2d577d95d3e7977187bd855f3e0075cdc51390de4e23628f04fb0aaa5dc3daL17-R17) [[2]](diffhunk://#diff-868e0b844a55b60a2bde45b7b6f698b062130e62e9e31622dcddca2abb0d6655L1328-R1328) [[3]](diffhunk://#diff-bdea664f8ba0a498057e1e57a7999c304dc302db9dfd5a69822d66a0fdac29aaL691-R691)

**Error handling improvements:**

* Changed direct `return` statements on error to setting `err->type` and jumping to the error handler with `goto error` in `R_InitKTXContext`, improving error reporting.
* Corrected assignment in error handling: now sets `err->errTextureType.internalFormat` instead of incorrectly overwriting `type` during unhandled texture type errors. [[1]](diffhunk://#diff-9c7e6c4b941bec96331ce5e1a6f0f422a93472365b74a8d1af581cea2e9e24c9L104-R106) [[2]](diffhunk://#diff-9c7e6c4b941bec96331ce5e1a6f0f422a93472365b74a8d1af581cea2e9e24c9L144-R154)

**Bug fixes and validation:**

* Restored and repositioned an `assert` to ensure `cntx->pixelDepth == 0` after it is assigned, ensuring validation occurs at the correct point.
* Updated an assertion in `RISegmentAlloc` to allow `alloc->elementOffset` to be equal to `alloc->maxElements`, fixing a potential off-by-one error.

**Code cleanup:**

* Removed unreachable or redundant mip truncation error handling code in `R_InitKTXContext`, as this logic is now handled elsewhere.