### PR TITLE
feat: fix fullscreen for gl renderer

### DIFF
--- a/source/client/cl_vid.c
+++ b/source/client/cl_vid.c
@@ -660,6 +660,12 @@ load_refresh:
 	*/
 	if( vid_xpos->modified || vid_ypos->modified )
 	{
+		// make sure the titlebar is not completely hidden away
+		if( vid_xpos->integer < 8 )
+			Cvar_ForceSet( vid_xpos->name, "8" );
+		if( vid_ypos->integer < 8 )
+			Cvar_ForceSet( vid_ypos->name, "8" );
+
 		if( !vid_fullscreen->integer )
 			VID_UpdateWindowPosAndSize( vid_xpos->integer, vid_ypos->integer );
 		vid_xpos->modified = false;
@@ -735,6 +741,16 @@ void VID_Init( void )
 	/* Add some console commands that we want to handle */
 	Cmd_AddCommand( "vid_restart", VID_Restart_f );
 	Cmd_AddCommand( "vid_modelist", VID_ModeList_f );
+
+	// make sure the titlebar is not completely hidden away
+	if( vid_xpos->integer < 8 ) {
+		Cvar_ForceSet( vid_xpos->name, "8" );
+		vid_xpos->modified = false;
+	}
+	if( vid_ypos->integer < 8 ) {
+		Cvar_ForceSet( vid_ypos->name, "8" );
+		vid_ypos->modified = false;
+	}
 
 	/* Start the graphics mode and load refresh DLL */
 	vid_ref_modified = true;

--- a/source/ref_gl/r_frontend.c
+++ b/source/ref_gl/r_frontend.c
@@ -213,7 +213,7 @@ rserr_t RF_SetMode( int x, int y, int width, int height, int displayFrequency, b
 	rserr_t err;
 
 	if( glConfig.width == width && glConfig.height == height && glConfig.fullScreen != fullScreen ) {
-		return GLimp_SetFullscreenMode( displayFrequency, fullScreen );
+		return GLimp_SetFullscreen( fullScreen, x, y );
 	}
 
 	RF_AdapterShutdown( &rrf.adapter );

--- a/source/ref_gl/r_glimp.h
+++ b/source/ref_gl/r_glimp.h
@@ -244,7 +244,7 @@ int		GLimp_Init( const char *applicationName, void *hinstance, void *wndproc, vo
 void	GLimp_Shutdown( void );
 rserr_t	GLimp_SetMode( int x, int y, int width, int height, int displayFrequency, bool fullscreen, bool stereo );
 rserr_t	GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd, bool *surfaceChangePending );
-rserr_t GLimp_SetFullscreenMode( int displayFrequency, bool fullscreen );
+rserr_t GLimp_SetFullscreen( bool fullscreen, int xpos, int ypos );
 void	GLimp_AppActivate( bool active, bool destroy );
 bool	GLimp_GetGammaRamp( size_t stride, unsigned short *psize, unsigned short *ramp );
 void	GLimp_SetGammaRamp( size_t stride, unsigned short   size, unsigned short *ramp );

--- a/source/sdl/sdl_glw.c
+++ b/source/sdl/sdl_glw.c
@@ -51,11 +51,12 @@ void GLimp_SetWindowIcon( void )
 #endif
 }
 
-rserr_t GLimp_SetFullscreenMode( int displayFrequency, bool fullscreen )
+rserr_t GLimp_SetFullscreen( bool fullscreen, int xpos, int ypos )
 {
 	Uint32 flags = 0;
 
 	if( fullscreen ) {
+		xpos = ypos = 0;
 #ifdef __APPLE__
 		// we need to use SDL_WINDOW_FULLSCREEN_DESKTOP to support Alt+Tab from fullscreen on OS X
 		flags = SDL_WINDOW_FULLSCREEN_DESKTOP;
@@ -65,6 +66,7 @@ rserr_t GLimp_SetFullscreenMode( int displayFrequency, bool fullscreen )
 	}
 
     if( SDL_SetWindowFullscreen( glw_state.sdl_window, flags ) == 0 ) {
+        SDL_SetWindowPosition( glw_state.sdl_window, xpos, ypos );
         glConfig.fullScreen = fullscreen;
         return rserr_ok;
     }
@@ -116,7 +118,7 @@ rserr_t GLimp_SetMode( int x, int y, int width, int height, int displayFrequency
 		return rserr_invalid_mode;
 	}
 
-    glConfig.fullScreen = fullscreen ? GLimp_SetFullscreenMode( displayFrequency, fullscreen ) == rserr_ok : false;
+    glConfig.fullScreen = fullscreen ? GLimp_SetFullscreen( fullscreen, x, y ) == rserr_ok : false;
 	glConfig.width = width;
 	glConfig.height = height;
 
@@ -128,6 +130,7 @@ rserr_t GLimp_SetMode( int x, int y, int width, int height, int displayFrequency
  */
 void GLimp_Shutdown()
 {
+	SDL_GL_DeleteContext( glw_state.sdl_glcontext );
 	SDL_DestroyWindow( glw_state.sdl_window );
 
 	free( glw_state.applicationName );
@@ -166,6 +169,7 @@ int GLimp_Init( const char *applicationName, void *hinstance, void *wndproc, voi
 static int GLimp_InitGL( int stencilbits, bool stereo )
 {
 	int colorBits, depthBits, stencilBits, stereo_;
+	SDL_GLContext sdl_glcontext = 0;
 
 	SDL_GL_SetAttribute( SDL_GL_STENCIL_SIZE, max( 0, stencilbits ) );
 #ifndef NDEBUG
@@ -177,13 +181,13 @@ static int GLimp_InitGL( int stencilbits, bool stereo )
 		SDL_GL_SetAttribute( SDL_GL_STEREO, 1 );
 	}
 
-	glw_state.sdl_glcontext = SDL_GL_CreateContext( glw_state.sdl_window );
-	if( glw_state.sdl_glcontext == 0 ) {
+	sdl_glcontext = SDL_GL_CreateContext( glw_state.sdl_window );
+	if( sdl_glcontext == 0 ) {
 		ri.Com_Printf( "GLimp_Init() - SDL_GL_CreateContext failed: \"%s\"\n", SDL_GetError() );
 		goto fail;
 	}
 
-	if( SDL_GL_MakeCurrent( glw_state.sdl_window, glw_state.sdl_glcontext ) ) {
+	if( SDL_GL_MakeCurrent( glw_state.sdl_window, sdl_glcontext ) ) {
 		ri.Com_Printf( "GLimp_Init() - SDL_GL_MakeCurrent failed: \"%s\"\n", SDL_GetError() );
 		goto fail;
 	}
@@ -201,9 +205,15 @@ static int GLimp_InitGL( int stencilbits, bool stereo )
 
 	ri.Com_Printf( "GL PFD: color(%d-bits) Z(%d-bit) stencil(%d-bits)\n", colorBits, depthBits, stencilBits );
 
+	glw_state.sdl_glcontext = sdl_glcontext;
 	return true;
 
 fail:
+	if( sdl_glcontext ) {
+		SDL_GL_DeleteContext( sdl_glcontext );
+		sdl_glcontext = 0;
+	}
+
 	return false;
 }
 

--- a/source/sdl/sdl_input.c
+++ b/source/sdl/sdl_input.c
@@ -413,6 +413,28 @@ static void IN_WarpMouseToCenter( int *pcenter_x, int *pcenter_y )
 void IN_MouseMove( usercmd_t *cmd )
 {
 	if( mouse_active ) {
+		if( cls.key_dest == key_menu ) {
+			// The menu cursor is driven by the absolute pointer position (relative
+			// mode is off in menus). Map window pixels into viddef (UI) space so the
+			// cursor tracks 1:1 even when the backend stretches the rendered image to
+			// the window; absolute positioning avoids the diagonal stair-stepping that
+			// accumulating scaled relative deltas would cause.
+			int ax = 0, ay = 0, winW = 0, winH = 0;
+
+			SDL_GetMouseState( &ax, &ay );
+			SDL_GetWindowSize( sdl_window, &winW, &winH );
+
+			int ux = ax, uy = ay;
+			if( winW > 0 && winH > 0 ) {
+				ux = (int)( (float)ax * (float)viddef.width / (float)winW );
+				uy = (int)( (float)ay * (float)viddef.height / (float)winH );
+			}
+
+			CL_MouseSet( ux, uy, true );
+			mx = my = 0;
+			return;
+		}
+
 		if( !mouse_relative ) {
 			if( mx || my ) {
 				int center_x, center_y;
@@ -507,34 +529,37 @@ void IN_Frame()
 	if( !input_inited )
 		return;
 
-	if( !input_focus || ( !Cvar_Value( "vid_fullscreen" ) && cls.key_dest == key_console && !in_grabinconsole->integer ) ) {
-		if( mouse_active ) {
-			if( mouse_relative ) {
-				mouse_relative = !(SDL_SetRelativeMouseMode( SDL_FALSE ) == 0);
-				if( !mouse_relative ) {
-					IN_SetMouseScalingEnabled( true );
-				}
-			}
-			SDL_ShowCursor( SDL_ENABLE );
-		}
-		mouse_active = false;
-		input_active = true;
-	} else {
-		if( !mouse_active ) {
-			SDL_ShowCursor( SDL_DISABLE );
+	// Evaluate the desired mouse state every frame (not just on activate/deactivate
+	// transitions) so switching between game/menu/console updates relative mode.
+	// Relative mode (FPS look) is only used in gameplay; menus use the absolute
+	// pointer position (see IN_MouseMove), matching upstream qfusion.
+	bool want_active = input_focus &&
+		!( !Cvar_Value( "vid_fullscreen" ) && cls.key_dest == key_console && !in_grabinconsole->integer );
+	bool want_relative = want_active && cls.key_dest != key_menu;
 
-			mouse_relative = SDL_SetRelativeMouseMode( SDL_TRUE ) == 0;
+	if( want_relative != mouse_relative ) {
+		if( SDL_SetRelativeMouseMode( want_relative ? SDL_TRUE : SDL_FALSE ) == 0 ) {
+			mouse_relative = want_relative;
+			IN_SetMouseScalingEnabled( !mouse_relative );
 			if( mouse_relative ) {
-				IN_SetMouseScalingEnabled( false );
+				IN_SkipRelativeMouseMove();
 			}
-			else {
-				IN_WarpMouseToCenter( NULL, NULL );
-			}
-			IN_SkipRelativeMouseMove();
 		}
-		mouse_active = true;
-		input_active = true;
 	}
+
+	if( want_active != mouse_active ) {
+		// OS cursor stays hidden while active (the UI draws its own cursor) and is
+		// shown when input is released to the desktop.
+		SDL_ShowCursor( want_active ? SDL_DISABLE : SDL_ENABLE );
+		mouse_active = want_active;
+	}
+
+	// Confine the (hidden) pointer to the window while in the absolute-cursor menu so
+	// clicks don't escape; relative mode already confines, and losing focus clears
+	// want_active which releases the grab.
+	SDL_SetWindowGrab( sdl_window, ( want_active && !mouse_relative ) ? SDL_TRUE : SDL_FALSE );
+
+	input_active = true;
 
 	IN_HandleEvents();
 }

--- a/source/unix/unix_glw.c
+++ b/source/unix/unix_glw.c
@@ -842,10 +842,10 @@ rserr_t GLimp_SetMode( int x, int y, int width, int height, int displayFrequency
 }
 
 /*
-** GLimp_SetFullscreenMode
+** GLimp_SetFullscreen
 */
-rserr_t GLimp_SetFullscreenMode( int displayFrequency, bool fullscreen ) {
-	return GLimp_SetMode_Real(0, 0, displayFrequency, fullscreen, false, false);
+rserr_t GLimp_SetFullscreen( bool fullscreen, int xpos, int ypos ) {
+	return GLimp_SetMode_Real(0, 0, 0, fullscreen, false, false);
 }
 
 /*

--- a/source/win32/win_glw.c
+++ b/source/win32/win_glw.c
@@ -178,9 +178,9 @@ static void GLimp_CreateWindow( void )
 }
 
 /*
-** GLimp_SetFullscreenMode
+** GLimp_SetFullscreen
 */
-rserr_t GLimp_SetFullscreenMode( int displayFrequency, bool fullscreen )
+rserr_t GLimp_SetFullscreen( bool fullscreen, int xpos, int ypos )
 {
 	glConfig.fullScreen = false;
 
@@ -200,13 +200,6 @@ rserr_t GLimp_SetFullscreenMode( int displayFrequency, bool fullscreen )
 		dm.dmPelsHeight = glConfig.height;
 		dm.dmFields     = DM_PELSWIDTH | DM_PELSHEIGHT;
 
-		if( displayFrequency > 0 )
-		{
-			dm.dmFields |= DM_DISPLAYFREQUENCY;
-			dm.dmDisplayFrequency = displayFrequency;
-			ri.Com_Printf( "...using display frequency %i\n", dm.dmDisplayFrequency );
-		}
-
 		ri.Com_Printf( "...calling CDS: " );
 		a = ChangeDisplaySettings( &dm, CDS_FULLSCREEN );
 		if( a == DISP_CHANGE_SUCCESSFUL )
@@ -222,6 +215,8 @@ rserr_t GLimp_SetFullscreenMode( int displayFrequency, bool fullscreen )
 	}
 
 	ChangeDisplaySettings( 0, 0 );
+	glw_state.win_x = xpos;
+	glw_state.win_y = ypos;
 	GLimp_SetWindowSize( false );
 
 	return rserr_ok;
@@ -260,7 +255,7 @@ rserr_t GLimp_SetMode( int x, int y, int width, int height, int displayFrequency
 
 	glConfig.width = width;
 	glConfig.height = height;
-	glConfig.fullScreen = ( fullscreen ? GLimp_SetFullscreenMode( displayFrequency, fullscreen ) == rserr_ok : false );
+	glConfig.fullScreen = ( fullscreen ? GLimp_SetFullscreen( fullscreen, x, y ) == rserr_ok : false );
 	glConfig.stereoEnabled = stereo;
 
 	GLimp_CreateWindow();


### PR DESCRIPTION
Qfusion/qfusion@16f0ccec1a9ad3231623f376da5e5b13038e28c8
       SDL_GL_DeleteContext in GLimp_Shutdown + local-context/fail-path cleanup in GLimp_InitGL (sdl_glw.c); the vid_xpos/vid_ypos ≥ 8 title-bar clamp (cl_vid.c)
Qfusion/qfusion@54df98cc8a09273f377af8460ef55e949fc940d5
       The GLimp_SetFullscreenMode → GLimp_SetFullscreen(fullscreen, xpos,ypos) rename + SDL_SetWindowPosition after the fullscreen toggle (sdl_glw.c, r_glimp.h, r_frontend.c, win_glw.c, unix_glw.c). The win32 WM_GETMINMAXINFO half was not ported