### PR TITLE
feat(shaders): add portalnoshadows directive to disable shadowmaps in portals

### DIFF
--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -120,6 +120,7 @@ typedef struct superLightStyle_s
 #define RF_LIGHTMAP				RF_BIT(8)
 #define RF_SOFT_PARTICLES		RF_BIT(9)
 #define RF_PORTAL_CAPTURE		RF_BIT(10)
+#define RF_NOSHADOWMAPS			RF_BIT(11)
 
 #define RF_CUBEMAPVIEW			( RF_ENVVIEW )
 #define RF_NONVIEWERREF			( RF_PORTALVIEW|RF_MIRRORVIEW|RF_ENVVIEW|RF_SHADOWMAPVIEW )
@@ -138,6 +139,7 @@ typedef struct portalSurface_s
 	image_t			*texures[2];			// front and back portalmaps
 	skyportal_t		*skyPortal;
 	int				portalmip;				// 0 = full res (memset clears to 0)
+	bool			portalnoshadows;		// no real-time shadows in this portal view
 } portalSurface_t;
 
 typedef struct

--- a/source/ref_gl/r_portals.c
+++ b/source/ref_gl/r_portals.c
@@ -139,6 +139,7 @@ portalSurface_t *R_AddPortalSurface( const entity_t *ent, const mesh_t *mesh,
 	ClearBounds( portalSurface->mins, portalSurface->maxs );
 	memset( portalSurface->texures, 0, sizeof( portalSurface->texures ) );
 	portalSurface->portalmip = shader->portalmip;
+	portalSurface->portalnoshadows = shader->portalnoshadows;
 
 	if( depthPortal ) {
 		rn.numDepthPortalSurfaces++;
@@ -361,6 +362,9 @@ setup_and_render:
 		if( prevFlipped )
 			rn.renderFlags |= RF_FLIPFRONTFACE;
 	}
+
+	if( portalSurface->portalnoshadows )
+		rn.renderFlags |= RF_NOSHADOWMAPS;
 
 	rn.refdef.rdflags &= ~( RDF_UNDERWATER|RDF_CROSSINGWATER|RDF_FLIPPED );
 

--- a/source/ref_gl/r_shader.c
+++ b/source/ref_gl/r_shader.c
@@ -834,6 +834,11 @@ static void Shader_PortalMip( shader_t *shader, shaderpass_t *pass, const char *
 	shader->portalmip = abs( (int)Shader_ParseFloat( ptr ) );
 }
 
+static void Shader_PortalNoShadows( shader_t *shader, shaderpass_t *pass, const char **ptr )
+{
+	shader->portalnoshadows = true;
+}
+
 static void Shader_PolygonOffset( shader_t *shader, shaderpass_t *pass, const char **ptr )
 {
 	shader->flags |= SHADER_POLYGONOFFSET;
@@ -1052,6 +1057,7 @@ static const shaderkey_t shaderkeys[] =
 	{ "softparticle", Shader_SoftParticle },
 	{ "forceworldoutlines", Shader_ForceWorldOutlines },
 	{ "portalmip", Shader_PortalMip },
+	{ "portalnoshadows", Shader_PortalNoShadows },
 
 	{ NULL,	NULL }
 };

--- a/source/ref_gl/r_shader.h
+++ b/source/ref_gl/r_shader.h
@@ -276,6 +276,7 @@ typedef struct shader_s
 	float				portalDistance;
 
 	int					portalmip;				// 0 = full res, 1 = half, 2 = quarter...
+	bool				portalnoshadows;		// disable real-time shadows in portal view
 
 	float				skyHeight;
 	image_t				*skyboxImages[6];

--- a/source/ref_gl/r_surf.c
+++ b/source/ref_gl/r_surf.c
@@ -729,7 +729,7 @@ void R_DrawWorld( void )
 	}
 
 	// cull shadowmaps
-	if( !( rn.renderFlags & RF_ENVVIEW ) ) {
+	if( !( rn.renderFlags & ( RF_ENVVIEW|RF_NOSHADOWMAPS ) ) ) {
 		for( i = 0; i < rsc.numShadowGroups; i++ ) {
 			shadowGroup_t *grp = rsc.shadowGroups + i;
 			if( R_CullBox( grp->visMins, grp->visMaxs, clipFlags ) ) {

--- a/source/ref_nri/r_local.h
+++ b/source/ref_nri/r_local.h
@@ -136,6 +136,7 @@ typedef struct superLightStyle_s
 #define RF_LIGHTMAP				RF_BIT(8)
 #define RF_SOFT_PARTICLES		RF_BIT(9)
 #define RF_PORTAL_CAPTURE		RF_BIT(10)
+#define RF_NOSHADOWMAPS			RF_BIT(11)
 
 #define RF_CUBEMAPVIEW			( RF_ENVVIEW )
 #define RF_NONVIEWERREF			( RF_PORTALVIEW|RF_MIRRORVIEW|RF_ENVVIEW|RF_SHADOWMAPVIEW )
@@ -191,6 +192,7 @@ typedef struct portalSurface_s
 	vec3_t			mins, maxs, centre;
 	skyportal_t		*skyPortal;
 	int				portalmip;				// 0 = full res (memset clears to 0)
+	bool			portalnoshadows;		// no real-time shadows in this portal view
 	struct portal_fb_s* portalfbs[2];
 } portalSurface_t;
 

--- a/source/ref_nri/r_portals.c
+++ b/source/ref_nri/r_portals.c
@@ -137,6 +137,7 @@ portalSurface_t *R_AddPortalSurface( const entity_t *ent, const mesh_t *mesh, co
 	ClearBounds( portalSurface->mins, portalSurface->maxs );
 	memset( portalSurface->portalfbs, 0, sizeof( portalSurface->portalfbs ) );
 	portalSurface->portalmip = shader->portalmip;
+	portalSurface->portalnoshadows = shader->portalnoshadows;
 
 	if( depthPortal ) {
 		rn.numDepthPortalSurfaces++;
@@ -532,6 +533,9 @@ setup_and_render:
 		if( prevFlipped )
 			rn.renderFlags |= RF_FLIPFRONTFACE;
 	}
+
+	if( portalSurface->portalnoshadows )
+		rn.renderFlags |= RF_NOSHADOWMAPS;
 
 	rn.refdef.rdflags &= ~( RDF_UNDERWATER|RDF_CROSSINGWATER|RDF_FLIPPED );
 

--- a/source/ref_nri/r_shader.c
+++ b/source/ref_nri/r_shader.c
@@ -833,6 +833,11 @@ static void Shader_PortalMip( shader_t *shader, shaderpass_t *pass, const char *
 	shader->portalmip = abs( (int)Shader_ParseFloat( ptr ) );
 }
 
+static void Shader_PortalNoShadows( shader_t *shader, shaderpass_t *pass, const char **ptr )
+{
+	shader->portalnoshadows = true;
+}
+
 static void Shader_PolygonOffset( shader_t *shader, shaderpass_t *pass, const char **ptr )
 {
 	shader->flags |= SHADER_POLYGONOFFSET;
@@ -1051,6 +1056,7 @@ static const shaderkey_t shaderkeys[] =
 	{ "softparticle", Shader_SoftParticle },
 	{ "forceworldoutlines", Shader_ForceWorldOutlines },
 	{ "portalmip", Shader_PortalMip },
+	{ "portalnoshadows", Shader_PortalNoShadows },
 
 	{ NULL,	NULL }
 };

--- a/source/ref_nri/r_shader.h
+++ b/source/ref_nri/r_shader.h
@@ -276,6 +276,7 @@ typedef struct shader_s
 	float				portalDistance;
 
 	int					portalmip;				// 0 = full res, 1 = half, 2 = quarter...
+	bool				portalnoshadows;		// disable real-time shadows in portal view
 
 	float				skyHeight;
 	image_t				*skyboxImages[6];

--- a/source/ref_nri/r_surf.c
+++ b/source/ref_nri/r_surf.c
@@ -744,7 +744,7 @@ void R_DrawWorld( void )
 	}
 
 	// cull shadowmaps
-	if( !( rn.renderFlags & RF_ENVVIEW ) ) {
+	if( !( rn.renderFlags & ( RF_ENVVIEW|RF_NOSHADOWMAPS ) ) ) {
 		for( i = 0; i < rsc.numShadowGroups; i++ ) {
 			shadowGroup_t *grp = rsc.shadowGroups + i;
 			if( R_CullBox( grp->visMins, grp->visMaxs, clipFlags ) ) {


### PR DESCRIPTION
Add shader directive "portalnoshadows" which allows the creator to disable rendering of shadowmaps in a portal/portalmap/distortion shader. Shadows in portals are only necessary when rendering a mirror or a clear reflection; for water they are not only unnecessary, but the shadows on the ground below the water also get reflected on the water surface.
