### PR TITLE
feat: add shader cache

### DIFF
--- a/source/ref_nri/r_backend.c
+++ b/source/ref_nri/r_backend.c
@@ -69,7 +69,9 @@ void RB_Init( void )
 	// initialize shading
 	RB_InitShading();
 
-	RP_PrecachePrograms();
+	// RP_PrecachePrograms() is driven by RP_Init(), not from here: RB_Init/RB_Shutdown re-enter on
+	// every RF_SetMode with the program table still live, which would replay the precache list once
+	// per video mode change.
 	TracyCZoneEnd( ctx );
 }
 
@@ -93,7 +95,9 @@ void RB_Shutdown( void )
 #endif
 	}
 	memset( rb.dynamicStreams, 0, sizeof( struct dynamic_vertex_stream_s ) * RB_DYN_STREAM_NUM );
-	RP_StorePrecacheList();
+	// RP_StorePrecacheList() is driven by RP_Shutdown(), not from here: RF_Shutdown calls
+	// RP_Shutdown() before RB_Shutdown(), so by this point every program has already been destroyed
+	// and the store would write an empty cache.
 	R_FreePool( &rb.mempool );
 	TracyCZoneEnd( ctx );
 }

--- a/source/ref_nri/r_local.h
+++ b/source/ref_nri/r_local.h
@@ -496,6 +496,11 @@ extern cvar_t *r_showtris;
 extern cvar_t *r_draworder;
 extern cvar_t *r_leafvis;
 
+extern cvar_t *r_shaderCache;
+extern cvar_t *r_shaderDebug;
+extern cvar_t *r_shaderValidate;
+extern cvar_t *r_shaderOptimize;
+
 extern cvar_t *r_fastsky;
 extern cvar_t *r_portalonly;
 extern cvar_t *r_portalmaps;

--- a/source/ref_nri/r_program.c
+++ b/source/ref_nri/r_program.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "r_local.h"
 #include "ri_vk.h"
 
+#include "r_program_cache.h"
 #include "spirv_reflect.h"
 #include <glslang/Include/glslang_c_interface.h>
 #include <glslang/Include/glslang_c_shader_types.h>
@@ -93,6 +94,12 @@ void RP_Init( void )
 
 	Trie_Create( TRIE_CASE_INSENSITIVE, &glsl_cache_trie );
 
+	// Both caches open before the base programs register: those 12 compile on every startup, so they
+	// are the most valuable cache hits available, and they would miss entirely if the caches only
+	// opened in RP_PrecachePrograms at the end of this function.
+	RP_InitPipelineCache();
+	RP_SpirvCacheOpen();
+
 	// register base programs
 	RP_RegisterProgram( GLSL_PROGRAM_TYPE_MATERIAL, DEFAULT_GLSL_MATERIAL_PROGRAM, NULL, NULL, 0, 0 );
 	RP_RegisterProgram( GLSL_PROGRAM_TYPE_DISTORTION, DEFAULT_GLSL_DISTORTION_PROGRAM, NULL, NULL, 0, 0 );
@@ -107,6 +114,9 @@ void RP_Init( void )
 	RP_RegisterProgram( GLSL_PROGRAM_TYPE_COLORCORRECTION, DEFAULT_GLSL_COLORCORRECTION_PROGRAM, NULL, NULL, 0, 0 );
 	// check whether compilation of the shader with GPU skinning succeeds, if not, disable GPU bone transforms
 	RP_RegisterProgram( GLSL_PROGRAM_TYPE_MATERIAL, DEFAULT_GLSL_MATERIAL_PROGRAM, NULL, NULL, 0, GLSL_SHADER_COMMON_BONE_TRANSFORMS1 );
+
+	// after the base programs, so the parent lookup for name-less permutations can resolve
+	RP_PrecachePrograms();
 	TracyCZoneEnd( ctx );
 }
 
@@ -198,24 +208,83 @@ static void __appendGLSLDeformv( struct QStr *str, const deformv_t *deformv, int
 /*
  * RP_PrecachePrograms
  *
- * Loads the list of known program permutations from disk file.
+ * Registers every permutation the last session recorded, so the SPIR-V load, reflection and layout
+ * creation happen here at init instead of mid-frame inside RB_DrawElements.
  *
- * Expected file format:
+ * This warms *programs*, not pipelines: a VkPipeline additionally needs a pipeline_desc_s built from
+ * live render state, which is not reconstructible here. The VkPipelineCache is what covers that.
+ *
+ * File format:
  * application_name\n
- * version_number\n*
- * program_type1 features_lower_bits1 features_higher_bits1 program_name1 binary_offset
+ * version_number\n
+ * program_type1 features1 "program_name1" "deforms_key1" binary_offset1
  * ..
- * program_typeN features_lower_bitsN features_higher_bitsN program_nameN binary_offset
+ * program_typeN featuresN "program_nameN" "deforms_keyN" binary_offsetN
  */
-void RP_PrecachePrograms( void ) {}
+void RP_PrecachePrograms( void )
+{
+	TracyCZoneN( ctx, "RP_PrecachePrograms", 1 );
+
+	// the index was already loaded by RP_SpirvCacheOpen() at the top of RP_Init
+	size_t warmed = 0;
+	for( size_t i = 0; i < RP_SpirvCacheEntryCount(); i++ ) {
+		int type;
+		r_glslfeat_t features;
+		const char *baseName;
+		const char *deformsKey;
+
+		if( !RP_SpirvCacheEntryAt( i, &type, &features, &baseName, &deformsKey ) ) {
+			break;
+		}
+		// leave headroom rather than march into the fixed-size r_glslprograms array
+		if( r_numglslprograms >= MAX_GLSL_PROGRAMS - 32 ) {
+			Com_Printf( S_COLOR_YELLOW "Precache list exceeds the program limit, warming %u of %u.\n", (unsigned)warmed, (unsigned)RP_SpirvCacheEntryCount() );
+			break;
+		}
+		// Deform permutations cannot be warmed from here: RP_ResolveProgram blanks deformsKey
+		// whenever deforms is NULL, and we have no deformv_t to hand it, so the call would silently
+		// resolve the non-deform program instead. They are still stored, and they still hit the
+		// SPIR-V cache mid-frame when the backend supplies the real deforms -- which is the path
+		// that was hitching anyway. Skipping them here only forgoes the load-time warm.
+		if( deformsKey && deformsKey[0] ) {
+			continue;
+		}
+		if( RP_ResolveProgram( type, baseName, NULL, NULL, 0, features ) ) {
+			warmed++;
+		}
+	}
+	if( warmed ) {
+		Com_Printf( "Precached %u GLSL programs.\n", (unsigned)warmed );
+	}
+	TracyCZoneEnd( ctx );
+}
 
 /*
  * RP_StorePrecacheList
  *
  * Stores the list of known GLSL program permutations to file on the disk.
  * File format matches that expected by RP_PrecachePrograms.
+ *
+ * Must run before RP_Shutdown's delete loop frees shaderBin and zeroes r_numglslprograms.
  */
-void RP_StorePrecacheList( void ) {}
+void RP_StorePrecacheList( void )
+{
+	unsigned int i;
+	struct glsl_program_s *program;
+
+	if( !RP_SpirvCacheStoreBegin() ) {
+		return;
+	}
+	for( i = 0, program = r_glslprograms; i < r_numglslprograms; i++, program++ ) {
+		// Two deliberate departures from ref_gl, which skips both of these:
+		//  - deform permutations are stored: they are exactly what hitches mid-game, and replaying a
+		//    cache hit needs no deformv_t (ref_gl had to skip them because its replay recompiles).
+		//  - zero-feature base programs are stored: RP_Init re-registers them on every startup, and
+		//    with the cache open before it does, they turn 12 unconditional compiles into 12 hits.
+		RP_SpirvCacheStoreProgram( program );
+	}
+	RP_SpirvCacheStoreEnd();
+}
 
 /*
  * RF_DeleteProgram
@@ -227,6 +296,8 @@ static void RF_DeleteProgram( struct glsl_program_s *program )
 
 	if( program->name )
 		R_Free( program->name );
+	if( program->baseName )
+		R_Free( program->baseName );
 	if( program->deformsKey )
 		R_Free( program->deformsKey );
 
@@ -882,26 +953,19 @@ void RP_ProgramList_f( void )
 	Com_Printf( "------------------\n" );
 	size_t i;
 	struct glsl_program_s *program;
-	struct QStr fullName = { 0 };
 	for( i = 0, program = r_glslprograms; i < MAX_GLSL_PROGRAMS; i++, program++ ) {
 		if( !program->name )
 			break;
 
-		qStrClear( &fullName );
-		qStrAppendSlice( &fullName, qCToStrRef( program->name ) );
-		for( feature_iter_t iter = __R_NextFeature( (feature_iter_t){ .it = glsl_programtypes_features[program->type], .bits = program->features } ); __R_IsValidFeatureIter( &iter );
-			 iter = __R_NextFeature( iter ) ) {
-			qStrAppendSlice( &fullName, qCToStrRef( iter.it->suffix ) );
-		}
-		Com_Printf( " %3i %.*s", i + 1, fullName.len, fullName.buf );
+		// program->name already carries the feature suffixes
+		Com_Printf( " %3i %s", (int)( i + 1 ), program->name );
 
 		if( *program->deformsKey ) {
 			Com_Printf( " dv:%s", program->deformsKey );
 		}
 		Com_Printf( "\n" );
 	}
-	qStrFree( &fullName );
-	Com_Printf( "%i programs total\n", i );
+	Com_Printf( "%i programs total\n", (int)i );
 }
 
 const char *RP_GLSLStageToShaderPrefix( const glsl_program_stage_t stage )
@@ -962,6 +1026,7 @@ void RP_BindPipeline( struct FrameState_s *cmd, struct pipeline_hash_s *pipeline
 
 struct pipeline_hash_s *RP_ResolvePipeline( struct glsl_program_s *program, struct pipeline_desc_s *cmd )
 {
+	TracyCZoneN( ctx, "RP_ResolvePipeline", 1 );
 	enum RICullMode_e cullMode = cmd->cullMode;
 	if( cmd->flippedViewport ) {
 		cullMode = RI_FlipCullMode( cullMode );
@@ -1042,6 +1107,7 @@ struct pipeline_hash_s *RP_ResolvePipeline( struct glsl_program_s *program, stru
 	struct pipeline_hash_s *pipeline = __resolvePipeline( program, hash );
 	assert( pipeline );
 	if( pipeline->vk.handle ) {
+		TracyCZoneEnd( ctx );
 		return pipeline; // pipeline is present in slot
 	}
 #if ( DEVICE_IMPL_VULKAN )
@@ -1147,7 +1213,7 @@ struct pipeline_hash_s *RP_ResolvePipeline( struct glsl_program_s *program, stru
 		depthStencilState.maxDepthBounds = 1.0f;
 		pipelineCreateInfo.pDepthStencilState = &depthStencilState;
 
-		VK_WrapResult( vkCreateGraphicsPipelines( rsh.device.vk.device, VK_NULL_HANDLE, 1, &pipelineCreateInfo, NULL, &pipeline->vk.handle ) );
+		VK_WrapResult( vkCreateGraphicsPipelines( rsh.device.vk.device, RP_PipelineCache(), 1, &pipelineCreateInfo, NULL, &pipeline->vk.handle ) );
 		//assert( ( attribFlags & program->vertexInputMask ) == program->vertexInputMask );
 		if( vkSetDebugUtilsObjectNameEXT ) {
 			VkDebugUtilsObjectNameInfoEXT debugName = { VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT, NULL, VK_OBJECT_TYPE_PIPELINE, (uint64_t)pipeline->vk.handle, program->name };
@@ -1160,6 +1226,7 @@ struct pipeline_hash_s *RP_ResolvePipeline( struct glsl_program_s *program, stru
 	}
 #endif
 
+	TracyCZoneEnd( ctx );
 	return pipeline;
 }
 
@@ -1387,8 +1454,18 @@ void _vk__descriptorSetAlloc( struct RIDevice_s *device, struct DescriptorSetAll
 struct glsl_program_s *RP_RegisterProgram( int type, const char *name, const char *deformsKey, const deformv_t *deforms, int numDeforms, r_glslfeat_t features )
 {
 	TracyCZoneN( ctx, "RP_RegisterProgram", 1 );
+	// RP_ResolveProgram bounds-checks before it calls here, but RP_Init and the precache replay
+	// reach this directly, and r_glslprograms is a fixed-size static array.
+	if( r_numglslprograms >= MAX_GLSL_PROGRAMS ) {
+		Com_Printf( S_COLOR_YELLOW "RP_RegisterProgram: GLSL programs limit exceeded\n" );
+		TracyCZoneEnd( ctx );
+		return NULL;
+	}
 	const uint64_t hashIndex = hash_u64( HASH_INITIAL_VALUE, features ) % GLSL_PROGRAMS_HASH_SIZE;
 	struct glsl_program_s *program = r_glslprograms + r_numglslprograms++;
+	// captured before fullName mangles it -- this is what the cache stores and what resolves back to
+	// the glsl_nri/<baseName>.<stage>.glsl source path
+	program->baseName = R_CopyString( name );
 	struct QStr featuresStr = { 0 };
 	struct QStr fullName = { 0 };
 	qStrAppendSlice( &fullName, qCToStrRef( name ) );
@@ -1398,9 +1475,9 @@ struct glsl_program_s *RP_RegisterProgram( int type, const char *name, const cha
 			qStrAppendSlice( &fullName, qCToStrRef( iter.it->suffix ) );
 		}
 	}
-	ri.Com_Printf( "Loading Shader: %.*s", fullName.len, fullName.buf );
-
 	bool error = false;
+	// declared before the cache lookup below because the reflection pass iterates it on both the
+	// cached and the compiled path
 	struct {
 		glsl_program_stage_t stage;
 		struct QStr source;
@@ -1408,170 +1485,207 @@ struct glsl_program_s *RP_RegisterProgram( int type, const char *name, const cha
 		{ .stage = GLSL_STAGE_VERTEX, .source = { 0 } },
 		{ .stage = GLSL_STAGE_FRAGMENT, .source = { 0 } },
 	};
-	{
-		struct QStr filePath = { 0 };
-		for( size_t i = 0; i < Q_ARRAY_COUNT( stages ); i++ ) {
-			qStrAppendSlice( &stages[i].source, qCToStrRef( "#version 440 \n" ) );
-			switch( stages[i].stage ) {
-				case GLSL_STAGE_VERTEX:
-					qStrAppendSlice( &stages[i].source, qCToStrRef( "#define VERTEX_SHADER\n" ) );
-					break;
-				case GLSL_STAGE_FRAGMENT:
-					qStrAppendSlice( &stages[i].source, qCToStrRef( "#define FRAGMENT_SHADER\n" ) );
-					break;
-				default:
-					assert( 0 );
-					break;
-			}
-			qStrAppendSlice( &stages[i].source, qToStrRef( featuresStr ) );
-			qStrAppendSlice( &stages[i].source, qCToStrRef( QF_BUILTIN_GLSL_CONSTANTS ) );
-			qStrAppendSlice( &stages[i].source, qCToStrRef( QF_GLSL_MATH ) );
-			if( stages[i].stage == GLSL_STAGE_VERTEX ) {
-				__appendGLSLDeformv( &stages[i].source, deforms, numDeforms );
-			}
-
-			qStrClear( &filePath );
-			qstrcatfmt( &filePath, "glsl_nri/%s.%s.glsl", name, RP_GLSLStageToShaderPrefix( stages[i].stage ) );
-			qStrSetNullTerm( &filePath );
-			error = RF_AppendShaderFromFile( &stages[i].source, filePath.buf, type, features );
-			if( error ) {
-				break;
-			}
-		}
-		qStrFree( &filePath );
-	}
-	qStrFree( &featuresStr );
 
 	program->hasPushConstant = false;
 	program->vertexInputMask = 0;
 
-	for( size_t i = 0; i < Q_ARRAY_COUNT( stages ); i++ ) {
-		qStrSetNullTerm( &stages[i].source );
-		const glslang_input_t input = { .language = GLSLANG_SOURCE_GLSL,
-										.stage = __RP_GLStageToSlang( stages[i].stage ),
-										.client = GLSLANG_CLIENT_VULKAN,
-										.client_version = GLSLANG_TARGET_VULKAN_1_2,
-										.target_language = GLSLANG_TARGET_SPV,
-										.target_language_version = GLSLANG_TARGET_SPV_1_5,
-										.code = stages[i].source.buf,
-										.default_version = 450,
-										.default_profile = GLSLANG_CORE_PROFILE,
-										.force_default_version_and_profile = false,
-										.forward_compatible = false,
-										.messages = GLSLANG_MSG_DEFAULT_BIT,
-										.resource = glslang_default_resource() };
-		glslang_shader_t *shader = glslang_shader_create( &input );
-		glslang_program_t *glslang_program = NULL;
-		if( !glslang_shader_preprocess( shader, &input ) ) {
-			struct QStr errFilePath = { 0 };
-			qstrcatfmt( &errFilePath, "logs/shader_err/%s.%s.glsl", name, RP_GLSLStageToShaderPrefix( stages[i].stage ) );
-			const char *infoLog = glslang_shader_get_info_log( shader );
-			const char *debugLogs = glslang_shader_get_info_debug_log( shader );
-			Com_Printf( S_COLOR_YELLOW "GLSL preprocess failed %.*s\n", fullName.len, fullName.buf );
-			Com_Printf( S_COLOR_YELLOW "%s\n", infoLog );
-			Com_Printf( S_COLOR_YELLOW "%s\n", debugLogs );
-			Com_Printf( S_COLOR_YELLOW "dump shader: %.*s\n", errFilePath.len, errFilePath.buf );
+	// A non-empty deformsKey with no deforms array cannot be compiled: __appendGLSLDeformv would
+	// bake no deform code, and the result would then be cached under a deform key -- silently wrong
+	// rendering that persists across runs. Such a call is only ever legal as a cache hit. Encoding
+	// it here rather than in the caller means no future caller can get it wrong.
+	const bool requiresCachedSpirv = ( deformsKey && deformsKey[0] && numDeforms == 0 );
+	const bool cacheHit = RP_SpirvCacheLookup( program, type, features, deformsKey );
 
-			struct QStr shaderErr = { 0 };
-			qstrcatfmt( &shaderErr, "%s\n", input.code );
-			qstrcatfmt( &shaderErr, "----------- Preprocessing Failed -----------\n" );
-			qstrcatfmt( &shaderErr, "%s\n", infoLog );
-			qstrcatfmt( &shaderErr, "%s\n", debugLogs );
-			__RP_writeTextToFile( errFilePath.buf, shaderErr.buf );
-			assert( false && "failed to preprocess shader" );
+	if( !cacheHit && requiresCachedSpirv ) {
+		qStrFree( &featuresStr );
+		qStrFree( &fullName );
+		R_Free( program->baseName );
+		memset( program, 0, sizeof( *program ) );
+		r_numglslprograms--;
+		TracyCZoneEnd( ctx );
+		return NULL;
+	}
 
-			qStrFree( &shaderErr );
-			qStrFree( &errFilePath );
+	if( !cacheHit ) {
+		ri.Com_Printf( "Loading Shader: %.*s", fullName.len, fullName.buf );
+		{
+			struct QStr filePath = { 0 };
+			for( size_t i = 0; i < Q_ARRAY_COUNT( stages ); i++ ) {
+				qStrAppendSlice( &stages[i].source, qCToStrRef( "#version 440 \n" ) );
+				switch( stages[i].stage ) {
+					case GLSL_STAGE_VERTEX:
+						qStrAppendSlice( &stages[i].source, qCToStrRef( "#define VERTEX_SHADER\n" ) );
+						break;
+					case GLSL_STAGE_FRAGMENT:
+						qStrAppendSlice( &stages[i].source, qCToStrRef( "#define FRAGMENT_SHADER\n" ) );
+						break;
+					default:
+						assert( 0 );
+						break;
+				}
+				qStrAppendSlice( &stages[i].source, qToStrRef( featuresStr ) );
+				qStrAppendSlice( &stages[i].source, qCToStrRef( QF_BUILTIN_GLSL_CONSTANTS ) );
+				qStrAppendSlice( &stages[i].source, qCToStrRef( QF_GLSL_MATH ) );
+				if( stages[i].stage == GLSL_STAGE_VERTEX ) {
+					__appendGLSLDeformv( &stages[i].source, deforms, numDeforms );
+				}
 
-			error = true;
-			goto shader_done;
+				qStrClear( &filePath );
+				qstrcatfmt( &filePath, "glsl_nri/%s.%s.glsl", name, RP_GLSLStageToShaderPrefix( stages[i].stage ) );
+				qStrSetNullTerm( &filePath );
+				error = RF_AppendShaderFromFile( &stages[i].source, filePath.buf, type, features );
+				if( error ) {
+					break;
+				}
+			}
+			qStrFree( &filePath );
 		}
 
-		if( !glslang_shader_parse( shader, &input ) ) {
-			struct QStr errFilePath = { 0 };
-			qstrcatfmt( &errFilePath, "logs/shader_err/%s.%s.glsl", name, RP_GLSLStageToShaderPrefix( stages[i].stage ) );
-			const char *infoLog = glslang_shader_get_info_log( shader );
-			const char *debugLogs = glslang_shader_get_info_debug_log( shader );
+		TracyCZoneN( compileCtx, "RP_GLSLCompile", 1 );
+		for( size_t i = 0; i < Q_ARRAY_COUNT( stages ); i++ ) {
+			qStrSetNullTerm( &stages[i].source );
+			const glslang_input_t input = { .language = GLSLANG_SOURCE_GLSL,
+											.stage = __RP_GLStageToSlang( stages[i].stage ),
+											.client = GLSLANG_CLIENT_VULKAN,
+											.client_version = GLSLANG_TARGET_VULKAN_1_2,
+											.target_language = GLSLANG_TARGET_SPV,
+											.target_language_version = GLSLANG_TARGET_SPV_1_5,
+											.code = stages[i].source.buf,
+											.default_version = 450,
+											.default_profile = GLSLANG_CORE_PROFILE,
+											.force_default_version_and_profile = false,
+											.forward_compatible = false,
+											.messages = GLSLANG_MSG_DEFAULT_BIT,
+											.resource = glslang_default_resource() };
+			glslang_shader_t *shader = glslang_shader_create( &input );
+			glslang_program_t *glslang_program = NULL;
+			if( !glslang_shader_preprocess( shader, &input ) ) {
+				struct QStr errFilePath = { 0 };
+				qstrcatfmt( &errFilePath, "logs/shader_err/%s.%s.glsl", name, RP_GLSLStageToShaderPrefix( stages[i].stage ) );
+				const char *infoLog = glslang_shader_get_info_log( shader );
+				const char *debugLogs = glslang_shader_get_info_debug_log( shader );
+				Com_Printf( S_COLOR_YELLOW "GLSL preprocess failed %.*s\n", fullName.len, fullName.buf );
+				Com_Printf( S_COLOR_YELLOW "%s\n", infoLog );
+				Com_Printf( S_COLOR_YELLOW "%s\n", debugLogs );
+				Com_Printf( S_COLOR_YELLOW "dump shader: %.*s\n", errFilePath.len, errFilePath.buf );
 
-			Com_Printf( S_COLOR_YELLOW "GLSL parsing failed %.*s\n", fullName.len, fullName.buf );
-			Com_Printf( S_COLOR_YELLOW "%s\n", infoLog );
-			Com_Printf( S_COLOR_YELLOW "%s\n", debugLogs );
-			Com_Printf( S_COLOR_YELLOW "dump shader: %.*s\n", errFilePath.len, errFilePath.buf );
+				struct QStr shaderErr = { 0 };
+				qstrcatfmt( &shaderErr, "%s\n", input.code );
+				qstrcatfmt( &shaderErr, "----------- Preprocessing Failed -----------\n" );
+				qstrcatfmt( &shaderErr, "%s\n", infoLog );
+				qstrcatfmt( &shaderErr, "%s\n", debugLogs );
+				__RP_writeTextToFile( errFilePath.buf, shaderErr.buf );
+				assert( false && "failed to preprocess shader" );
 
-			struct QStr shaderErr = { 0 };
-			qstrcatfmt( &shaderErr, "%s\n", input.code );
-			qstrcatfmt( &shaderErr, "----------- Parsing Failed -----------\n" );
-			qstrcatfmt( &shaderErr, "%s\n", infoLog );
-			qstrcatfmt( &shaderErr, "%s\n", debugLogs );
-			__RP_writeTextToFile( errFilePath.buf, shaderErr.buf );
-			assert( false && "failed to parse shader" );
-			qStrFree( &shaderErr );
-			qStrFree( &errFilePath );
+				qStrFree( &shaderErr );
+				qStrFree( &errFilePath );
 
-			error = true;
-			goto shader_done;
-		} else {
-			struct QStr shaderDebugPath = { 0 };
-			qstrcatfmt( &shaderDebugPath, "logs/shader_debug/%S_%u.%s.glsl", qToStrRef( fullName ), features, RP_GLSLStageToShaderPrefix( stages[i].stage ) );
-			__RP_writeTextToFile( shaderDebugPath.buf, glslang_shader_get_preprocessed_code( shader ) );
-			qStrFree( &shaderDebugPath );
-		}
+				error = true;
+				goto shader_done;
+			}
 
-		glslang_program = glslang_program_create();
-		glslang_program_add_shader( glslang_program, shader );
+			if( !glslang_shader_parse( shader, &input ) ) {
+				struct QStr errFilePath = { 0 };
+				qstrcatfmt( &errFilePath, "logs/shader_err/%s.%s.glsl", name, RP_GLSLStageToShaderPrefix( stages[i].stage ) );
+				const char *infoLog = glslang_shader_get_info_log( shader );
+				const char *debugLogs = glslang_shader_get_info_debug_log( shader );
 
-		if( !glslang_program_link( glslang_program, GLSLANG_MSG_SPV_RULES_BIT | GLSLANG_MSG_VULKAN_RULES_BIT ) ) {
-			struct QStr errFilePath = { 0 };
-			qstrcatfmt( &errFilePath, "logs/shader_err/%s.%s.glsl", name, RP_GLSLStageToShaderPrefix( stages[i].stage ) );
+				Com_Printf( S_COLOR_YELLOW "GLSL parsing failed %.*s\n", fullName.len, fullName.buf );
+				Com_Printf( S_COLOR_YELLOW "%s\n", infoLog );
+				Com_Printf( S_COLOR_YELLOW "%s\n", debugLogs );
+				Com_Printf( S_COLOR_YELLOW "dump shader: %.*s\n", errFilePath.len, errFilePath.buf );
 
-			const char *infoLogs = glslang_program_get_info_log( glslang_program );
-			const char *debugLogs = glslang_program_get_info_debug_log( glslang_program );
+				struct QStr shaderErr = { 0 };
+				qstrcatfmt( &shaderErr, "%s\n", input.code );
+				qstrcatfmt( &shaderErr, "----------- Parsing Failed -----------\n" );
+				qstrcatfmt( &shaderErr, "%s\n", infoLog );
+				qstrcatfmt( &shaderErr, "%s\n", debugLogs );
+				__RP_writeTextToFile( errFilePath.buf, shaderErr.buf );
+				assert( false && "failed to parse shader" );
+				qStrFree( &shaderErr );
+				qStrFree( &errFilePath );
 
-			Com_Printf( S_COLOR_YELLOW "GLSL linking failed %.*s\n", fullName.len, fullName.buf );
-			Com_Printf( S_COLOR_YELLOW "%s\n", infoLogs );
-			Com_Printf( S_COLOR_YELLOW "%s\n", debugLogs );
-			Com_Printf( S_COLOR_YELLOW "dump shader: %.*s\n", errFilePath.len, errFilePath.buf );
+				error = true;
+				goto shader_done;
+			} else if( r_shaderDebug->integer ) {
+				struct QStr shaderDebugPath = { 0 };
+				qstrcatfmt( &shaderDebugPath, "logs/shader_debug/%S_%u.%s.glsl", qToStrRef( fullName ), features, RP_GLSLStageToShaderPrefix( stages[i].stage ) );
+				__RP_writeTextToFile( shaderDebugPath.buf, glslang_shader_get_preprocessed_code( shader ) );
+				qStrFree( &shaderDebugPath );
+			}
 
-			struct QStr shaderErr = { 0 };
-			qstrcatfmt( &shaderErr, "%s\n", input.code );
-			qstrcatfmt( &shaderErr, "----------- Linking Failed -----------\n" );
-			qstrcatfmt( &shaderErr, "%s\n", infoLogs );
-			qstrcatfmt( &shaderErr, "%s\n", debugLogs );
-			__RP_writeTextToFile( errFilePath.buf, shaderErr.buf );
-			qStrFree( &shaderErr );
-			qStrFree( &errFilePath );
+			glslang_program = glslang_program_create();
+			glslang_program_add_shader( glslang_program, shader );
 
-			assert( false && "failed to link shader" );
-			error = true;
-			goto shader_done;
-		}
+			if( !glslang_program_link( glslang_program, GLSLANG_MSG_SPV_RULES_BIT | GLSLANG_MSG_VULKAN_RULES_BIT ) ) {
+				struct QStr errFilePath = { 0 };
+				qstrcatfmt( &errFilePath, "logs/shader_err/%s.%s.glsl", name, RP_GLSLStageToShaderPrefix( stages[i].stage ) );
 
-		const char *spirv_messages = glslang_program_SPIRV_get_messages( glslang_program );
-		if( spirv_messages ) {
-			Com_Printf( S_COLOR_BLUE "(%s) %s\b", name, spirv_messages );
-		}
+				const char *infoLogs = glslang_program_get_info_log( glslang_program );
+				const char *debugLogs = glslang_program_get_info_debug_log( glslang_program );
 
-		// TODO: spv needs to be optimized for release
-		glslang_spv_options_t spvOptions = { 0 };
-		spvOptions.disable_optimizer = false;
-		spvOptions.optimize_size = true;
-		spvOptions.validate = true;
-		glslang_program_SPIRV_generate_with_options( glslang_program, __RP_GLStageToSlang( stages[i].stage ), &spvOptions );
-		size_t binSize = glslang_program_SPIRV_get_size( glslang_program ) * sizeof( uint32_t );
-		struct shader_bin_data_s *binData = &program->shaderBin[stages[i].stage];
-		binData->bin = R_Malloc( binSize );
-		binData->size = binSize;
-		glslang_program_SPIRV_get( glslang_program, (uint32_t *)binData->bin );
-		binData->stage = stages[i].stage;
+				Com_Printf( S_COLOR_YELLOW "GLSL linking failed %.*s\n", fullName.len, fullName.buf );
+				Com_Printf( S_COLOR_YELLOW "%s\n", infoLogs );
+				Com_Printf( S_COLOR_YELLOW "%s\n", debugLogs );
+				Com_Printf( S_COLOR_YELLOW "dump shader: %.*s\n", errFilePath.len, errFilePath.buf );
+
+				struct QStr shaderErr = { 0 };
+				qstrcatfmt( &shaderErr, "%s\n", input.code );
+				qstrcatfmt( &shaderErr, "----------- Linking Failed -----------\n" );
+				qstrcatfmt( &shaderErr, "%s\n", infoLogs );
+				qstrcatfmt( &shaderErr, "%s\n", debugLogs );
+				__RP_writeTextToFile( errFilePath.buf, shaderErr.buf );
+				qStrFree( &shaderErr );
+				qStrFree( &errFilePath );
+
+				assert( false && "failed to link shader" );
+				error = true;
+				goto shader_done;
+			}
+
+			const char *spirv_messages = glslang_program_SPIRV_get_messages( glslang_program );
+			if( spirv_messages ) {
+				Com_Printf( S_COLOR_BLUE "(%s) %s\b", name, spirv_messages );
+			}
+
+			// The optimizer stays on by default: its cost is paid once per permutation per
+			// GLSL_BITS_VERSION bump, while its output is what the driver compiles and what the
+			// pipeline cache stores for every run after. Turning it off speeds up the first compile
+			// at the price of permanently caching bigger, slower-to-compile SPIR-V. Because it
+			// changes the generated SPIR-V, flipping r_shaderOptimize needs a GLSL_BITS_VERSION bump.
+			// The validator only inspects the output, so gating it costs nothing and needs no bump.
+			glslang_spv_options_t spvOptions = { 0 };
+			spvOptions.disable_optimizer = ( r_shaderOptimize->integer == 0 );
+			spvOptions.optimize_size = true;
+			spvOptions.validate = ( r_shaderValidate->integer != 0 );
+			glslang_program_SPIRV_generate_with_options( glslang_program, __RP_GLStageToSlang( stages[i].stage ), &spvOptions );
+			size_t binSize = glslang_program_SPIRV_get_size( glslang_program ) * sizeof( uint32_t );
+			struct shader_bin_data_s *binData = &program->shaderBin[stages[i].stage];
+			binData->bin = R_Malloc( binSize );
+			binData->size = binSize;
+			glslang_program_SPIRV_get( glslang_program, (uint32_t *)binData->bin );
+			binData->stage = stages[i].stage;
 
 	shader_done:
-		glslang_shader_delete( shader );
-		if( glslang_program ) {
-			glslang_program_delete( glslang_program );
+			glslang_shader_delete( shader );
+			if( glslang_program ) {
+				glslang_program_delete( glslang_program );
+			}
 		}
-	}
+		TracyCZoneEnd( compileCtx );
+	} // !cacheHit
+
+	// freed on both paths: the feature defines are only consumed by the source assembly above, but
+	// the loop that builds them runs before the cache lookup
+	qStrFree( &featuresStr );
+
+	// Reflection runs on both paths -- it derives vertexInputMask, push constants, descriptor set
+	// layouts and the pipeline layout from the SPIR-V, and costs ~1% of a glslang compile, so
+	// caching its output would be a wide fragile format for a negligible win. On the cache path it
+	// doubles as the integrity check on the loaded blob.
 	SpvReflectDescriptorSet **reflectionDescSets = NULL;
 
+	TracyCZoneN( reflectCtx, "RP_Reflect", 1 );
 #if ( DEVICE_IMPL_VULKAN )
 	{
 		SpvReflectBlockVariable *reflectionBlockVariables[1] = { 0 };
@@ -1584,7 +1698,14 @@ struct glsl_program_s *RP_RegisterProgram( int type, const char *name, const cha
 		for( size_t i = 0; i < Q_ARRAY_COUNT( stages ); i++ ) {
 			SpvReflectShaderModule module = { 0 };
 			SpvReflectResult result = spvReflectCreateShaderModule( program->shaderBin[stages[i].stage].size, program->shaderBin[stages[i].stage].bin, &module );
-			assert( result == SPV_REFLECT_RESULT_SUCCESS );
+			// A real branch, not an assert: this is a full SPIR-V parse, so it doubles as the
+			// integrity check on blobs loaded from the on-disk cache -- and asserts compile out in
+			// release, which is exactly where a corrupt cache would reach the driver.
+			if( result != SPV_REFLECT_RESULT_SUCCESS ) {
+				Com_Printf( S_COLOR_YELLOW "Failed to reflect SPIR-V for %s\n", name );
+				error = true;
+				break;
+			}
 			{
 				uint32_t pushConstantCount = 0;
 				result = spvReflectEnumeratePushConstantBlocks( &module, &pushConstantCount, NULL );
@@ -1761,10 +1882,14 @@ struct glsl_program_s *RP_RegisterProgram( int type, const char *name, const cha
 		VK_WrapResult( vkCreatePipelineLayout( rsh.device.vk.device, &pipelineLayoutCreateInfo, NULL, &program->vk.pipelineLayout ) );
 	}
 #endif
+	TracyCZoneEnd( reflectCtx );
 	arrfree( reflectionDescSets );
 
 	program->type = type;
 	program->features = features;
+	// a program whose stages failed to compile is still registered (with no shaderBin), so record
+	// that here and never let it reach the cache
+	program->valid = !error;
 	qStrSetNullTerm( &fullName );
 	program->name = R_CopyString( fullName.buf );
 	program->deformsKey = R_CopyString( deformsKey ? deformsKey : "" );
@@ -1822,9 +1947,15 @@ void RP_Shutdown( void )
 	struct glsl_program_s *program;
 	TracyCZoneN( ctx, "RP_Shutdown", 1 );
 
+	// must run before the delete loop below frees shaderBin and zeroes r_numglslprograms
+	RP_StorePrecacheList();
+	RP_StorePipelineCache();
+
 	for( i = 0, program = r_glslprograms; i < r_numglslprograms; i++, program++ ) {
 		RF_DeleteProgram( program );
 	}
+	RP_ShutdownPipelineCache();
+	RP_SpirvCacheClose();
 
 	Trie_Destroy( glsl_cache_trie );
 	glsl_cache_trie = NULL;

--- a/source/ref_nri/r_program.h
+++ b/source/ref_nri/r_program.h
@@ -33,6 +33,14 @@ typedef uint64_t r_glslfeat_t;
 #include "qhash.h"
 
 #define GLSL_BIT(x)							(1ULL << (x))
+
+// Bump on ANY change that alters generated SPIR-V: glsl_nri/*.glsl or their #includes, the
+// glsl_features_* tables, __appendGLSLDeformv, the QF_BUILTIN_GLSL_* headers, the glslang_input_t
+// settings, r_shaderOptimize's default, or the glslang dependency version. Forgetting to bump serves
+// stale SPIR-V out of cache/nri_glsl.cache.bin, and you will debug a shader change that never took
+// effect -- it survives a rebuild because the cache lives under ~/.cache. Invalidation is MANUAL by
+// design (no source hashing); "r_shaderCache 0" is the escape hatch while iterating.
+// See RP_PrecachePrograms.
 #define GLSL_BITS_VERSION					16
 
 #define PIPELINE_LAYOUT_HASH_SIZE 4096// need to handle this large number of pipelines 
@@ -241,9 +249,16 @@ struct glsl_program_s {
 		} vk;
 	};
 
+	// name is the mangled name: base name plus every feature suffix, for logging and debug labels.
+	// baseName is the unsuffixed name the caller passed, which is also the glsl_nri/<baseName>.*.glsl
+	// source path -- that is the one the cache has to round-trip.
 	char *name;
+	char *baseName;
 	int type;
 	bool hasPushConstant;
+	// false if compilation failed; such a program is still registered but has no shaderBin, so it
+	// must never be written to the cache.
+	bool valid;
 	r_glslfeat_t features;
 	char *deformsKey;
 	struct glsl_program_s *hash_next;

--- a/source/ref_nri/r_program_cache.c
+++ b/source/ref_nri/r_program_cache.c
@@ -1,0 +1,622 @@
+/*
+Copyright (C) 2024 Warfork
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#include "r_local.h"
+#include "r_program_cache.h"
+#include "stb_ds.h"
+
+#define GLSL_CACHE_FILE_NAME "cache/nri_glsl.cache"
+#define GLSL_BINARY_CACHE_FILE_NAME "cache/nri_glsl.cache.bin"
+
+#define SPIRV_CACHE_MAGIC ( ( 'N' ) | ( 'S' << 8 ) | ( 'P' << 16 ) | ( 'V' << 24 ) )
+#define SPIRV_RECORD_MAGIC ( ( 'S' ) | ( 'R' << 8 ) | ( 'E' << 16 ) | ( 'C' << 24 ) )
+#define SPIRV_CACHE_HEADER_SIZE 12
+#define SPIRV_WORD_MAGIC 0x07230203u // SpvMagicNumber -- a free, strong shape check
+#define SPIRV_MIN_BYTES 20
+
+#define MAX_CACHE_BASENAME 256
+#define MAX_CACHE_DEFORMSKEY 1024
+
+#define PIPELINE_CACHE_FILE_NAME "cache/nri_pipeline.cache"
+
+#define PIPELINE_CACHE_MAGIC ( ( 'W' ) | ( 'F' << 8 ) | ( 'P' << 16 ) | ( 'C' << 24 ) )
+#define PIPELINE_CACHE_FORMAT_VERSION 1u
+
+// A blob larger than this is treated as corrupt rather than loaded. Nothing evicts, so this also
+// bounds unbounded growth across driver updates and shader edits: trip the cap and we discard and
+// start fresh, which costs exactly one cold session.
+#define PIPELINE_CACHE_MAX_BYTES ( 128u * 1024u * 1024u )
+
+// ---------------------------------------------------------------------------
+// SPIR-V blob cache + precache index
+// ---------------------------------------------------------------------------
+
+struct spirv_cache_entry_s {
+	int type;
+	r_glslfeat_t features;
+	int binaryPos; // byte offset into the blob; 0 means "no binary"
+	char baseName[MAX_CACHE_BASENAME];
+	char deformsKey[MAX_CACHE_DEFORMSKEY];
+};
+
+static struct spirv_cache_entry_s *r_spirvCacheIndex = NULL; // stb_ds array
+static int r_spirvBlobHandle = 0;
+static int r_spirvBlobSize = 0;
+
+// store-side state
+static int r_storeIndexHandle = 0;
+static int r_storeBlobHandle = 0;
+static bool r_storeActive = false;
+
+size_t RP_SpirvCacheEntryCount( void )
+{
+	return (size_t)arrlen( r_spirvCacheIndex );
+}
+
+bool RP_SpirvCacheEntryAt( size_t i, int *outType, r_glslfeat_t *outFeatures, const char **outBaseName, const char **outDeformsKey )
+{
+	if( i >= (size_t)arrlen( r_spirvCacheIndex ) ) {
+		return false;
+	}
+	const struct spirv_cache_entry_s *e = &r_spirvCacheIndex[i];
+	*outType = e->type;
+	*outFeatures = e->features;
+	*outBaseName = e->baseName;
+	*outDeformsKey = e->deformsKey;
+	return true;
+}
+
+static void __RP_CloseSpirvBlob( void )
+{
+	if( r_spirvBlobHandle ) {
+		FS_FCloseFile( r_spirvBlobHandle );
+		r_spirvBlobHandle = 0;
+	}
+	r_spirvBlobSize = 0;
+}
+
+// Opens and header-checks the blob. The handle stays open for the session so a mid-frame miss is a
+// seek+read rather than a reparse.
+static void __RP_OpenSpirvBlob( void )
+{
+	uint32_t magic = 0;
+	uint32_t version = 0;
+
+	if( FS_FOpenFile( GLSL_BINARY_CACHE_FILE_NAME, &r_spirvBlobHandle, FS_READ | FS_CACHE ) == -1 ) {
+		r_spirvBlobHandle = 0;
+		return;
+	}
+	FS_Seek( r_spirvBlobHandle, 0, FS_SEEK_END );
+	r_spirvBlobSize = FS_Tell( r_spirvBlobHandle );
+	FS_Seek( r_spirvBlobHandle, 0, FS_SEEK_SET );
+
+	if( r_spirvBlobSize < SPIRV_CACHE_HEADER_SIZE ) {
+		ri.Com_DPrintf( "spirv cache: blob too small\n" );
+		__RP_CloseSpirvBlob();
+		return;
+	}
+	if( FS_Read( &magic, sizeof( magic ), r_spirvBlobHandle ) != sizeof( magic ) || magic != SPIRV_CACHE_MAGIC ) {
+		ri.Com_DPrintf( "spirv cache: blob bad magic\n" );
+		__RP_CloseSpirvBlob();
+		return;
+	}
+	// version 0 means a previous run died between writing the blob and committing it
+	if( FS_Read( &version, sizeof( version ), r_spirvBlobHandle ) != sizeof( version ) || version != GLSL_BITS_VERSION ) {
+		ri.Com_DPrintf( "spirv cache: blob version %u, expected %u (or an interrupted write)\n", version, (unsigned)GLSL_BITS_VERSION );
+		__RP_CloseSpirvBlob();
+		return;
+	}
+}
+
+void RP_SpirvCacheOpen( void )
+{
+	char *buffer = NULL;
+	char *data;
+	char **ptr;
+	const char *token;
+	char tempbuf[MAX_TOKEN_CHARS];
+
+	if( !r_shaderCache->integer ) {
+		return;
+	}
+
+	if( R_LoadCacheFile( GLSL_CACHE_FILE_NAME, (void **)&buffer ) == -1 || !buffer ) {
+		return;
+	}
+
+	data = buffer;
+	ptr = &data;
+
+	token = COM_Parse_r( tempbuf, sizeof( tempbuf ), ptr );
+	if( strcmp( token, rf.applicationName ) ) {
+		ri.Com_DPrintf( "Ignoring %s: unknown application name \"%s\", expected \"%s\"\n", GLSL_CACHE_FILE_NAME, token, rf.applicationName );
+		goto done;
+	}
+
+	token = COM_Parse_r( tempbuf, sizeof( tempbuf ), ptr );
+	if( atoi( token ) != GLSL_BITS_VERSION ) {
+		ri.Com_DPrintf( "Ignoring %s: found version %i, expected %i\n", GLSL_CACHE_FILE_NAME, atoi( token ), GLSL_BITS_VERSION );
+		goto done;
+	}
+
+	__RP_OpenSpirvBlob();
+
+	while( 1 ) {
+		struct spirv_cache_entry_s entry = { 0 };
+
+		token = COM_ParseExt_r( tempbuf, sizeof( tempbuf ), ptr, true );
+		if( !token[0] ) {
+			break;
+		}
+		// validate before it can ever index glsl_programtypes_features[type]
+		entry.type = atoi( token );
+		if( entry.type <= GLSL_PROGRAM_TYPE_NONE || entry.type >= GLSL_PROGRAM_TYPE_MAXTYPE ) {
+			ri.Com_DPrintf( "spirv cache: bad program type %i, dropping the rest\n", entry.type );
+			break;
+		}
+
+		// one unsigned hex token: a signed round-trip would corrupt bit 31/63, and ref_nri feature
+		// bits already reach past 32
+		token = COM_ParseExt_r( tempbuf, sizeof( tempbuf ), ptr, false );
+		if( !token[0] ) {
+			break;
+		}
+		entry.features = (r_glslfeat_t)strtoull( token, NULL, 16 );
+
+		token = COM_ParseExt_r( tempbuf, sizeof( tempbuf ), ptr, false );
+		if( !token[0] ) {
+			break;
+		}
+		Q_strncpyz( entry.baseName, token, sizeof( entry.baseName ) );
+
+		token = COM_ParseExt_r( tempbuf, sizeof( tempbuf ), ptr, false );
+		Q_strncpyz( entry.deformsKey, token, sizeof( entry.deformsKey ) );
+
+		token = COM_ParseExt_r( tempbuf, sizeof( tempbuf ), ptr, false );
+		entry.binaryPos = atoi( token );
+
+		if( !entry.baseName[0] ) {
+			continue;
+		}
+		arrput( r_spirvCacheIndex, entry );
+	}
+
+	ri.Com_DPrintf( "spirv cache: %i entries indexed\n", (int)arrlen( r_spirvCacheIndex ) );
+
+done:
+	// single exit that always frees -- the equivalent ref_gl paths leak the buffer
+	R_FreeFile( buffer );
+}
+
+void RP_SpirvCacheClose( void )
+{
+	__RP_CloseSpirvBlob();
+	arrfree( r_spirvCacheIndex );
+	r_spirvCacheIndex = NULL;
+}
+
+static const struct spirv_cache_entry_s *__RP_FindEntry( int type, r_glslfeat_t features, const char *deformsKey )
+{
+	// Linear, but only walked once per *new permutation* -- never per frame; r_glslprograms_hash
+	// already absorbs the hot path.
+	for( size_t i = 0; i < (size_t)arrlen( r_spirvCacheIndex ); i++ ) {
+		const struct spirv_cache_entry_s *e = &r_spirvCacheIndex[i];
+		if( e->type == type && e->features == features && !strcmp( e->deformsKey, deformsKey ) ) {
+			return e;
+		}
+	}
+	return NULL;
+}
+
+// Reads one 'SREC' record into program->shaderBin[]. Validates everything before the bytes could
+// reach vkCreateShaderModule; on any failure frees whatever it read and returns false.
+static bool __RP_ReadBlobRecord( struct glsl_program_s *program, int binaryPos )
+{
+	uint32_t recordMagic = 0;
+	uint32_t numStages = 0;
+	struct shader_bin_data_s loaded[GLSL_STAGE_MAX] = { 0 };
+	size_t numLoaded = 0;
+
+	if( binaryPos < SPIRV_CACHE_HEADER_SIZE || binaryPos >= r_spirvBlobSize ) {
+		return false;
+	}
+	if( FS_Seek( r_spirvBlobHandle, binaryPos, FS_SEEK_SET ) < 0 ) {
+		return false;
+	}
+	// a per-record magic is what keeps a stale offset from being read as a length
+	if( FS_Read( &recordMagic, sizeof( recordMagic ), r_spirvBlobHandle ) != sizeof( recordMagic ) || recordMagic != SPIRV_RECORD_MAGIC ) {
+		return false;
+	}
+	if( FS_Read( &numStages, sizeof( numStages ), r_spirvBlobHandle ) != sizeof( numStages ) || numStages == 0 || numStages > GLSL_STAGE_MAX ) {
+		return false;
+	}
+
+	for( uint32_t i = 0; i < numStages; i++ ) {
+		uint32_t stage = 0;
+		uint32_t length = 0;
+		uint32_t firstWord = 0;
+
+		if( FS_Read( &stage, sizeof( stage ), r_spirvBlobHandle ) != sizeof( stage ) || stage >= GLSL_STAGE_MAX ) {
+			goto fail;
+		}
+		if( FS_Read( &length, sizeof( length ), r_spirvBlobHandle ) != sizeof( length ) ) {
+			goto fail;
+		}
+		if( length < SPIRV_MIN_BYTES || ( length % 4 ) != 0 || (int)length >= r_spirvBlobSize ) {
+			goto fail;
+		}
+
+		uint8_t *bin = R_Malloc( length ); // allocator alignment, not a file offset
+		if( FS_Read( bin, length, r_spirvBlobHandle ) != (int)length ) {
+			R_Free( bin );
+			goto fail;
+		}
+		memcpy( &firstWord, bin, sizeof( firstWord ) );
+		if( firstWord != SPIRV_WORD_MAGIC ) {
+			R_Free( bin );
+			goto fail;
+		}
+
+		loaded[numLoaded].bin = (char *)bin;
+		loaded[numLoaded].size = length;
+		loaded[numLoaded].stage = (glsl_program_stage_t)stage;
+		numLoaded++;
+	}
+
+	for( size_t i = 0; i < numLoaded; i++ ) {
+		program->shaderBin[loaded[i].stage] = loaded[i];
+	}
+	return true;
+
+fail:
+	for( size_t i = 0; i < numLoaded; i++ ) {
+		R_Free( loaded[i].bin );
+	}
+	return false;
+}
+
+bool RP_SpirvCacheLookup( struct glsl_program_s *program, int type, r_glslfeat_t features, const char *deformsKey )
+{
+	if( !r_shaderCache->integer || !r_spirvBlobHandle ) {
+		return false;
+	}
+	const struct spirv_cache_entry_s *entry = __RP_FindEntry( type, features, deformsKey ? deformsKey : "" );
+	if( !entry || !entry->binaryPos ) {
+		return false;
+	}
+	if( !__RP_ReadBlobRecord( program, entry->binaryPos ) ) {
+		// self-heal: a corrupt record means the blob is untrustworthy, so stop using it and let the
+		// store at shutdown rewrite the whole thing from scratch
+		Com_Printf( S_COLOR_YELLOW "Dropping corrupt SPIR-V cache.\n" );
+		__RP_CloseSpirvBlob();
+		return false;
+	}
+	return true;
+}
+
+bool RP_SpirvCacheStoreBegin( void )
+{
+	const uint32_t magic = SPIRV_CACHE_MAGIC;
+	const uint32_t version = 0; // committed in RP_SpirvCacheStoreEnd
+	const uint32_t reserved = 0;
+
+	r_storeActive = false;
+	if( !r_shaderCache->integer ) {
+		return false;
+	}
+
+	// read-only install, full disk, ... -- degrade to "no cache", never assert
+	if( FS_FOpenFile( GLSL_CACHE_FILE_NAME, &r_storeIndexHandle, FS_WRITE | FS_CACHE ) == -1 ) {
+		Com_Printf( S_COLOR_YELLOW "Could not open %s for writing.\n", GLSL_CACHE_FILE_NAME );
+		r_storeIndexHandle = 0;
+		return false;
+	}
+	if( FS_FOpenFile( GLSL_BINARY_CACHE_FILE_NAME, &r_storeBlobHandle, FS_WRITE | FS_CACHE ) == -1 ) {
+		Com_Printf( S_COLOR_YELLOW "Could not open %s for writing.\n", GLSL_BINARY_CACHE_FILE_NAME );
+		FS_FCloseFile( r_storeIndexHandle );
+		r_storeIndexHandle = 0;
+		r_storeBlobHandle = 0;
+		return false;
+	}
+
+	FS_Write( &magic, sizeof( magic ), r_storeBlobHandle );
+	FS_Write( &version, sizeof( version ), r_storeBlobHandle );
+	FS_Write( &reserved, sizeof( reserved ), r_storeBlobHandle );
+
+	FS_Printf( r_storeIndexHandle, "%s\n", rf.applicationName );
+	FS_Printf( r_storeIndexHandle, "%i\n", GLSL_BITS_VERSION );
+	r_storeActive = true;
+	return true;
+}
+
+void RP_SpirvCacheStoreProgram( const struct glsl_program_s *program )
+{
+	uint32_t numStages = 0;
+
+	if( !r_storeActive ) {
+		return;
+	}
+	// never cache a program whose stages failed to compile
+	if( !program->valid || !program->baseName ) {
+		return;
+	}
+	for( size_t i = 0; i < GLSL_STAGE_MAX; i++ ) {
+		if( program->shaderBin[i].bin && program->shaderBin[i].size > 0 ) {
+			numStages++;
+		}
+	}
+	if( numStages == 0 ) {
+		return;
+	}
+
+	const int binaryPos = FS_Tell( r_storeBlobHandle );
+	const uint32_t recordMagic = SPIRV_RECORD_MAGIC;
+	FS_Write( &recordMagic, sizeof( recordMagic ), r_storeBlobHandle );
+	FS_Write( &numStages, sizeof( numStages ), r_storeBlobHandle );
+	for( size_t i = 0; i < GLSL_STAGE_MAX; i++ ) {
+		const struct shader_bin_data_s *bin = &program->shaderBin[i];
+		if( !bin->bin || bin->size == 0 ) {
+			continue;
+		}
+		const uint32_t stage = (uint32_t)i;
+		const uint32_t length = (uint32_t)bin->size;
+		FS_Write( &stage, sizeof( stage ), r_storeBlobHandle );
+		FS_Write( &length, sizeof( length ), r_storeBlobHandle );
+		FS_Write( bin->bin, length, r_storeBlobHandle );
+	}
+
+	FS_Printf( r_storeIndexHandle, "%i %016llx \"%s\" \"%s\" %i\n", program->type, (unsigned long long)program->features, program->baseName, program->deformsKey ? program->deformsKey : "", binaryPos );
+}
+
+void RP_SpirvCacheStoreEnd( void )
+{
+	if( !r_storeActive ) {
+		return;
+	}
+	FS_FCloseFile( r_storeIndexHandle );
+	FS_FCloseFile( r_storeBlobHandle );
+	r_storeIndexHandle = 0;
+	r_storeBlobHandle = 0;
+	r_storeActive = false;
+
+	// commit: stamp the real version only once the blob is safely on disk, so a crash mid-write
+	// leaves version 0 and the loader rejects it
+	int handle = 0;
+	if( FS_FOpenFile( GLSL_BINARY_CACHE_FILE_NAME, &handle, FS_UPDATE | FS_CACHE ) != -1 ) {
+		const uint32_t version = GLSL_BITS_VERSION;
+		FS_Seek( handle, sizeof( uint32_t ), FS_SEEK_SET ); // past the magic
+		FS_Write( &version, sizeof( version ), handle );
+		FS_FCloseFile( handle );
+	} else {
+		Com_Printf( S_COLOR_YELLOW "Could not commit %s.\n", GLSL_BINARY_CACHE_FILE_NAME );
+	}
+}
+
+#if ( DEVICE_IMPL_VULKAN )
+
+// Our own header in front of the driver's blob. The driver validates its own embedded
+// VkPipelineCacheHeaderVersionOne, but that header carries no length and no checksum -- a blob
+// truncated by a crash or a full disk still has a byte-perfect 32-byte driver header, and truncation
+// is the realistic corruption source. dataSize + dataHash are the fields that actually earn their
+// keep; the vendor triple only catches a cache dir copied between machines.
+//
+// Field order keeps every member naturally aligned, so there is no implicit padding to hash over.
+struct r_pipeline_cache_header_s {
+	uint32_t magic;
+	uint32_t formatVersion; // 0 while writing, PIPELINE_CACHE_FORMAT_VERSION once committed
+	uint32_t vendorID;
+	uint32_t deviceID;
+	uint32_t driverVersion;
+	uint32_t dataSize;
+	uint64_t dataHash;
+	uint8_t pipelineCacheUUID[VK_UUID_SIZE];
+};
+
+Q_COMPILE_ASSERT_MSG( sizeof( struct r_pipeline_cache_header_s ) == 48, "r_pipeline_cache_header_s has unexpected padding" );
+
+static VkPipelineCache r_vkPipelineCache = VK_NULL_HANDLE;
+
+VkPipelineCache RP_PipelineCache( void )
+{
+	return r_vkPipelineCache;
+}
+
+static void __RP_QueryDeviceProps( VkPhysicalDeviceProperties *props )
+{
+	memset( props, 0, sizeof( *props ) );
+	vkGetPhysicalDeviceProperties( rsh.device.physicalAdapter.vk.physicalDevice, props );
+}
+
+// Returns true when payload is safe to hand to vkCreatePipelineCache as pInitialData.
+static bool __RP_ValidatePipelineCacheBlob( const uint8_t *buf, size_t fileLen, const VkPhysicalDeviceProperties *props, const uint8_t **outPayload, uint32_t *outSize )
+{
+	struct r_pipeline_cache_header_s header;
+
+	// checks are ordered cheapest-and-most-likely-to-fail first
+	if( fileLen < sizeof( header ) ) {
+		ri.Com_DPrintf( "pipeline cache: too small (%u bytes)\n", (unsigned)fileLen );
+		return false;
+	}
+	memcpy( &header, buf, sizeof( header ) );
+
+	if( header.magic != PIPELINE_CACHE_MAGIC ) {
+		ri.Com_DPrintf( "pipeline cache: bad magic\n" );
+		return false;
+	}
+	// formatVersion 0 means a previous run was killed between writing the payload and committing
+	if( header.formatVersion != PIPELINE_CACHE_FORMAT_VERSION ) {
+		ri.Com_DPrintf( "pipeline cache: version %u, expected %u (or an interrupted write)\n", header.formatVersion, PIPELINE_CACHE_FORMAT_VERSION );
+		return false;
+	}
+	if( header.dataSize == 0 || header.dataSize > PIPELINE_CACHE_MAX_BYTES || header.dataSize != fileLen - sizeof( header ) ) {
+		ri.Com_DPrintf( "pipeline cache: truncated (dataSize %u, have %u)\n", header.dataSize, (unsigned)( fileLen - sizeof( header ) ) );
+		return false;
+	}
+	if( header.vendorID != props->vendorID || header.deviceID != props->deviceID || header.driverVersion != props->driverVersion ) {
+		ri.Com_DPrintf( "pipeline cache: built for a different device/driver\n" );
+		return false;
+	}
+	if( memcmp( header.pipelineCacheUUID, props->pipelineCacheUUID, VK_UUID_SIZE ) != 0 ) {
+		ri.Com_DPrintf( "pipeline cache: pipelineCacheUUID changed, driver invalidated it\n" );
+		return false;
+	}
+
+	const uint8_t *payload = buf + sizeof( header );
+	if( hash_data_hsieh( HASH_INITIAL_VALUE, payload, header.dataSize ) != header.dataHash ) {
+		ri.Com_DPrintf( "pipeline cache: checksum mismatch\n" );
+		return false;
+	}
+
+	// last line of defense: sanity-check the driver's own header before it ever sees the bytes
+	{
+		uint32_t embHeaderSize = 0;
+		uint32_t embHeaderVersion = 0;
+		if( header.dataSize < 8 ) {
+			return false;
+		}
+		memcpy( &embHeaderSize, payload, sizeof( embHeaderSize ) );
+		memcpy( &embHeaderVersion, payload + 4, sizeof( embHeaderVersion ) );
+		if( embHeaderVersion != VK_PIPELINE_CACHE_HEADER_VERSION_ONE || embHeaderSize < 8 || embHeaderSize > header.dataSize ) {
+			ri.Com_DPrintf( "pipeline cache: bad driver header\n" );
+			return false;
+		}
+	}
+
+	*outPayload = payload;
+	*outSize = header.dataSize;
+	return true;
+}
+
+void RP_InitPipelineCache( void )
+{
+	uint8_t *buf = NULL;
+	const uint8_t *payload = NULL;
+	uint32_t payloadSize = 0;
+	VkPhysicalDeviceProperties props;
+
+	r_vkPipelineCache = VK_NULL_HANDLE;
+	if( !r_shaderCache->integer ) {
+		return;
+	}
+
+	__RP_QueryDeviceProps( &props );
+
+	const int fileLen = R_LoadCacheFile( PIPELINE_CACHE_FILE_NAME, (void **)&buf );
+	if( buf && fileLen > 0 ) {
+		if( !__RP_ValidatePipelineCacheBlob( buf, (size_t)fileLen, &props, &payload, &payloadSize ) ) {
+			payload = NULL;
+			payloadSize = 0;
+		}
+	}
+
+	VkPipelineCacheCreateInfo createInfo = { VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO };
+	createInfo.initialDataSize = payloadSize;
+	createInfo.pInitialData = payload;
+	// deliberately not VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT: the driver's internal
+	// locking is what keeps this safe if a pipeline is ever created off the render thread.
+	if( vkCreatePipelineCache( rsh.device.vk.device, &createInfo, NULL, &r_vkPipelineCache ) != VK_SUCCESS ) {
+		// not fatal -- VK_NULL_HANDLE is exactly what vkCreateGraphicsPipelines got before this existed
+		Com_Printf( S_COLOR_YELLOW "Could not create pipeline cache, pipelines will compile cold.\n" );
+		r_vkPipelineCache = VK_NULL_HANDLE;
+	} else if( payloadSize > 0 ) {
+		ri.Com_DPrintf( "pipeline cache: loaded %u bytes\n", payloadSize );
+	}
+
+	if( buf ) {
+		R_FreeFile( buf );
+	}
+}
+
+void RP_StorePipelineCache( void )
+{
+	size_t dataSize = 0;
+	int handle = 0;
+
+	if( !r_shaderCache->integer || r_vkPipelineCache == VK_NULL_HANDLE ) {
+		return;
+	}
+
+	if( vkGetPipelineCacheData( rsh.device.vk.device, r_vkPipelineCache, &dataSize, NULL ) != VK_SUCCESS || dataSize == 0 ) {
+		return;
+	}
+	if( dataSize > PIPELINE_CACHE_MAX_BYTES ) {
+		Com_Printf( S_COLOR_YELLOW "Pipeline cache is %u bytes, over the %u cap; not storing.\n", (unsigned)dataSize, (unsigned)PIPELINE_CACHE_MAX_BYTES );
+		return;
+	}
+
+	uint8_t *data = R_Malloc( dataSize );
+	// a short read would mean writing a blob whose dataSize lies; drop it instead
+	if( vkGetPipelineCacheData( rsh.device.vk.device, r_vkPipelineCache, &dataSize, data ) != VK_SUCCESS ) {
+		R_Free( data );
+		return;
+	}
+
+	struct r_pipeline_cache_header_s header = { 0 };
+	VkPhysicalDeviceProperties props;
+	__RP_QueryDeviceProps( &props );
+
+	header.magic = PIPELINE_CACHE_MAGIC;
+	header.formatVersion = 0; // committed at the end, so an interrupted write stays rejectable
+	header.vendorID = props.vendorID;
+	header.deviceID = props.deviceID;
+	header.driverVersion = props.driverVersion;
+	header.dataSize = (uint32_t)dataSize;
+	header.dataHash = hash_data_hsieh( HASH_INITIAL_VALUE, data, dataSize );
+	memcpy( header.pipelineCacheUUID, props.pipelineCacheUUID, VK_UUID_SIZE );
+
+	if( FS_FOpenFile( PIPELINE_CACHE_FILE_NAME, &handle, FS_WRITE | FS_CACHE ) == -1 ) {
+		// read-only install dir, full disk, ... -- degrade to "no cache", never assert
+		Com_Printf( S_COLOR_YELLOW "Could not open %s for writing.\n", PIPELINE_CACHE_FILE_NAME );
+		R_Free( data );
+		return;
+	}
+	FS_Write( &header, sizeof( header ), handle );
+	FS_Write( data, dataSize, handle );
+	FS_FCloseFile( handle );
+	R_Free( data );
+
+	// commit: stamp the real version only once the payload is safely on disk
+	handle = 0;
+	if( FS_FOpenFile( PIPELINE_CACHE_FILE_NAME, &handle, FS_UPDATE | FS_CACHE ) != -1 ) {
+		const uint32_t version = PIPELINE_CACHE_FORMAT_VERSION;
+		FS_Seek( handle, offsetof( struct r_pipeline_cache_header_s, formatVersion ), FS_SEEK_SET );
+		FS_Write( &version, sizeof( version ), handle );
+		FS_FCloseFile( handle );
+		ri.Com_DPrintf( "pipeline cache: stored %u bytes\n", (unsigned)dataSize );
+	} else {
+		Com_Printf( S_COLOR_YELLOW "Could not commit %s.\n", PIPELINE_CACHE_FILE_NAME );
+	}
+}
+
+void RP_ShutdownPipelineCache( void )
+{
+	if( r_vkPipelineCache != VK_NULL_HANDLE ) {
+		vkDestroyPipelineCache( rsh.device.vk.device, r_vkPipelineCache, NULL );
+		r_vkPipelineCache = VK_NULL_HANDLE;
+	}
+}
+
+#else
+
+void RP_InitPipelineCache( void ) {}
+void RP_StorePipelineCache( void ) {}
+void RP_ShutdownPipelineCache( void ) {}
+
+#endif // DEVICE_IMPL_VULKAN

--- a/source/ref_nri/r_program_cache.h
+++ b/source/ref_nri/r_program_cache.h
@@ -1,0 +1,67 @@
+/*
+Copyright (C) 2024 Warfork
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+#ifndef R_PROGRAM_CACHE_H
+#define R_PROGRAM_CACHE_H
+
+#include "r_program.h"
+
+// On-disk caches that let a warm start skip work the first run had to do:
+//
+//   cache/nri_pipeline.cache  - VkPipelineCache blob. Device-specific: only valid for the exact
+//                               vendor/device/driver/pipelineCacheUUID that produced it.
+//   cache/nri_glsl.cache      - text index: which (type, features, baseName, deformsKey)
+//                               permutations to warm, and where each one's SPIR-V lives.
+//   cache/nri_glsl.cache.bin  - the SPIR-V blobs themselves. Device-INDEPENDENT, unlike GL program
+//                               binaries, so it is keyed on GLSL_BITS_VERSION alone and survives
+//                               driver updates and GPU swaps. Kept separate from the pipeline cache
+//                               for exactly that reason.
+//
+// All of it is best-effort. Any failure degrades to "no cache" -- it must never fail init, and it
+// must never hand the driver bytes it has not validated.
+
+void RP_InitPipelineCache( void );
+void RP_StorePipelineCache( void );
+void RP_ShutdownPipelineCache( void );
+
+// SPIR-V blob cache. Read side.
+void RP_SpirvCacheOpen( void );	 // load the index + open the blob; safe to call when disabled
+void RP_SpirvCacheClose( void ); // release the index and the blob handle
+
+// Fills program->shaderBin[] from the cache. Returns false on a miss or on any validation failure,
+// in which case nothing is written to the program and the caller must compile.
+bool RP_SpirvCacheLookup( struct glsl_program_s *program, int type, r_glslfeat_t features, const char *deformsKey );
+
+// The precache index doubles as the SPIR-V blob directory, so both are rewritten together from the
+// live program table. Call Begin, then Program for each program worth storing, then End to commit.
+bool RP_SpirvCacheStoreBegin( void );
+void RP_SpirvCacheStoreProgram( const struct glsl_program_s *program );
+void RP_SpirvCacheStoreEnd( void );
+
+// Number of entries the index held at load, for the precache replay to iterate.
+size_t RP_SpirvCacheEntryCount( void );
+bool RP_SpirvCacheEntryAt( size_t i, int *outType, r_glslfeat_t *outFeatures, const char **outBaseName, const char **outDeformsKey );
+
+#if ( DEVICE_IMPL_VULKAN )
+// VK_NULL_HANDLE is a legal argument to vkCreateGraphicsPipelines and is what this returns when the
+// cache is disabled or could not be created.
+VkPipelineCache RP_PipelineCache( void );
+#endif
+
+#endif // R_PROGRAM_CACHE_H

--- a/source/ref_nri/r_register.c
+++ b/source/ref_nri/r_register.c
@@ -61,6 +61,11 @@ cvar_t *r_showtris;
 cvar_t *r_draworder;
 cvar_t *r_leafvis;
 
+cvar_t *r_shaderCache;
+cvar_t *r_shaderDebug;
+cvar_t *r_shaderValidate;
+cvar_t *r_shaderOptimize;
+
 cvar_t *r_fastsky;
 cvar_t *r_portalonly;
 cvar_t *r_portalmaps;
@@ -158,6 +163,19 @@ static void R_Register( const char *screenshotsPrefix )
 	r_picmip = Cvar_Get( "r_picmip", "0", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 	r_skymip = Cvar_Get( "r_skymip", "0", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 	r_polyblend = Cvar_Get( "r_polyblend", "1", 0 );
+
+	// Set r_shaderCache to 0 when iterating on glsl_nri/*.glsl without bumping GLSL_BITS_VERSION,
+	// otherwise the on-disk SPIR-V cache keeps serving the shader you just edited away.
+	r_shaderCache = Cvar_Get( "r_shaderCache", "1", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
+	r_shaderDebug = Cvar_Get( "r_shaderDebug", "0", 0 );
+#ifdef NDEBUG
+	r_shaderValidate = Cvar_Get( "r_shaderValidate", "0", 0 );
+#else
+	r_shaderValidate = Cvar_Get( "r_shaderValidate", "1", 0 );
+#endif
+	// Changing this changes the generated SPIR-V, so it needs a GLSL_BITS_VERSION bump to take
+	// effect on an already-populated cache.
+	r_shaderOptimize = Cvar_Get( "r_shaderOptimize", "1", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 
 	r_mapoverbrightbits = Cvar_Get( "r_mapoverbrightbits", "2", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 	r_brightness = Cvar_Get( "r_brightness", "0", CVAR_ARCHIVE );


### PR DESCRIPTION
This pull request introduces a comprehensive overhaul of the shader program caching and initialization system in the Vulkan renderer backend. The main goals are to improve shader loading performance, ensure cache integrity, and provide more robust and configurable shader compilation. The changes include a new mechanism for precaching and storing shader programs, enhancements to pipeline cache handling, new developer-facing controls via cvars, and improved error handling and diagnostics.

**Shader program and pipeline cache improvements:**

* Implemented `RP_PrecachePrograms` and `RP_StorePrecacheList` to load and store all known shader program permutations at startup and shutdown, reducing runtime compilation hitches and ensuring the most valuable cache hits are available immediately. The new system also records deform permutations and base programs for more complete cache coverage. [[1]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cL201-R287) [[2]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cR1950-R1958)
* Added explicit pipeline cache management (`RP_InitPipelineCache`, `RP_StorePipelineCache`, etc.) and ensured Vulkan pipelines are created with the pipeline cache, further reducing pipeline creation overhead. [[1]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cR97-R102) [[2]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cL1150-R1216)

**Shader compilation and validation enhancements:**

* Introduced new cvars: `r_shaderCache`, `r_shaderDebug`, `r_shaderValidate`, and `r_shaderOptimize`, allowing developers to control shader cache usage, debug output, SPIR-V validation, and optimization at runtime.
* Made shader compilation more robust by checking for cache hits before compiling, handling deformsKey correctly, and ensuring that only valid programs are cached. Also added detailed error handling for SPIR-V reflection failures. [[1]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cL1401-R1510) [[2]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cL1587-R1708) [[3]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cR1885-R1892)

**Codebase and API changes:**

* Refactored program registration to store both the base name and the full name (with feature suffixes), improved memory management, and made the program table bounds-safe. [[1]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cR1457-R1468) [[2]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cR299-R300)
* Updated the program listing command to use the new naming scheme and improved output clarity.
* Added documentation and comments to clarify cache versioning and manual invalidation requirements.

**Initialization and shutdown order fixes:**

* Moved cache open/close and store operations to the correct initialization and shutdown phases, preventing cache corruption and ensuring all programs are properly recorded and released. [[1]](diffhunk://#diff-af10b831f1960ea9937a173a383755284c6741d6e2117a264bfcf61f1fc4e6abL72-R74) [[2]](diffhunk://#diff-af10b831f1960ea9937a173a383755284c6741d6e2117a264bfcf61f1fc4e6abL96-R100) [[3]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cR1950-R1958)

**Performance and diagnostics:**

* Added Tracy profiling zones to key functions for improved performance analysis and debugging. [[1]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cR97-R102) [[2]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cR1029) [[3]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cR1110) [[4]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cR1457-R1468) [[5]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cL1443-R1544) [[6]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cR1675-R1688) [[7]](diffhunk://#diff-9f63cebbc5ae5202b59b38ca84466bb488518c7311ed79dee2ae64ecc545f55cR1885-R1892)

These changes collectively provide a much more efficient, reliable, and developer-friendly shader pipeline for the Vulkan backend.