### PR TITLE
bugfix: resolve image loading bug for nri

### DIFF
--- a/source/ref_nri/r_image.c
+++ b/source/ref_nri/r_image.c
@@ -1358,6 +1358,7 @@ image_t *R_FindImage( const char *name, const char *suffix, int flags, int minmi
 					lastDot = resolvedPath.len - 1;
 					break;
 				case '/':
+				case '\\':
 					lastSlash = resolvedPath.len - 1;
 					break;
 			}


### PR DESCRIPTION
fix image loading in wfdm4

<img width="914" height="629" alt="image" src="https://github.com/user-attachments/assets/fcade69d-1705-43d6-9800-71bf21d587eb" />

- Path handling improvement:
  * Updated the logic in `R_FindImage` to treat backslashes (`This pull request makes a minor update to the path parsing logic in `r_image.c` to improve compatibility with file paths that use backslashes as directory separators.