### PR TITLE
fix: Make package_assets in linux deterministic

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           path: artifacts
 
+      - name: Install strip-nondeterminism
+        run: apt-get install strip-nondeterminism
+
       - name: Prepare Steam depot structure
         run: |
           mkdir -p steam-build/windows steam-build/linux steam-build/macos

--- a/BUILD.md
+++ b/BUILD.md
@@ -115,7 +115,7 @@ The container runs [`docker-entrypoint.sh`](docker-entrypoint.sh), which configu
 
 ### Linux
 
-Dependencies: `gcc-12`/`g++-12`, CMake >= 3.20, GNU Make, plus `libsdl2-dev`, `libopenal-dev`, `libcurl4-openssl-dev`, `zlib1g-dev`, `libfreetype-dev`, `libvulkan-dev`, X11/Wayland headers., `strip-nondeterminism`
+Dependencies: `gcc-12`/`g++-12`, CMake >= 3.20, GNU Make, plus `libsdl2-dev`, `libopenal-dev`, `libcurl4-openssl-dev`, `zlib1g-dev`, `libfreetype-dev`, `libvulkan-dev`, `strip-nondeterminism`, X11/Wayland headers.
 
 ```bash
 cd source

--- a/BUILD.md
+++ b/BUILD.md
@@ -115,7 +115,7 @@ The container runs [`docker-entrypoint.sh`](docker-entrypoint.sh), which configu
 
 ### Linux
 
-Dependencies: `gcc-12`/`g++-12`, CMake >= 3.20, GNU Make, plus `libsdl2-dev`, `libopenal-dev`, `libcurl4-openssl-dev`, `zlib1g-dev`, `libfreetype-dev`, `libvulkan-dev`, X11/Wayland headers.
+Dependencies: `gcc-12`/`g++-12`, CMake >= 3.20, GNU Make, plus `libsdl2-dev`, `libopenal-dev`, `libcurl4-openssl-dev`, `zlib1g-dev`, `libfreetype-dev`, `libvulkan-dev`, X11/Wayland headers., `strip-nondeterminism`
 
 ```bash
 cd source

--- a/source/package_assets.cmake
+++ b/source/package_assets.cmake
@@ -30,12 +30,21 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     message(WARNING "OpenAL DLL not found: ${OPENAL_DLL_SRC}")
   endif()
 else()
-  execute_process (COMMAND mkdir -p ${BIN_DIR}/basewf)
-  execute_process (COMMAND bash -c "cd ${ASSET_ROOT}/data0_000_21/ && zip -r ${BIN_DIR}/basewf/data0_000_21.pk3 *")
-  execute_process (COMMAND bash -c "cd ${ASSET_ROOT}/data0_000_21pure/ && zip -r ${BIN_DIR}/basewf/data0_000_21pure.pk3 *")
-  execute_process (COMMAND bash -c "cd ${ASSET_ROOT}/data0_21/ && zip -r ${BIN_DIR}/basewf/data0_21.pk3 *")
-  execute_process (COMMAND bash -c "cd ${ASSET_ROOT}/data0_21pure/ && zip -r ${BIN_DIR}/basewf/data0_21pure.pk3 *")
-  execute_process (COMMAND bash -c "cd ${ASSET_ROOT}/data1_21pure/ && zip -r ${BIN_DIR}/basewf/data1_21pure.pk3 *")
+  execute_process (COMMAND bash -c "
+    mkdir -p ${BIN_DIR}/basewf
+    files=(
+      data0_000_21
+      data0_000_21pure
+      data0_21
+      data0_21pure
+      data1_21pure
+    )
+    for p in \"\${files[@]}\"; do
+      cd \"${ASSET_ROOT}/$p\"
+      zip -r \"${BIN_DIR}/basewf/$p.pk3\" *
+      strip-nondeterminism -T 1 \"${BIN_DIR}/basewf/$p.pk3\"
+    done
+  ")
 endif()
 
 file(COPY ${ASSET_ROOT}/profiles  DESTINATION ${BIN_DIR}/basewf)


### PR DESCRIPTION
Users packaging pure files from source may not result in the same files as the ones from GitHub Workflows even if the assets content is the same due to indeterminism in the current zip commands. This PR aims to improve that.