### PR TITLE
bugfix: resolve crash with serverbrowser

### DIFF
--- a/source/ui/datasources/ui_serverbrowser_datasource.h
+++ b/source/ui/datasources/ui_serverbrowser_datasource.h
@@ -114,7 +114,7 @@ namespace WSWUI {
 			CompareFunction function;
 			InvertCompareFunction(CompareFunction _function) : function(_function) {}
 			bool operator()( const ServerInfo &lhs, const ServerInfo &rhs ) {
-				return !function(lhs, rhs);
+				return function(rhs, lhs);
 			}
 		};
 
@@ -122,7 +122,8 @@ namespace WSWUI {
 			ComparePtrFunction function;
 			InvertComparePtrFunction(ComparePtrFunction _function) : function(_function) {}
 			bool operator()( const ServerInfo *lhs, const ServerInfo *rhs ) {
-				return !function(lhs, rhs);
+				// reverse the order by swapping the arguments; see InvertCompareFunction.
+				return function(rhs, lhs);
 			}
 		};
 


### PR DESCRIPTION
here is the relevant callstack
```
EXCEPTION_ACCESS_VIOLATION_READ / 0x1d: Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ / 0x1d
  ui_x64              0x7fff5ff6e207 std::_Tree<T>::_Find_lower_bound (xtree:1630)
  ui_x64              0x7fff5ff6e207 std::_Tree<T>::_Find (xtree:1384)
  ui_x64              0x7fff5ff6e207 std::_Tree<T>::find (xtree:1398)
  ui_x64              0x7fff5ff6e207 WSWUI::Table::GetRocketRow (ui_gameajax_datasource.cpp:66)
  ui_x64              0x7fff5ff6e763 WSWUI::GameAjaxDataSource::GetRow (ui_gameajax_datasource.cpp:118)
  ui_x64              0x7fff5ff0cd91 ASUI::DataSource_GetField (as_bind_datasource.cpp:39)
  angelwrap_x64       0x7fff75fa3444 CallX64
  angelwrap_x64       0x7fff75f6e800 CallSystemFunctionNative (as_callfunc_x64_msvc.cpp:198)
  angelwrap_x64       0x7fff75f497da CallSystemFunction (as_callfunc.cpp:752)
  angelwrap_x64       0x7fff75f35995 asCContext::ExecuteNext (as_context.cpp:2971)
  angelwrap_x64       0x7fff75f34df7 asCContext::Execute (as_context.cpp:1499)
  ui_x64              0x7fff5ff4858c ASBind::FunctionPtrBase::call (asbind.h:1036)
  ui_x64              0x7fff5ff678ec ASUI::ScriptEventListener::ProcessEvent (asui_scriptevent.cpp:169)
  ui_x64              0x7fff5fe8eb61 Rocket::Core::EventDispatcher::TriggerEvents (EventDispatcher.cpp:182)
  ui_x64              0x7fff5fe8e9bc Rocket::Core::EventDispatcher::DispatchEvent (EventDispatcher.cpp:146)
  ui_x64              0x7fff5fe5f68d Rocket::Core::Element::DispatchEvent (Element.cpp:1053)
  ui_x64              0x7fff5ffb5657 WSWUI::SelectableDataGrid::ProcessEvent (ui_selectable_datagrid.cpp:123)
  ui_x64              0x7fff5fe8ec73 Rocket::Core::EventDispatcher::TriggerEvents (EventDispatcher.cpp:215)
  ui_x64              0x7fff5fe8ea1a Rocket::Core::EventDispatcher::DispatchEvent (EventDispatcher.cpp:157)
  ui_x64              0x7fff5fe5f68d Rocket::Core::Element::DispatchEvent (Element.cpp:1053)
  ui_x64              0x7fff5fe48159 Rocket::Core::Context::ProcessMouseButtonUp (Context.cpp:770)
  ui_x64              0x7fff5ff9fdf8 WSWUI::RocketModule::keyEvent (ui_rocketmodule.cpp:214)
  warfork_x64         0x7ff79c03cbf2 Key_Event (keys.c:800)
  warfork_x64         0x7ff79c040801 IN_RawInput_MouseRead (win_input.c:699)
  warfork_x64         0x7ff79c04351f MainWndProc (win_vid.c:348)
  USER32              0x7fff9aa1ef5b UserCallWinProcCheckWow
  USER32              0x7fff9aa1e9dd CallWindowProcW
  opengl32            0x7fff7db7f1ff wglWndProc
  USER32              0x7fff9aa1ef5b UserCallWinProcCheckWow
  USER32              0x7fff9aa1e683 DispatchMessageWorker
  warfork_x64         0x7ff79c0427b5 WinMain (win_sys.c:489)
  warfork_x64         0x7ff79c0ecca5 invoke_main (exe_common.inl:102)
  warfork_x64         0x7ff79c0ecca5 __scrt_common_main_seh (exe_common.inl:288)
  KERNEL32.DLL        0x7fff9a457373 BaseThreadInitThunk
  ntdll               0x7fff9b5dcc90 RtlUserThreadStart
```