### PR TITLE
bugfix: resolve performance issue with steamshim

### DIFF
--- a/source/qcommon/net.c
+++ b/source/qcommon/net.c
@@ -73,6 +73,77 @@ static bool	net_initialized = false;
 static int numIP;
 static uint8_t localIP[MAX_IPS][4];
 
+#define STEAM_SLOT_MAX 256
+
+struct steam_pkt_recieved_s {
+	struct steam_pkt_recieved_s *next;
+	uint32_t handle;           // HSteamNetConnection (peer connection)
+	uint64_t steam_handle;     // peer SteamID
+	size_t   recvSize;
+	uint8_t  buffered[];
+};
+
+struct steam_slot_s {
+	uint32_t handle;
+	struct steam_pkt_recieved_s *head;
+	struct steam_pkt_recieved_s *tail;
+};
+
+static struct steam_slot_s steam_slots[STEAM_SLOT_MAX];
+static size_t              num_steam_slots = 0;
+
+static void __SDR_DisconnectMessages( void *self, struct steam_rpc_pkt_s *pkt )
+{
+	struct p2p_disconnect_req_s *rpc = &pkt->p2p_disconnect;
+	for( size_t i = 0; i < num_steam_slots; i++ ) {
+		if( steam_slots[i].handle != rpc->handle)
+			continue;
+		struct steam_pkt_recieved_s *p = steam_slots[i].head;
+		while( p ) {
+			struct steam_pkt_recieved_s *next = p->next;
+			free( p );
+			p = next;
+		}
+		steam_slots[i] = steam_slots[--num_steam_slots];
+		return;
+	}	
+}
+
+static void __SDR_OnRecvMessages( void *self, struct steam_evt_pkt_s *pkt )
+{
+	struct recv_messages_evt_s *evt = &pkt->recv_messages;
+	struct steam_slot_s *slot = NULL; //__SDR_GetOrCreateSlot( evt->handle );
+	for( size_t i = 0; i < num_steam_slots; i++ ) {
+		if( steam_slots[i].handle == evt->handle ) {
+			slot = &steam_slots[i];
+		}
+	}
+	if( slot == NULL ) {
+		if( num_steam_slots >= STEAM_SLOT_MAX )
+			return;
+		slot = &steam_slots[num_steam_slots++];
+		slot->handle = evt->handle;
+		slot->head = NULL;
+		slot->tail = NULL;
+	}
+	size_t offset = 0;
+	for( int i = 0; i < evt->count; i++ ) {
+		size_t isz = (size_t)evt->messageinfo[i].count;
+		struct steam_pkt_recieved_s *p = malloc( sizeof( struct steam_pkt_recieved_s ) + isz );
+		p->next = NULL;
+		p->handle = evt->handle;
+		p->steam_handle = evt->steamID;
+		p->recvSize = isz;
+		memcpy( p->buffered, evt->buffer + offset, isz );
+		if( slot->tail )
+			slot->tail->next = p;
+		else
+			slot->head = p;
+		slot->tail = p;
+		offset += isz;
+	}
+}
+
 /*
 =============================================================================
 PRIVATE FUNCTIONS
@@ -339,48 +410,38 @@ static bool NET_SocketMakeNonBlocking( socket_handle_t handle )
 	return true;
 }
 
-struct SDR_GetPacket_Self {
-	msg_t* message;
-	netadr_t* addr;
-	int result;
-};
-static void NET_SDR_ConsumePacket(void* self, struct steam_rpc_pkt_s* rpc) {
-	struct SDR_GetPacket_Self* netRecieve = self;
-	msg_t* message = netRecieve->message;
-	netadr_t* address = netRecieve->addr;
-	struct recv_messages_recv_s *recv = &rpc->recv_messages_recv;
-	if(recv->count == 0) {
-		message->cursize = 0;
-		netRecieve->result = 0;
-		return;
+static int NET_SDR_GetPacket( const socket_t *socket, netadr_t *address, msg_t *message )
+{
+	assert( socket && socket->open && socket->type == SOCKET_SDR );
+
+	STEAMSHIM_dispatch();
+
+	struct steam_slot_s *slot = NULL;
+	for( size_t i = 0; i < num_steam_slots; i++ ) {
+		if( steam_slots[i].handle == socket->steam_handle ) {
+			slot = &steam_slots[i];
+			break;
+		}
 	}
+	if( !slot || !slot->head )
+		return 0;
 
-	int size = recv->messageinfo[0].count;
-	if (size > message->maxsize)
-		size = message->maxsize;
-	message->cursize = size;
+	struct steam_pkt_recieved_s *p = slot->head;
+	slot->head = p->next;
+	if( !slot->head )
+		slot->tail = NULL;
 
-	memcpy(message->data, recv->buffer, size);
-	NET_InitAddress(address, NA_SDR);
-	address->address.steamid = recv->steamID;
-	netRecieve->result = 1;
-}
+	size_t sz = p->recvSize;
+	if( sz > message->maxsize )
+		sz = message->maxsize;
+	memcpy( message->data, p->buffered, sz );
+	message->cursize   = sz;
+	message->readcount = 0;
+	NET_InitAddress( address, NA_SDR );
+	address->address.steamid = p->steam_handle;
 
-static int NET_SDR_GetPacket( const socket_t *socket, netadr_t *address, msg_t *message ) {
-  assert(socket && socket->open && socket->type == SOCKET_SDR);
-	struct recv_messages_req_s req;
-	if(socket->server) {
-		req.cmd = RPC_SRV_P2P_RECV_MESSAGES;
-	} else {
-		req.cmd = RPC_P2P_RECV_MESSAGES;
-	}
-	req.handle = socket->steam_handle;
-
-	uint32_t syncIndex;
-	struct SDR_GetPacket_Self self = {message, address, -1}; 
-	STEAMSHIM_sendRPC(&req, sizeof req, &self, NET_SDR_ConsumePacket, &syncIndex);
-	STEAMSHIM_waitDispatchSync(syncIndex);
-	return self.result;
+	free( p );
+	return 1;
 }
 
 /*
@@ -576,13 +637,10 @@ static void NET_SDR_CloseSocket( socket_t *socket ) {
 		return;
 
 	struct p2p_disconnect_req_s req;
-	if(socket->server) {
-		req.cmd = RPC_SRV_P2P_DISCONNECT;
-	} else {
-		req.cmd = RPC_P2P_DISCONNECT;
-	}
+	req.cmd = socket->server ? RPC_SRV_P2P_DISCONNECT : RPC_P2P_DISCONNECT;
 	req.handle = socket->handle;
-	STEAMSHIM_sendRPC(&req, sizeof req, NULL, NULL, NULL);
+	STEAMSHIM_sendRPC( &req, sizeof req, NULL, __SDR_DisconnectMessages, NULL );
+
 	socket->open = false;
 	socket->handle = 0;
 }
@@ -2094,6 +2152,10 @@ void NET_Init( void )
 
 	GetLocalAddress();
 
+	num_steam_slots = 0;
+	STEAMSHIM_subscribeEvent( EVT_P2P_RECV_MESSAGES, NULL, __SDR_OnRecvMessages );
+	STEAMSHIM_subscribeEvent( EVT_SRV_P2P_RECV_MESSAGES, NULL, __SDR_OnRecvMessages );
+
 	net_initialized = true;
 }
 
@@ -2108,6 +2170,18 @@ void NET_Shutdown( void )
 	errorstring[0] = '\0';
 
 	Sys_NET_Shutdown();
+
+	STEAMSHIM_unsubscribeEvent( EVT_P2P_RECV_MESSAGES, __SDR_OnRecvMessages );
+	STEAMSHIM_unsubscribeEvent( EVT_SRV_P2P_RECV_MESSAGES, __SDR_OnRecvMessages );
+	for( size_t i = 0; i < num_steam_slots; i++ ) {
+		struct steam_pkt_recieved_s *p = steam_slots[i].head;
+		while( p ) {
+			struct steam_pkt_recieved_s *next = p->next;
+			free( p );
+			p = next;
+		}
+	}
+	num_steam_slots = 0;
 
 	net_initialized = false;
 }

--- a/source/steamshim/src/child/child.cpp
+++ b/source/steamshim/src/child/child.cpp
@@ -65,8 +65,47 @@ static ISteamUGC *GSteamUGC = NULL;
 ServerBrowser *GServerBrowser = NULL;
 static time_t time_since_last_pump = 0;
 
+// Tracked SDR connections. Populated when SteamNetConnectionStatusChangedCallback_t
+// reports Connected, removed on ClosedByPeer / ProblemDetectedLocally / None.
+// Drained every loop iteration to push messages as events to the parent.
+#define MAX_TRACKED_CONNS 256
+static HSteamNetConnection g_serverConns[MAX_TRACKED_CONNS];
+static int g_numServerConns = 0;
+static HSteamNetConnection g_clientConns[MAX_TRACKED_CONNS];
+static int g_numClientConns = 0;
+
 static void handleSteamConnectionStatusChanged( steam_cmd_s cmd, SteamNetConnectionStatusChangedCallback_t *pCallback )
 {
+	HSteamNetConnection *arr = ( cmd == EVT_SRV_P2P_CONNECTION_CHANGED ) ? g_serverConns : g_clientConns;
+	int *n                   = ( cmd == EVT_SRV_P2P_CONNECTION_CHANGED ) ? &g_numServerConns : &g_numClientConns;
+	const HSteamNetConnection h = pCallback->m_hConn;
+	switch( pCallback->m_info.m_eState ) {
+		case k_ESteamNetworkingConnectionState_Connected: {
+			bool found = false;
+			for( int i = 0; i < *n; i++ ) {
+				if( arr[i] == h ) {
+					found = true;
+					break;
+				}
+			}
+			if( !found && *n < MAX_TRACKED_CONNS )
+				arr[(*n)++] = h;
+			break;
+		}
+		case k_ESteamNetworkingConnectionState_ClosedByPeer:
+		case k_ESteamNetworkingConnectionState_ProblemDetectedLocally:
+		case k_ESteamNetworkingConnectionState_None:
+			for( int i = 0; i < *n; i++ ) {
+				if( arr[i] == h ) {
+					arr[i] = arr[--(*n)];
+					break;
+				}
+			}
+			break;
+		default:
+			break;
+	}
+
 	struct p2p_net_connection_changed_evt_s evt;
 	evt.cmd = cmd;
 	evt.hConn = pCallback->m_hConn;
@@ -77,37 +116,50 @@ static void handleSteamConnectionStatusChanged( steam_cmd_s cmd, SteamNetConnect
 	write_packet( GPipeWrite, &evt, sizeof( p2p_net_connection_changed_evt_s ) );
 }
 
-static void handleRecvMessageRPC( const steam_rpc_shim_common_s *req, SteamNetworkingMessage_t **msgs, int num_messages, uint64_t steamID, uint32_t handle )
+static void _drainSocket( steam_cmd_s evtCmd, ISteamNetworkingSockets *sockets, HSteamNetConnection h )
 {
-	if(num_messages == -1) {
-		recv_messages_recv_s recv;
-		recv.steamID = steamID;
-		recv.handle = handle;
-		recv.count = 0;
-		prepared_rpc_packet( req, &recv );
-		write_packet( GPipeWrite, &recv, sizeof( struct recv_messages_recv_s ));
-		printf("invalid handle for req: %d\n", req->cmd);
+	SteamNetworkingMessage_t *msgs[SDR_MAX_REQUESTED_PACKETS];
+	const int n = sockets->ReceiveMessagesOnConnection( h, msgs, SDR_MAX_REQUESTED_PACKETS );
+	if( n <= 0 )
 		return;
-	}
+
+	SteamNetConnectionInfo_t info;
+	sockets->GetConnectionInfo( h, &info );
+	const uint64_t steamid = info.m_identityRemote.GetSteamID().ConvertToUint64();
 
 	size_t total = 0;
-	for( int i = 0; i < num_messages; i++ ) {
+	for( int i = 0; i < n; i++ )
 		total += msgs[i]->GetSize();
-	}
-	auto recv = (struct recv_messages_recv_s *)malloc( sizeof( struct recv_messages_recv_s ) + total );
-	recv->steamID = steamID;
-	recv->handle = handle;
-	recv->count = num_messages;
-	size_t offset = 0;
 
-	for( int i = 0; i < num_messages; i++ ) {
-		recv->messageinfo[i].count = msgs[i]->GetSize();
-		memcpy( recv->buffer + offset, msgs[i]->GetData(), msgs[i]->GetSize() );
-		offset += msgs[i]->GetSize();
+	auto evt = (struct recv_messages_evt_s *)malloc( sizeof( struct recv_messages_evt_s ) + total );
+	evt->cmd     = evtCmd;
+	evt->steamID = steamid;
+	evt->handle  = h;
+	evt->count   = n;
+	size_t offset = 0;
+	for( int i = 0; i < n; i++ ) {
+		const size_t sz = msgs[i]->GetSize();
+		evt->messageinfo[i].count = (int)sz;
+		memcpy( evt->buffer + offset, msgs[i]->GetData(), sz );
+		offset += sz;
+		msgs[i]->Release();
 	}
-	prepared_rpc_packet( req, recv );
-	write_packet( GPipeWrite, recv, sizeof( struct recv_messages_recv_s ) + total );
-	free( recv );
+	write_packet( GPipeWrite, evt, sizeof( struct recv_messages_evt_s ) + total );
+	free( evt );
+}
+
+static void drainAllConnections( void )
+{
+	if( GRunServer ) {
+		ISteamNetworkingSockets *s = SteamGameServerNetworkingSockets();
+		for( int i = 0; i < g_numServerConns; i++ )
+			_drainSocket( EVT_SRV_P2P_RECV_MESSAGES, s, g_serverConns[i] );
+	}
+	if( GRunClient ) {
+		ISteamNetworkingSockets *s = SteamNetworkingSockets();
+		for( int i = 0; i < g_numClientConns; i++ )
+			_drainSocket( EVT_P2P_RECV_MESSAGES, s, g_clientConns[i] );
+	}
 }
 
 static void processEVT( steam_evt_pkt_s *req, size_t size )
@@ -329,25 +381,6 @@ static void processRPC( steam_rpc_pkt_s *req, size_t size )
 			struct steam_rpc_shim_common_s recv;
 			prepared_rpc_packet( &req->common, &recv );
 			write_packet( GPipeWrite, &recv, sizeof( steam_rpc_shim_common_s ) );
-			break;
-		}
-		case RPC_SRV_P2P_RECV_MESSAGES: {
-			SteamNetworkingMessage_t *msgs[32];
-			SteamNetConnectionInfo_t info;
-			SteamGameServerNetworkingSockets()->GetConnectionInfo( req->recv_messages.handle, &info );
-			const uint64_t steamid = info.m_identityRemote.GetSteamID().ConvertToUint64();
-			const int n = SteamGameServerNetworkingSockets()->ReceiveMessagesOnConnection( req->recv_messages.handle, msgs, 1 );
-			handleRecvMessageRPC( &req->common, msgs, n, steamid, req->recv_messages.handle );
-			break;
-		}
-		case RPC_P2P_RECV_MESSAGES: {
-			SteamNetworkingMessage_t *msgs[32];
-			SteamNetConnectionInfo_t info;
-			SteamNetworkingSockets()->GetConnectionInfo( req->recv_messages.handle, &info );
-			const uint64_t steamid = info.m_identityRemote.GetSteamID().ConvertToUint64();
-
-			const int n = SteamNetworkingSockets()->ReceiveMessagesOnConnection( req->recv_messages.handle, msgs, 1 );
-			handleRecvMessageRPC( &req->common, msgs, n, steamid, req->recv_messages.handle );
 			break;
 		}
 		case RPC_GETVOICE: {
@@ -615,6 +648,7 @@ static void processCommands()
 
 		processSteamServerDispatch();
 		processSteamDispatch();
+		drainAllConnections();
 	continue_processing:
 
 		if( packet.size > STEAM_PACKED_RESERVE_SIZE - sizeof( uint32_t ) ) {

--- a/source/steamshim/src/mod_steam.h
+++ b/source/steamshim/src/mod_steam.h
@@ -19,6 +19,7 @@ DECLARE_TYPEDEF_METHOD( int, STEAMSHIM_dispatch );
 DECLARE_TYPEDEF_METHOD( int, STEAMSHIM_sendRPC, void *req, uint32_t size, void *self, STEAMSHIM_rpc_handle rpc, uint32_t *syncIndex );
 DECLARE_TYPEDEF_METHOD( int, STEAMSHIM_sendEVT, void *packet, uint32_t size );
 DECLARE_TYPEDEF_METHOD( int, STEAMSHIM_waitDispatchSync, uint32_t syncIndex ); // wait on the dispatch loop does not trigger steam callbacks
+DECLARE_TYPEDEF_METHOD( uint32_t, STEAMSHIM_currentSync ); // sync index of the most recently processed RPC
 DECLARE_TYPEDEF_METHOD( void, STEAMSHIM_subscribeEvent, uint32_t id, void *self, STEAMSHIM_evt_handle evt );
 DECLARE_TYPEDEF_METHOD( void, STEAMSHIM_unsubscribeEvent, uint32_t id, STEAMSHIM_evt_handle evt );
 DECLARE_TYPEDEF_METHOD( bool, STEAMSHIM_active );
@@ -30,6 +31,7 @@ struct steam_import_s {
 	STEAMSHIM_sendRPCFn STEAMSHIM_sendRPC;
 	STEAMSHIM_sendEVTFn STEAMSHIM_sendEVT;
 	STEAMSHIM_waitDispatchSyncFn STEAMSHIM_waitDispatchSync;
+	STEAMSHIM_currentSyncFn STEAMSHIM_currentSync;
 	STEAMSHIM_subscribeEventFn STEAMSHIM_subscribeEvent;
 	STEAMSHIM_unsubscribeEventFn STEAMSHIM_unsubscribeEvent;
 	STEAMSHIM_activeFn STEAMSHIM_active;
@@ -39,6 +41,7 @@ struct steam_import_s {
 	STEAMSHIM_sendRPC, \
 	STEAMSHIM_sendEVT, \
 	STEAMSHIM_waitDispatchSync, \
+	STEAMSHIM_currentSync, \
 	STEAMSHIM_subscribeEvent, \
 	STEAMSHIM_unsubscribeEvent, \
 	STEAMSHIM_active \
@@ -54,6 +57,7 @@ int STEAMSHIM_dispatch() { return steam_import.STEAMSHIM_dispatch();}
 int STEAMSHIM_sendRPC( void *req, uint32_t size, void *self, STEAMSHIM_rpc_handle rpc, uint32_t *syncIndex ) { return steam_import.STEAMSHIM_sendRPC(req, size, self, rpc, syncIndex);}
 int STEAMSHIM_sendEVT( void *packet, uint32_t size) { return steam_import.STEAMSHIM_sendEVT(packet, size);}
 int STEAMSHIM_waitDispatchSync( uint32_t syncIndex ){ return steam_import.STEAMSHIM_waitDispatchSync(syncIndex);} // wait on the dispatch loop
+uint32_t STEAMSHIM_currentSync(){ return steam_import.STEAMSHIM_currentSync();}
 void STEAMSHIM_subscribeEvent( uint32_t id, void *self, STEAMSHIM_evt_handle evt ){ return steam_import.STEAMSHIM_subscribeEvent(id, self, evt);} // wait on the dispatch loop
 void STEAMSHIM_unsubscribeEvent( uint32_t id, STEAMSHIM_evt_handle evt){ return steam_import.STEAMSHIM_unsubscribeEvent(id, evt);} // wait on the dispatch loop
 bool STEAMSHIM_active(){ return steam_import.STEAMSHIM_active();} // wait on the dispatch loop

--- a/source/steamshim/src/parent/parent.cpp
+++ b/source/steamshim/src/parent/parent.cpp
@@ -25,6 +25,7 @@ freely, subject to the following restrictions:
 #include <mutex>
 #include <stdio.h>
 #include <thread>
+#include <vector>
 #define DEBUGPIPE 1
 #include "../os.h"
 #include "../steamshim.h"
@@ -35,6 +36,7 @@ freely, subject to the following restrictions:
 #include "../mod_steam.h"
 
 #include "tracy/TracyC.h"
+
 
 int GArgc = 0;
 char **GArgv = NULL;
@@ -56,26 +58,85 @@ struct event_subscriber_s {
 	} handles[NUM_EVT_HANDLE];
 };
 
-static std::atomic<size_t> SyncToken;
+static std::atomic<size_t> SyncToken = 1;
 static size_t currentSync;
 static struct steam_rpc_async_s rpc_handles[NUM_RPC_ASYNC_HANDLE];
 static struct event_subscriber_s evt_handles[STEAM_EVT_LEN];
 
+// Accumulation buffer shared by STEAMSHIM_dispatch (non-blocking drain) and
+// STEAMSHIM_waitDispatchSync (blocking wait). Grows to fit oversized packets.
+// Only the main thread reads from GPipeRead, so no synchronization is needed.
+static std::vector<uint8_t> dispatchBuf;
+static size_t dispatchCursor = 0;
+
 std::mutex writeGuard;
+
+static int processBufferedPackets( uint32_t waitSync )
+{
+	while( 1 ) {
+		// Drain every complete packet currently in the buffer.
+		while( dispatchCursor >= sizeof( uint32_t ) ) {
+			struct steam_packet_buf *packet = reinterpret_cast<struct steam_packet_buf *>( dispatchBuf.data() );
+			const size_t packetlen = (size_t)packet->size + sizeof( uint32_t );
+			if( packetlen < sizeof( uint32_t ) ) {
+				// overflow guard — reset and bail
+				dispatchCursor = 0;
+				return -1;
+			}
+			if( packetlen > dispatchBuf.size() ) {
+				dispatchBuf.resize( packetlen );
+				packet = reinterpret_cast<struct steam_packet_buf *>( dispatchBuf.data() );
+			}
+			if( dispatchCursor < packetlen ) {
+				break; // body still arriving — fall through to read more
+			}
+
+			const bool rpcPacket = packet->common.cmd >= RPC_BEGIN && packet->common.cmd < RPC_END;
+			if( rpcPacket ) {
+				struct steam_rpc_async_s *handle = rpc_handles + ( packet->rpc_payload.common.sync % NUM_RPC_ASYNC_HANDLE );
+				if( handle->cb ) {
+					handle->cb( handle->self, &packet->rpc_payload );
+				}
+				currentSync = packet->rpc_payload.common.sync;
+			} else if( packet->common.cmd >= EVT_BEGIN && packet->common.cmd < EVT_END ) {
+				struct event_subscriber_s *handle = evt_handles + ( packet->common.cmd - EVT_BEGIN );
+				for( size_t i = 0; i < handle->numSubscribers; i++ ) {
+					handle->handles[i].cb( handle->handles[i].self, &packet->evt_payload );
+				}
+			}
+
+			if( dispatchCursor > packetlen ) {
+				const size_t remainingLen = dispatchCursor - packetlen;
+				memmove( dispatchBuf.data(), dispatchBuf.data() + packetlen, remainingLen );
+				dispatchCursor = remainingLen;
+			} else {
+				dispatchCursor = 0;
+			}
+
+			if( waitSync != WAIT_SYNC_NONBLOCKING && currentSync == waitSync ) {
+				return 0;
+			}
+		}
+
+		// Buffer fully decoded; need more bytes from the pipe.
+		if( waitSync == WAIT_SYNC_NONBLOCKING && !pipeReady( GPipeRead ) ) {
+			return 0;
+		}
+		if( dispatchBuf.empty() ) {
+			dispatchBuf.resize( STEAM_PACKED_RESERVE_SIZE );
+		}
+		int bytesRead = readPipe( GPipeRead, dispatchBuf.data() + dispatchCursor, dispatchBuf.size() - dispatchCursor );
+		if( bytesRead <= 0 ) {
+			return -1;
+		}
+		dispatchCursor += bytesRead;
+	}
+}
 
 int STEAMSHIM_dispatch()
 {
 	TracyCZoneN( ctx, "STEAMSHIM_dispatch", 1 );
-	// struct steam_packet_buf packet;
-	uint32_t syncIndex = 0;
-	// size_t cursor = 0;
-	struct steam_rpc_shim_common_s pkt;
-	pkt.cmd = RPC_PUMP;
-	if( STEAMSHIM_sendRPC( &pkt, sizeof( steam_rpc_shim_common_s ), NULL, NULL, &syncIndex ) < 0 ) {
-		TracyCZoneEnd( ctx );
-		return -1;
-	}
-	int result = STEAMSHIM_waitDispatchSync( syncIndex );
+	int result = processBufferedPackets( WAIT_SYNC_NONBLOCKING );
 	TracyCZoneEnd( ctx );
 	return result;
 }
@@ -114,6 +175,9 @@ int STEAMSHIM_init( SteamshimOptions *options )
 	PipeType pipeChildRead = NULLPIPE;
 	PipeType pipeChildWrite = NULLPIPE;
 	ProcessType childPid;
+
+	dispatchBuf.resize( STEAM_PACKED_RESERVE_SIZE );
+	dispatchCursor = 0;
 
 	if( options->runclient )
 		setEnvVar( "STEAMSHIM_RUNCLIENT", "1" );
@@ -168,13 +232,16 @@ int STEAMSHIM_init( SteamshimOptions *options )
 void STEAMSHIM_deinit( void )
 {
 	dbgprintf( "Child deinit.\n" );
-	if( GPipeWrite != NULLPIPE ) 
+	if( GPipeWrite != NULLPIPE )
 		closePipe( GPipeWrite );
 
 	if( GPipeRead != NULLPIPE )
 		closePipe( GPipeRead );
 
 	GPipeRead = GPipeWrite = NULLPIPE;
+
+	dispatchBuf.clear();
+	dispatchCursor = 0;
 
 #ifndef _WIN32
 	signal( SIGPIPE, SIG_DFL );
@@ -230,58 +297,13 @@ int STEAMSHIM_waitDispatchSync( uint32_t syncIndex )
 		TracyCZoneEnd( ctx );
 		return 0; // can't wait on dispatch if there is no RPC's staged
 	}
-	static struct steam_packet_buf packet;
-	static size_t cursor = 0;
-	while( 1 ) {
-		assert( sizeof( struct steam_packet_buf ) == STEAM_PACKED_RESERVE_SIZE );
-		int bytesRead = readPipe( GPipeRead, packet.buffer + cursor, STEAM_PACKED_RESERVE_SIZE - cursor );
-		if( bytesRead > 0 ) {
-			cursor += bytesRead;
-		} else {
-			TracyCZoneEnd( ctx );
-			return -1;
-		}
-	continue_processing:
-
-		if( packet.size > STEAM_PACKED_RESERVE_SIZE - sizeof( uint32_t ) ) {
-			// the packet is larger then the reserved size
-			TracyCZoneEnd( ctx );
-			return -1;
-		}
-
-		if( cursor < packet.size + sizeof( uint32_t ) ) {
-			continue;
-		}
-		const bool rpcPacket = packet.common.cmd >= RPC_BEGIN && packet.common.cmd < RPC_END;
-		if( rpcPacket ) {
-			// assert(packet.rpc_payload.common.sync > currentSync); // rpc's are FIFO no out of order
-			struct steam_rpc_async_s *handle = rpc_handles + ( packet.rpc_payload.common.sync % NUM_RPC_ASYNC_HANDLE );
-			if( handle->cb ) {
-				handle->cb( handle->self, &packet.rpc_payload );
-			}
-			currentSync = packet.rpc_payload.common.sync;
-		} else if( packet.common.cmd >= EVT_BEGIN && packet.common.cmd < EVT_END ) {
-			struct event_subscriber_s *handle = evt_handles + ( packet.common.cmd - EVT_BEGIN );
-			for( size_t i = 0; i < handle->numSubscribers; i++ ) {
-				handle->handles[i].cb( handle->handles[i].self, &packet.evt_payload );
-			}
-		}
-
-		if( cursor > packet.size + sizeof( uint32_t ) ) {
-			const size_t packetlen = packet.size + sizeof( uint32_t );
-			const size_t remainingLen = cursor - packetlen;
-			memmove( packet.buffer, packet.buffer + packet.size + sizeof( uint32_t ), remainingLen );
-			cursor = remainingLen;
-			goto continue_processing;
-		} else {
-			cursor = 0;
-		}
-		if( rpcPacket && currentSync == syncIndex ) {
-			break;
-		}
-	}
+	int result = processBufferedPackets( syncIndex );
 	TracyCZoneEnd( ctx );
-	return 0;
+	return result;
+}
+uint32_t STEAMSHIM_currentSync()
+{
+	return (uint32_t)currentSync;
 }
 void STEAMSHIM_subscribeEvent( uint32_t id, void *self, STEAMSHIM_evt_handle evt )
 {

--- a/source/steamshim/src/steamshim_types.h
+++ b/source/steamshim/src/steamshim_types.h
@@ -23,10 +23,12 @@ freely, subject to the following restrictions:
 
 #include "../../gameshared/q_arch.h"
 
+#define WAIT_SYNC_NONBLOCKING 0
 #define STEAM_AVATAR_SIZE ( 128 * 128 * 4 )
 #define PIPEMESSAGE_MAX ( STEAM_AVATAR_SIZE + 64 )
 #define AUTH_TICKET_MAXSIZE 1024
 #define SDR_MAX_MESSAGE_SIZE 32768
+#define SDR_MAX_REQUESTED_PACKETS 32
 typedef struct {
 	char pTicket[AUTH_TICKET_MAXSIZE];
 	long long pcbTicket;
@@ -211,14 +213,12 @@ enum steam_cmd_s {
 	RPC_SRV_P2P_ACCEPT_CONNECTION,
 	RPC_SRV_P2P_DISCONNECT,
 	RPC_SRV_P2P_SEND_MESSAGE,
-	RPC_SRV_P2P_RECV_MESSAGES,
 	RPC_SRV_P2P_CLOSE_LISTEN,
 
 	RPC_P2P_CONNECT,
 	RPC_P2P_DISCONNECT,
 
 	RPC_P2P_SEND_MESSAGE,
-	RPC_P2P_RECV_MESSAGES,
 
 	RPC_AUTHSESSION_TICKET,
 
@@ -236,6 +236,9 @@ enum steam_cmd_s {
 	EVT_P2P_CONNECTION_CHANGED,
 
 	EVT_SRV_P2P_CONNECTION_CHANGED,
+
+	EVT_P2P_RECV_MESSAGES,
+	EVT_SRV_P2P_RECV_MESSAGES,
 
 	EVT_END,
 	CMD_LEN
@@ -376,24 +379,6 @@ STEAM_RPC_REQ( send_message )
 	char buffer[];
 };
 
-STEAM_RPC_REQ( recv_messages )
-{
-	STEAM_RPC_SHIM_COMMON()
-	uint32_t handle;
-};
-
-STEAM_RPC_RECV( recv_messages )
-{
-	STEAM_RPC_SHIM_COMMON()
-	uint64_t steamID;
-	uint32_t handle; // -1 for the client->server handle
-	int count;
-	struct {
-		int count;
-	} messageinfo[32];
-	char buffer[];
-};
-
 STEAM_RPC_RECV( getvoice )
 {
 	STEAM_RPC_SHIM_COMMON()
@@ -438,8 +423,6 @@ struct steam_rpc_pkt_s {
 		struct p2p_listen_recv_s p2p_listen_recv;
 
 		struct send_message_req_s send_message;
-		struct recv_messages_req_s recv_messages;
-		struct recv_messages_recv_s recv_messages_recv;
 
 		struct getvoice_recv_s getvoice_recv;
 		struct decompress_voice_req_s decompress_voice;
@@ -517,6 +500,18 @@ STEAM_EVT( p2p_net_connection_changed )
 	uint32_t state;
 };
 
+STEAM_EVT( recv_messages )
+{
+	STEAM_SHIM_COMMON()
+	uint64_t steamID;
+	uint32_t handle;
+	int      count;
+	struct {
+		int count;
+	} messageinfo[SDR_MAX_REQUESTED_PACKETS];
+	char     buffer[];
+};
+
 struct steam_evt_pkt_s {
 	union {
 		struct steam_shim_common_s common;
@@ -526,7 +521,8 @@ struct steam_evt_pkt_s {
 		struct p2p_lost_connection_evt_s p2p_lost_connection;
 		struct p2p_connection_status_changed_evt_s p2p_connection_status_changed;
 		struct p2p_net_connection_changed_evt_s p2p_net_connection_changed;
-		struct policy_response_evt_s policy_response; 
+		struct recv_messages_evt_s recv_messages;
+		struct policy_response_evt_s policy_response;
 	};
 };
 


### PR DESCRIPTION
This pull request introduces a significant refactor and improvement to the Steam networking (SDR) packet handling system, transitioning from synchronous, request-based message polling to an event-driven, buffered architecture. The main goals are to improve packet delivery efficiency, reduce blocking, and ensure robust cleanup of resources. The changes affect both the game-side networking code (`net.c`) and the SteamShim IPC layer (`parent.cpp`, `child.cpp`, `mod_steam.h`).

The most important changes are:

**Networking Layer Refactor and Buffering:**
* Replaces synchronous packet polling with an event-driven, buffered system for SDR packets. Incoming Steam messages are now buffered per connection slot and delivered asynchronously to the game, improving performance and reliability (`net.c`). [[1]](diffhunk://#diff-6b64053b9e2957622a07c75386a0c2676bf7b5319fef6d5eb544fa663a055087R76-R146) [[2]](diffhunk://#diff-6b64053b9e2957622a07c75386a0c2676bf7b5319fef6d5eb544fa663a055087L342-R444)
* Adds robust cleanup of buffered packets and slot management on disconnect and shutdown to prevent memory leaks (`net.c`). [[1]](diffhunk://#diff-6b64053b9e2957622a07c75386a0c2676bf7b5319fef6d5eb544fa663a055087L579-R643) [[2]](diffhunk://#diff-6b64053b9e2957622a07c75386a0c2676bf7b5319fef6d5eb544fa663a055087R2174-R2185)

**SteamShim Event and Message Handling:**
* Implements background draining of all tracked Steam connections in the SteamShim child process, pushing received messages as events to the parent process. The parent now processes these events via a non-blocking, buffered dispatch loop, decoupling network polling from game logic (`child.cpp`, `parent.cpp`). [[1]](diffhunk://#diff-857aa209c8d8eed2d22e23dd6e46b6d307c90685b9ee4f0ee8f5d14df172f3d0R68-R108) [[2]](diffhunk://#diff-857aa209c8d8eed2d22e23dd6e46b6d307c90685b9ee4f0ee8f5d14df172f3d0L80-L110) [[3]](diffhunk://#diff-857aa209c8d8eed2d22e23dd6e46b6d307c90685b9ee4f0ee8f5d14df172f3d0R651) [[4]](diffhunk://#diff-17a8aa0cdd0638b6d3c9f7ca667a0dda653189b2ef8ea00bf336e81b96d3a678L59-R139)
* Refactors the parent dispatch logic to use a shared accumulation buffer (`dispatchBuf`) for efficient, non-blocking packet processing, and ensures correct synchronization and memory management (`parent.cpp`).

**API and Interface Updates:**
* Updates the SteamShim interface to expose the current sync index and ensure all new functions are properly declared and accessible (`mod_steam.h`). [[1]](diffhunk://#diff-8c734db685d4e42734be666ef1947a943e967b8122964e793ca53283a37281ebR22) [[2]](diffhunk://#diff-8c734db685d4e42734be666ef1947a943e967b8122964e793ca53283a37281ebR34) [[3]](diffhunk://#diff-8c734db685d4e42734be666ef1947a943e967b8122964e793ca53283a37281ebR44) [[4]](diffhunk://#diff-8c734db685d4e42734be666ef1947a943e967b8122964e793ca53283a37281ebR60)

These changes collectively modernize the SDR networking path, making it more robust, less blocking, and easier to maintain.