### PR TITLE
feat: Update Nix

### DIFF
--- a/nix/warfork-assets.nix
+++ b/nix/warfork-assets.nix
@@ -4,6 +4,7 @@
 
   cmake,
   zip,
+  strip-nondeterminism,
 }:
 let
   fs = lib.fileset;
@@ -20,10 +21,12 @@ gcc13Stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake
     zip
+    strip-nondeterminism
   ];
   dontUnpack = true;
   dontConfigure = true;
   dontInstall = true;
+  dontFixup = true;
   buildPhase = ''
     cmake \
       -DCMAKE_SYSTEM_NAME=Linux \

--- a/nix/warfork.nix
+++ b/nix/warfork.nix
@@ -125,7 +125,6 @@ let
     installPhase = ''
       mkdir $out
       cp -r build/warfork-qfusion/* $out
-      cp build/libs/libTracyClient_x86_64.so* $out/libs
     '';
     preFixup = ''
       bads=(


### PR DESCRIPTION
Continuation of #587, #591 and #592.
- Update `nix/warfork-assets.nix` with `strip-nondeterminism` dependency.
- Remove libTracyClient hack from nix/warfork.nix