### PR TITLE
Remove 'legacy' from shaderlist.txt

### DIFF
--- a/assets/data0_21pure/scripts/shaderlist.txt
+++ b/assets/data0_21pure/scripts/shaderlist.txt
@@ -81,6 +81,5 @@ neon
 dev_legacy
 etrtex
 scifi_interior
-legacy
 solidfake
 


### PR DESCRIPTION
[legacy.shader](https://github.com/TeamForbiddenLLC/warfork-qfusion/blob/a611927b4d306450f7ada8632743d0e3dddaeeca/assets/data0_21pure/scripts/legacy.shader) is the garbage bin of old shaders for textures removed from the game. The goal is to remove textures while not breaking the custom maps that have used them, but stop people from using them in new maps. The whole purpose of this file is not to be included in the shaderlist.txt.